### PR TITLE
Change DryIoc NuGet

### DIFF
--- a/Softeq.XToolkit.WhiteLabel/Softeq.XToolkit.WhiteLabel.csproj
+++ b/Softeq.XToolkit.WhiteLabel/Softeq.XToolkit.WhiteLabel.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DryIoc" Version="4.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="DryIoc.dll" Version="4.0.5" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Current NuGet package `DryIoc` provides via linked sources.
`DryIoc.dll` package contains compiled assembly.

> Source code is the default way of distribution (e.g. DryIoc package) for a historical reasons. If you want a "normal" assembly reference, please use the packages with .dll suffix (e.g. DryIoc.dll package). https://bitbucket.org/dadhi/dryioc/wiki/InstallationOptions.md