### PR TITLE
improved generic event args

### DIFF
--- a/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
@@ -2,6 +2,7 @@
 // http://www.softeq.com
 
 using System;
+using CoreAnimation;
 using CoreGraphics;
 using UIKit;
 
@@ -37,6 +38,17 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
         public static void AsCircle(this UIView view)
         {
             WithCornerRadius(view, view.Frame.Width / 2f);
+        }
+
+        public static void WithCornerRadius(this UIView view, UIRectCorner corners, float radius)
+        {
+            view.ClipsToBounds = true;
+            var path = UIBezierPath.FromRoundedRect(view.Bounds, corners, new CGSize(radius, radius));
+            var maskLayer = new CAShapeLayer
+            {
+                Path = path.CGPath
+            };
+            view.Layer.Mask = maskLayer;
         }
     }
 }

--- a/Softeq.XToolkit.Common/EventArguments/GenericEventArgs.cs
+++ b/Softeq.XToolkit.Common/EventArguments/GenericEventArgs.cs
@@ -14,4 +14,12 @@ namespace Softeq.XToolkit.Common.EventArguments
 
         public T Value { get; }
     }
+
+    public static class GenericEventArgs
+    {
+        public static GenericEventArgs<T> From<T>(T item)
+        {
+            return new GenericEventArgs<T>(item);
+        }
+    }
 }


### PR DESCRIPTION
instead of using every time 
`var e = new GenericEventArgs<MyFavoriteCustomClass>(MyFavoriteCustomClass.CustomPropertyName)`
For now we can use 
`var e = GenericEventArgs.From(MyFavoriteCustomClass.CustomPropertyName)`