### PR TITLE
Update iOS DateTime extensions

### DIFF
--- a/Softeq.XToolkit.Common.iOS/Extensions/DateTimeExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/DateTimeExtensions.cs
@@ -8,21 +8,17 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
 {
     public static class DateTimeExtensions
     {
-        public static DateTime NSDateToDateTime(this NSDate date)
+        public static DateTime ToDateTime(this NSDate date)
         {
-            var reference = TimeZone.CurrentTimeZone.ToLocalTime(
-                new DateTime(2001, 1, 1, 0, 0, 0));
-            return reference.AddSeconds(date.SecondsSinceReferenceDate);
+            return ((DateTime) date).ToLocalTime();
         }
 
-        public static NSDate DateTimeToNSDate(this DateTime date)
+        public static NSDate ToNsDate(this DateTime date)
         {
-            var reference = new DateTime(2001, 1, 1, 0, 0, 0);
-            return NSDate.FromTimeIntervalSinceReferenceDate(
-                (date - reference).TotalSeconds);
+            return (NSDate) DateTime.SpecifyKind(date, DateTimeKind.Utc);
         }
 
-        public static NSDate ToNSDateLocal(this DateTimeOffset dateTimeOffset)
+        public static NSDate ToNsDateLocal(this DateTimeOffset dateTimeOffset)
         {
             var timeSpan = dateTimeOffset - new DateTimeOffset(2001, 1, 1, 0, 0, 0, DateTimeOffset.UtcNow.Offset);
             var nsDate = NSDate.FromTimeIntervalSinceReferenceDate(timeSpan.TotalSeconds);


### PR DESCRIPTION
### Description of Change ###

Fixed obsolete warning with iOS DateTime extensions.

Resources:
- [NSDate.cs sources](https://github.com/xamarin/xamarin-macios/blob/master/src/Foundation/NSDate.cs)
- [NSDate conversions after Unified.](https://forums.xamarin.com/discussion/comment/118230/#Comment_118230)

### API Changes ###

Changed:
- `NSDateToDateTime` => `DateTime ToDateTime(NSDate)`
- `DateTimeToNSDate` => `NSDate ToNsDate(DateTime)`
- `ToNSDateLocal` => `ToNsDateLocal`
 
### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)