### PR TITLE
[Droid] Refactor extensions

### DIFF
--- a/Softeq.XToolkit.Common.Droid/Extensions/ContextExtensions.cs
+++ b/Softeq.XToolkit.Common.Droid/Extensions/ContextExtensions.cs
@@ -6,11 +6,10 @@ using System.Runtime.CompilerServices;
 using Android.Content;
 using Android.OS;
 using Android.Util;
-using Android.Views;
 
 namespace Softeq.XToolkit.Common.Droid.Extensions
 {
-	public static class ContextExtensions
+    public static class ContextExtensions
     {
         private const string StatusBarHeight = "status_bar_height";
         private const string Dimen = "dimen";
@@ -62,32 +61,26 @@ namespace Softeq.XToolkit.Common.Droid.Extensions
             }
         }
 
-        public static void RemoveFromParent(this View view)
-        {
-            ((ViewGroup) view?.Parent)?.RemoveView(view);
-        }
-
         public static int GetStatusBarHeight(Context context)
         {
-            var result = 0;
             var resourceId = context.Resources.GetIdentifier(StatusBarHeight, Dimen, Android);
             if (resourceId > 0)
             {
-                result = context.Resources.GetDimensionPixelSize(resourceId);
+                return context.Resources.GetDimensionPixelSize(resourceId);
             }
 
-            return result;
+            return 0;
         }
 
-		public static bool IsInPowerSavingMode(this Context context)
-		{
-			if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
-			{
-				var powerManager = (PowerManager)(context.GetSystemService(Context.PowerService));
-				return powerManager.IsPowerSaveMode;
-			}
+        public static bool IsInPowerSavingMode(this Context context)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+            {
+                var powerManager = (PowerManager) (context.GetSystemService(Context.PowerService));
+                return powerManager.IsPowerSaveMode;
+            }
 
-			return false;
-		}
+            return false;
+        }
     }
 }

--- a/Softeq.XToolkit.Common.Droid/Extensions/EditTextExtensions.cs
+++ b/Softeq.XToolkit.Common.Droid/Extensions/EditTextExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Collections.Generic;
 using System.Linq;
 using Android.Text;
 using Android.Widget;
@@ -9,6 +8,9 @@ using Java.Lang;
 
 namespace Softeq.XToolkit.Common.Droid.Extensions
 {
+    /// <summary>
+    /// Extensions related to <see cref="EditText" />
+    /// </summary>
     public static class EditTextExtensions
     {
         /// <summary>
@@ -24,32 +26,26 @@ namespace Softeq.XToolkit.Common.Droid.Extensions
         }
 
         /// <summary>
-        /// Allows to apply limitations of length and/or input symbols to an EditText
+        /// Allows applying multiple input filters to the EditText.
         /// </summary>
         /// <param name="editText">Edit text.</param>
-        /// <param name="maxLength">Maximum length of text allowed. Ignored when 0 or negative</param>
-        /// <param name="forbiddenCharacters">Char array of characters not allowed in the input. Ignored when null</param>
-        public static void SetMaxLengthWithForbiddenSymbols(this EditText editText, int maxLength = 0, char[] forbiddenCharacters = null)
+        /// <param name="filters">Array of filters.</param>
+        public static void SetFilters(this EditText editText, params IInputFilter[] filters)
         {
-            var filters = new List<IInputFilter>();
-
-            if (maxLength > 0)
-            {
-                filters.Add(new InputFilterLengthFilter(maxLength));
-            }
-
-            if (forbiddenCharacters != null)
-            {
-                filters.Add(new ForbiddenCharsInputFilter(forbiddenCharacters));
-            }
-
-            editText.SetFilters(filters.ToArray());
+            editText.SetFilters(filters);
         }
 
-        private class ForbiddenCharsInputFilter : Object, IInputFilter
+        /// <summary>
+        /// This filter will constrain edits not to make text contains forbidden symbols.
+        /// </summary>
+        public class ForbiddenCharsInputFilter : Object, IInputFilter
         {
             private readonly char[] _forbiddenCharacters;
 
+            /// <summary>
+            /// This filter will constrain edits not to make text contains forbidden symbols.
+            /// </summary>
+            /// <param name="forbiddenCharacters">Char array of characters not allowed in the input. Ignored when null</param>
             public ForbiddenCharsInputFilter(char[] forbiddenCharacters)
             {
                 _forbiddenCharacters = forbiddenCharacters;

--- a/Softeq.XToolkit.Common.Droid/Extensions/ViewExtensions.cs
+++ b/Softeq.XToolkit.Common.Droid/Extensions/ViewExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Android.Views;
+
+namespace Softeq.XToolkit.Common.Droid.Extensions
+{
+    /// <summary>
+    /// Extensions related to <see cref="View" />
+    /// </summary>
+    public static class ViewExtensions
+    {
+        /// <summary>
+        /// Remove target view from parent.
+        /// </summary>
+        /// <param name="view">Target view.</param>
+        public static void RemoveFromParent(this View view)
+        {
+            ((ViewGroup) view?.Parent)?.RemoveView(view);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
+++ b/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Extensions\EditTextExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\IntentExtensions.cs" />
+    <Compile Include="Extensions\ViewExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Helpers\" />


### PR DESCRIPTION
- Remove `SetMaxLengthWithForbiddenSymbols` method, currently can use this syntax:
```cs
_editView.SetFilters(
    new InputFilterLengthFilter(maxLength),
    new ForbiddenCharsInputFilter(forbiddenCharacters),
    ...);
```
- Fixed #89 
- Export view extensions to separate file.