### PR TITLE
[iOS] Improves for AttributedString

### DIFF
--- a/Softeq.XToolkit.Common.iOS/Helpers/AttributedStringHelper.cs
+++ b/Softeq.XToolkit.Common.iOS/Helpers/AttributedStringHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Softeq.XToolkit.Common.Extensions;
-using System.Text.RegularExpressions;
 using Foundation;
 using UIKit;
 using System;
@@ -12,6 +11,11 @@ namespace Softeq.XToolkit.Common.iOS.Helpers
 {
     public static class AttributedStringHelper
     {
+        /// <summary>
+        /// Returns new instance of the default paragraph style.
+        /// </summary>
+        public static NSMutableParagraphStyle NewParagraphStyle => NSParagraphStyle.Default.MutableCopy() as NSMutableParagraphStyle;
+
         public static NSUrl ToNSUrl(this string link)
         {
             var uri = new Uri(link);
@@ -24,15 +28,17 @@ namespace Softeq.XToolkit.Common.iOS.Helpers
             return new NSMutableAttributedString(inputString);
         }
 
-        public static NSMutableAttributedString BuildAttributedStringFromHtml(this string inputString)
+
+        public static NSMutableAttributedString BuildAttributedStringFromHtml(this string inputString,
+            NSStringEncoding encoding = NSStringEncoding.UTF8)
         {
             var importParams = new NSAttributedStringDocumentAttributes
             {
                 DocumentType = NSDocumentType.HTML,
-
+                StringEncoding = encoding
             };
 
-            NSError error = new NSError();
+            var error = new NSError();
 
             var attributedString = new NSAttributedString(inputString, importParams, ref error);
             return new NSMutableAttributedString(attributedString);
@@ -44,9 +50,10 @@ namespace Softeq.XToolkit.Common.iOS.Helpers
             return self;
         }
 
-        public static NSMutableAttributedString Underline(this NSMutableAttributedString self, NSUnderlineStyle underlineStyle = NSUnderlineStyle.Single)
+        public static NSMutableAttributedString Underline(this NSMutableAttributedString self,
+            NSUnderlineStyle underlineStyle = NSUnderlineStyle.Single)
         {
-            self.AddAttribute(UIStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int)underlineStyle), new NSRange(0, self.Length));
+            self.AddAttribute(UIStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int) underlineStyle), new NSRange(0, self.Length));
             return self;
         }
 
@@ -65,6 +72,19 @@ namespace Softeq.XToolkit.Common.iOS.Helpers
                 self.Foreground(color, r);
             }
 
+            return self;
+        }
+
+        /// <summary>
+        /// Set paragraph style of attributed string.
+        /// </summary>
+        /// <param name="self">Attributed string.</param>
+        /// <param name="style">Paragraph style. Use <see cref="NewParagraphStyle" /> for create custom style.</param>
+        /// <returns></returns>
+        public static NSMutableAttributedString ParagraphStyle(this NSMutableAttributedString self,
+           NSMutableParagraphStyle style)
+        {
+            self.AddAttribute(UIStringAttributeKey.ParagraphStyle, style, new NSRange(0, self.Length));
             return self;
         }
 
@@ -107,7 +127,7 @@ namespace Softeq.XToolkit.Common.iOS.Helpers
             string linkName, UIColor color, NSUnderlineStyle style, NSRange range)
         {
             self.AddAttribute(new NSString(linkName), url, range);
-            self.AddAttribute(UIStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int)style), range);
+            self.AddAttribute(UIStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int) style), range);
             self.AddAttribute(UIStringAttributeKey.UnderlineColor, color, range);
             return self;
         }


### PR DESCRIPTION
- Add `encoding` args for `BuildAttributedStringFromHtml`, by default UTF8
- Add `ParagraphStyle`