### PR TITLE
Refactor bootstrapper & containerBuilder

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapper.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapper.cs
@@ -22,9 +22,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
         {
             var viewModelToViewControllerDictionary = CreateAndRegisterMissedViewModels(builder, assemblies);
 
-            builder.Singleton<IViewLocator>(x =>
+            builder.Singleton<IViewLocator>(container =>
             {
-                var viewLocator = x.Resolve<DroidViewLocator>();
+                var viewLocator = container.Resolve<DroidViewLocator>();
                 viewLocator.Initialize(viewModelToViewControllerDictionary);
                 return viewLocator;
             }, IfRegistered.Keep);
@@ -34,11 +34,15 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         protected override void RegisterInternalServices(IContainerBuilder builder)
         {
+            base.RegisterInternalServices(builder);
+
+            // common
             builder.Singleton(c => CrossCurrentActivity.Current, IfRegistered.Keep);
+
+            // navigation
             builder.Singleton<ActivityPageNavigationService, IPlatformNavigationService>(IfRegistered.Keep);
             builder.Singleton<BundleService, IBundleService>(IfRegistered.Keep);
             builder.Singleton<DroidViewLocator>(IfRegistered.Keep);
-
             builder.PerDependency<DroidFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
         }
 

--- a/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraper.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraper.cs
@@ -22,9 +22,9 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
         {
             var viewModelToViewControllerDictionary = CreateAndRegisterMissedViewModels(builder, assemblies);
 
-            builder.Singleton<IViewLocator>(x =>
+            builder.Singleton<IViewLocator>(container =>
             {
-                var viewLocator = x.Resolve<StoryboardViewLocator>();
+                var viewLocator = container.Resolve<StoryboardViewLocator>();
                 viewLocator.Initialize(viewModelToViewControllerDictionary);
                 return viewLocator;
             }, IfRegistered.Keep);
@@ -34,6 +34,9 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
         protected override void RegisterInternalServices(IContainerBuilder builder)
         {
+            base.RegisterInternalServices(builder);
+
+            // navigation
             builder.Singleton<ViewControllerProvider, IViewControllerProvider>(IfRegistered.Keep);
             builder.Singleton<StoryboardViewLocator>(IfRegistered.Keep);
             builder.Singleton<StoryboardNavigation, IPlatformNavigationService>(IfRegistered.Keep);

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainer.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainer.cs
@@ -7,8 +7,11 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
 {
     public interface IContainer
     {
-        T Resolve<T>();
-        Lazy<T> ResolveLazy<T>();
+        TService Resolve<TService>();
+
+        [Obsolete("Use Resolve<Lazy<TService>> instead.")]
+        Lazy<TService> ResolveLazy<TService>();
+
         object Resolve(Type type);
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
@@ -7,15 +7,26 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
 {
     public interface IContainerBuilder
     {
-        void PerDependency<T1, T2>(IfRegistered ifRegistered = IfRegistered.AppendNewImplementation) where T1 : T2;
-        void PerDependency<T1>(IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
-        void PerDependency<T1>(Func<IContainer, T1> func, IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
-        void PerDependency(Type type, IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
-        void PerDependency<T1>(Func<IContainer, object> func, IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
-        void Singleton<T1, T2>(IfRegistered ifRegistered = IfRegistered.AppendNewImplementation) where T1 : T2;
-        void Singleton<T1>(IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
-        void Singleton<T1>(Func<IContainer, T1> func, IfRegistered ifRegistered = IfRegistered.AppendNewImplementation);
+        void PerDependency<TImplementation, TService>(IfRegistered ifRegistered = IfRegistered.AppendNew)
+            where TImplementation : TService;
+
+        void PerDependency<TService>(IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void PerDependency<TService>(Func<IContainer, TService> func, IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void PerDependency(Type type, IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void PerDependency<TService>(Func<IContainer, object> func, IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void Singleton<TImplementation, TService>(IfRegistered ifRegistered = IfRegistered.AppendNew)
+            where TImplementation : TService;
+
+        void Singleton<TService>(IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void Singleton<TService>(Func<IContainer, TService> func, IfRegistered ifRegistered = IfRegistered.AppendNew);
+
         void RegisterBuildCallback(Action<IContainer> action);
+
         IContainer Build();
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IfRegistered.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IfRegistered.cs
@@ -19,6 +19,6 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
         ///     Adds the new implementation or null (Made.Of),
         ///     otherwise keeps the previous registration of the same implementation type.
         /// </summary>
-        AppendNewImplementation
+        AppendNew
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -18,8 +18,8 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         {
             var containerBuilder = CreateContainerBuilder();
 
-            ConfigureIoc(containerBuilder);
             RegisterInternalServices(containerBuilder);
+            ConfigureIoc(containerBuilder);
 
             var container = BuildContainer(containerBuilder, assemblies);
 
@@ -31,23 +31,24 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             return new DryIocContainerBuilder();
         }
 
-        protected abstract void ConfigureIoc(IContainerBuilder builder);
+        protected virtual void RegisterInternalServices(IContainerBuilder builder)
+        {
+            // logs
+            builder.Singleton<ConsoleLogManager, ILogManager>(IfRegistered.Keep);
 
-        protected abstract void RegisterInternalServices(IContainerBuilder builder);
+            // navigation
+            builder.Singleton<PageNavigationService, IPageNavigationService>(IfRegistered.Keep);
+            builder.Singleton<BackStackManager, IBackStackManager>(IfRegistered.Keep);
+
+            // tabs
+            builder.Singleton<TabNavigationService, ITabNavigationService>(IfRegistered.Keep);
+            builder.PerDependency<TabViewModel>(IfRegistered.Keep);
+        }
+
+        protected abstract void ConfigureIoc(IContainerBuilder builder);
 
         protected virtual IContainer BuildContainer(IContainerBuilder builder, IList<Assembly> assemblies)
         {
-            // navigation
-            builder.Singleton<PageNavigationService, IPageNavigationService>();
-            builder.Singleton<BackStackManager, IBackStackManager>();
-
-            // tabs
-            builder.Singleton<TabNavigationService, ITabNavigationService>();
-            builder.PerDependency<TabViewModel>();
-
-            // logs
-            builder.Singleton<ConsoleLogManager, ILogManager>();
-
             return builder.Build();
         }
     }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
@@ -3,23 +3,23 @@
 
 using System;
 using DryIoc;
+using IDryContainer = DryIoc.IContainer;
 using IContainer = Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract.IContainer;
 
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
 {
-    internal class DryIocContainer : IContainer
+    internal class DryIocContainerAdapter : IContainer
     {
-        private DryIoc.IContainer _container;
+        private IDryContainer _container;
 
-        public IContainer Initialize(DryIoc.IContainer container)
+        internal void Initialize(IDryContainer container)
         {
             _container = container;
-            return this;
         }
 
-        public T Resolve<T>()
+        public TService Resolve<TService>()
         {
-            return _container.Resolve<T>();
+            return _container.Resolve<TService>();
         }
 
         public object Resolve(Type type)
@@ -27,9 +27,9 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
             return _container.Resolve(type);
         }
 
-        public Lazy<T> ResolveLazy<T>()
+        public Lazy<TService> ResolveLazy<TService>()
         {
-            return new Lazy<T>(() => _container.Resolve<T>());
+            return new Lazy<TService>(() => _container.Resolve<TService>());
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

- Fixed services registration order.
- Internal refactoring.

**Important**
- When you register new instances of internal services, you need to use `IfRegistered.Replace` otherwise you will have runtime exception about duplication registration.

**Additional notes**
- **Lazy resolving** - Because we use DryIoc under the hood, our `IContainer` has the implicit ability for lazy, factory resolving ([DryIoc doc](https://bitbucket.org/dadhi/dryioc/wiki/Wrappers#markdown-header-predefined-wrappers), [Autofac doc](https://autofaccn.readthedocs.io/en/latest/resolve/relationships.html#delayed-instantiation-lazy-b))

### API Changes ###

Obsoleted:
- `IContainer.ResolveLazy<TService>` look above.

Changed:
- enum `IfRegistered.AppendNewImplementation` => `IfRegistered.AppendNew`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)