### PR TITLE
Feature/pn droid badges

### DIFF
--- a/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
@@ -7,6 +7,7 @@ using Android.App;
 using Android.Arch.Lifecycle;
 using Android.Content;
 using Android.Gms.Extensions;
+using Android.Support.V4.App;
 using Firebase;
 using Firebase.Iid;
 using Firebase.Messaging;
@@ -22,7 +23,6 @@ namespace Softeq.XToolkit.PushNotifications.Droid
     {
         private readonly Context _appContext;
         private readonly AppLifecycleObserver _lifecycleObserver;
-        private readonly INotificationsSettingsProvider _notificationsSettings;
 
         private bool _isInitialized;
 
@@ -39,8 +39,9 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             : base(remotePushNotificationsService, pushTokenStorageService, pushNotificationsHandler, pushNotificationParser,
                 logManager)
         {
-            _notificationsSettings = notificationsSettings;
             _appContext = Application.Context;
+
+            NotificationsHelper.Init(notificationsSettings);
 
             _lifecycleObserver = new AppLifecycleObserver();
             ProcessLifecycleOwner.Get().Lifecycle.AddObserver(_lifecycleObserver);
@@ -56,8 +57,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             _isInitialized = true;
             _showForegroundNotificationsInSystemOptions = showForegroundNotificationsInSystemOptions;
 
-            //TODO: + update on locale changed
-            NotificationsHelper.CreateNotificationChannels(_appContext, _notificationsSettings);
+            NotificationsHelper.CreateNotificationChannels(_appContext);
 
             FirebaseApp.InitializeApp(_appContext);
             XFirebaseMessagingService.OnTokenRefreshed += OnPushTokenRefreshed;
@@ -86,8 +86,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         {
             if (_appContext != null)
             {
-                var notificationManager = NotificationManager.FromContext(_appContext);
-                notificationManager.CancelAll();
+                NotificationManagerCompat.From(_appContext).CancelAll();
             }
         }
 
@@ -152,7 +151,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             if (_showForegroundNotificationsInSystemOptions.ShouldShow() || !inForeground)
             {
                 var notificationData = (pushNotification as RemoteMessage)?.Data;
-                NotificationsHelper.CreateNotification(_appContext, parsedPushNotification, notificationData, _notificationsSettings);
+                NotificationsHelper.CreateNotification(_appContext, parsedPushNotification, notificationData);
             }
         }
 

--- a/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
@@ -13,6 +13,7 @@ using Firebase.Messaging;
 using Java.Interop;
 using Java.IO;
 using Softeq.XToolkit.Common.Logger;
+using XamarinShortcutBadger;
 using Object = Java.Lang.Object;
 
 namespace Softeq.XToolkit.PushNotifications.Droid
@@ -92,7 +93,10 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
         protected override void SetBadgeNumberInternal(int badgeNumber)
         {
-            // Not implemented for now
+            if (_appContext != null)
+            {
+                var result = ShortcutBadger.ApplyCount(_appContext, badgeNumber);
+            }
         }
 
         protected override Task<bool> UnregisterFromPushTokenInSystem()

--- a/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationsService.cs
@@ -96,6 +96,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             if (_appContext != null)
             {
                 var result = ShortcutBadger.ApplyCount(_appContext, badgeNumber);
+                Logger.Debug($"Badge count {badgeNumber} was" + (!result ? "NOT" : "") + "set");
             }
         }
 

--- a/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
 using System.Collections.Generic;
 using Android.App;
 using Android.Content;
@@ -18,6 +17,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
         /// <summary>
         ///     Obtains a dictionary of notification channles where the key is channel id and the value is channel name
+        ///     Note: if you are using "notification" notifications, Firebase will use a separate channel for them when received in Background
         /// </summary>
         /// <param name="context">
         ///     Context for obtaining channel names from resources (Names should be obtained from resources for
@@ -34,7 +34,9 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         NotificationImportance GetNotificationChannelImportance(string channelId);
 
         /// <summary>
-        ///     You can add some custom configuration for a created Notification Channel (like description, sound, etc.)
+        ///     You can add some custom configuration for a created Notification Channel (like description, sound,
+        ///     create and set group (<see cref="NotificationChannelsHelper"/> to create a group), etc.)
+        ///     This method will only be called on API 26+
         /// </summary>
         /// <param name="channelId">Channel Id string</param>
         /// <param name="channel">
@@ -61,17 +63,19 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
         /// <summary>
         ///     You can customize how push notification will be shown (apart from ContentTitle, ContentText, channelid,
-        ///     styles set in GetStylesForNotification and content intent). You can use SetNumber to set badge on Android 26+
+        ///     styles set in GetStylesForNotification and content intent). For instance, you can use SetNumber to set badge on Android 26+;
+        ///     add Action buttons; add groups and create additional notifications - like group summary notification;
+        ///     add progress bar and later update for this notificationId; or simply save notificationId; etc.
         /// </summary>
         /// <param name="notificationBuilder">Already created notification builder that can be further customized</param>
         /// <param name="pushNotification">Push notification data</param>
-        void CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification);
+        void CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification, int notificationId);
 
         /// <summary>
-        ///     Obtains type of the Start Activity which will be opened by tap on the given notification
+        ///     Provides info about the Activity which will be opened by tap on the given notification
         /// </summary>
         /// <param name="pushNotification">Push notification data</param>
-        /// <returns>Start Activity type</returns>
-        Type GetStartActivityTypeFromPush(PushNotificationModel pushNotification);
+        /// <returns>Intent Activity info (type and whether parent stack should be created)</returns>
+        NotificationIntentActivityInfo GetIntentActivityInfoFromPush(PushNotificationModel pushNotification);
     }
 }

--- a/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
@@ -21,7 +21,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         /// </summary>
         /// <param name="context">
         ///     Context for obtaining channel names from resources (Names should be obtained from resources for
-        ///     localization support)
+        ///     localization support, this list of channels will be automatically recreated when language changes)
         /// </param>
         /// <returns>Dictionary of channel Ids and Names</returns>
         Dictionary<string, string> GetNotificationChannels(Context context);
@@ -35,7 +35,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
         /// <summary>
         ///     You can add some custom configuration for a created Notification Channel (like description, sound,
-        ///     create and set group (<see cref="NotificationChannelsHelper"/> to create a group), etc.)
+        ///     turn off badges, create and set group - <see cref="NotificationChannelsHelper"/> to create a group, etc.)
         ///     This method will only be called on API 26+
         /// </summary>
         /// <param name="channelId">Channel Id string</param>
@@ -63,9 +63,9 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
         /// <summary>
         ///     You can customize how push notification will be shown (apart from ContentTitle, ContentText, channelid,
-        ///     styles set in GetStylesForNotification and content intent). For instance, you can use SetNumber to set badge on Android 26+;
-        ///     add Action buttons; add groups and create additional notifications - like group summary notification;
-        ///     add progress bar and later update for this notificationId; or simply save notificationId; etc.
+        ///     styles set in GetStylesForNotification and content intent). For instance, you can use SetNumber to change badge
+        ///     value increment on Android 26+; add Action buttons; add groups and create additional notifications - like group
+        ///     summary notification; add progress bar and later update for this notificationId; or simply save notificationId; etc.
         /// </summary>
         /// <param name="notificationBuilder">Already created notification builder that can be further customized</param>
         /// <param name="pushNotification">Push notification data</param>

--- a/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
@@ -23,7 +23,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         ///     Context for obtaining channel names from resources (Names should be obtained from resources for
         ///     localization support)
         /// </param>
-        /// <returns>Dictionary of channel ids and names</returns>
+        /// <returns>Dictionary of channel Ids and Names</returns>
         Dictionary<string, string> GetNotificationChannels(Context context);
 
         /// <summary>
@@ -33,6 +33,15 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         /// <returns>Notification channel importance</returns>
         NotificationImportance GetNotificationChannelImportance(string channelId);
 
+        /// <summary>
+        ///     You can add some custom configuration for a created Notification Channel (like description, sound, etc.)
+        /// </summary>
+        /// <param name="channelId">Channel Id string</param>
+        /// <param name="channel">
+        ///     A NotificationChannel that will be registered in the system. Contains already set channelId,
+        ///     name (received from <see cref="GetNotificationChannels"/>)
+        ///     and importance (provided by <see cref="GetNotificationChannelImportance"/>)
+        /// </param>
         void ConfigureNotificationChannel(string channelId, NotificationChannel channel);
 
         /// <summary>
@@ -51,13 +60,12 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         PushNotificationStyles GetStylesForNotification(PushNotificationModel pushNotification);
 
         /// <summary>
-        /// You can customize how push notification will be shown (apart from ContentTitle, ContentText, channelid,
-        /// styles set in GetStylesForNotification and content intent)
+        ///     You can customize how push notification will be shown (apart from ContentTitle, ContentText, channelid,
+        ///     styles set in GetStylesForNotification and content intent). You can use SetNumber to set badge on Android 26+
         /// </summary>
         /// <param name="notificationBuilder">Already created notification builder that can be further customized</param>
         /// <param name="pushNotification">Push notification data</param>
-        /// <returns>The same notification builder passed inside the parameter, possibly modified</returns>
-        NotificationCompat.Builder CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification);
+        void CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification);
 
         /// <summary>
         ///     Obtains type of the Start Activity which will be opened by tap on the given notification

--- a/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/INotificationsSettingsProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Android.App;
 using Android.Content;
+using Android.Support.V4.App;
 
 namespace Softeq.XToolkit.PushNotifications.Droid
 {
@@ -32,6 +33,8 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         /// <returns>Notification channel importance</returns>
         NotificationImportance GetNotificationChannelImportance(string channelId);
 
+        void ConfigureNotificationChannel(string channelId, NotificationChannel channel);
+
         /// <summary>
         ///     Obtains channel id for specific notification
         /// </summary>
@@ -43,9 +46,18 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         ///     Obtains styles for displaying the given push notification in system. Provide different ids for notifications if you do not
         ///     want them to replace each other
         /// </summary>
-        /// <param name="pushNotification"></param>
+        /// <param name="pushNotification">Push notification data</param>
         /// <returns></returns>
         PushNotificationStyles GetStylesForNotification(PushNotificationModel pushNotification);
+
+        /// <summary>
+        /// You can customize how push notification will be shown (apart from ContentTitle, ContentText, channelid,
+        /// styles set in GetStylesForNotification and content intent)
+        /// </summary>
+        /// <param name="notificationBuilder">Already created notification builder that can be further customized</param>
+        /// <param name="pushNotification">Push notification data</param>
+        /// <returns>The same notification builder passed inside the parameter, possibly modified</returns>
+        NotificationCompat.Builder CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification);
 
         /// <summary>
         ///     Obtains type of the Start Activity which will be opened by tap on the given notification

--- a/Softeq.XToolkit.PushNotifications.Droid/LocaleChangeBroadcastReceiver.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/LocaleChangeBroadcastReceiver.cs
@@ -1,0 +1,18 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Android.App;
+using Android.Content;
+
+namespace Softeq.XToolkit.PushNotifications.Droid
+{
+    [BroadcastReceiver(Enabled = true)]
+    [IntentFilter(new[] { Intent.ActionLocaleChanged })]
+    public class LocaleChangeBroadcastReceiver : BroadcastReceiver
+    {
+        public override void OnReceive(Context context, Intent intent)
+        {
+            NotificationsHelper.CreateNotificationChannels(context);
+        }
+    }
+}

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationActionsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationActionsHelper.cs
@@ -1,0 +1,76 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Android.App;
+using Android.Content;
+using Android.Support.V4.App;
+using RemoteInput = Android.Support.V4.App.RemoteInput;
+
+namespace Softeq.XToolkit.PushNotifications.Droid
+{
+    /// <summary>
+    /// A helper class with utils methods for creating notification actions and handling remote input messages
+    /// </summary>
+    public static class NotificationActionsHelper
+    {
+        /// <summary>
+        /// Creates a simple notification action. Note: you can pass these parameters directly
+        /// to <see cref="NotificationCompat.Builder.AddAction"/> without creating an instance of action
+        /// </summary>
+        /// <param name="iconResId">Resource id for the icon</param>
+        /// <param name="name">Name for the action button</param>
+        /// <param name="pendingIntent">Pending intent for this action button</param>
+        /// <returns>A notification action</returns>
+        public static NotificationCompat.Action CreateAction(int iconResId, string name, PendingIntent pendingIntent)
+        {
+            return new NotificationCompat.Action.Builder(iconResId, name, pendingIntent)
+                .Build();
+        }
+
+        /// <summary>
+        /// Creates a direct reply action. Make sure to create correct pendingIntent
+        /// </summary>
+        /// <param name="iconResId">Resource id for the icon</param>
+        /// <param name="name">Name for the action button</param>
+        /// <param name="pendingIntent">Pending intent for this action button</param>
+        /// <param name="remoteInputResultKey">Result key for remote input (needed to obtain user reply)</param>
+        /// <param name="remoteInputLabel">A label to be displayed in remote input field</param>
+        /// <returns>A notification action with <see cref="RemoteInput"/> attached</returns>
+        public static NotificationCompat.Action CreateDirectReplyAction(int iconResId, string name, PendingIntent pendingIntent,
+            string remoteInputResultKey, string remoteInputLabel)
+        {
+            var remoteInput = CreateRemoteInput(remoteInputResultKey, remoteInputLabel);
+            return new NotificationCompat.Action.Builder(iconResId, name, pendingIntent)
+                .AddRemoteInput(remoteInput)
+                .Build();
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="RemoteInput"/> with specified parameters
+        /// </summary>
+        /// <param name="resultKey">Result key needed to obtain user reply</param>
+        /// <param name="label">A label to be displayed in remote input field</param>
+        /// <returns>An instance of <see cref="RemoteInput"/></returns>
+        public static RemoteInput CreateRemoteInput(string resultKey, string label)
+        {
+            return new RemoteInput.Builder(resultKey).SetLabel(label).Build();
+        }
+
+        /// <summary>
+        /// Obtains user reply from the <see cref="RemoteInput"/>
+        /// </summary>
+        /// <param name="intent">Intent which opened Activity/BroadcastReceiver/Service and contains data from <see cref="RemoteInput"/></param>
+        /// <param name="resultKey">Result key that was used to create the <see cref="RemoteInput"/></param>
+        /// <returns>A string message with user reply or null</returns>
+        public static string GetRemoteInputMessage(Intent intent, string resultKey)
+        {
+            string reply = null;
+            var remoteInput = RemoteInput.GetResultsFromIntent(intent);
+            if (remoteInput != null)
+            {
+                reply = remoteInput.GetCharSequence(resultKey);
+            }
+            return reply;
+        }
+    }
+}

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationChannelsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationChannelsHelper.cs
@@ -1,0 +1,78 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Android.App;
+using Android.OS;
+
+namespace Softeq.XToolkit.PushNotifications.Droid
+{
+    /// <summary>
+    /// A helper class to perform some actions with Notification Channels,
+    /// can be used to manage Channels dynamically to reflect choices made by users of your app
+    /// </summary>
+    public static class NotificationChannelsHelper
+    {
+        /// <summary>
+        /// Create and possibly configure a Notification Channel
+        /// </summary>
+        /// <param name="channelId">Id for the channel</param>
+        /// <param name="channelName">Name for the channel (should be localized, don't forget to update the channel when Locale changes)</param>
+        /// <param name="channelImportance">Channel importance</param>
+        /// <param name="configureChannelAction">Action to additionally configure channel before registration (set description, group, etc.)</param>
+        public static void CreateNotificationChannel(string channelId, string channelName, NotificationImportance channelImportance,
+            Action configureChannelAction = null)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                var channel = new NotificationChannel(channelId, channelName, channelImportance);
+                configureChannelAction?.Invoke();
+                NotificationManager.FromContext(Application.Context).CreateNotificationChannel(channel);
+            }
+        }
+
+        /// <summary>
+        /// Delete a Notification Channel
+        /// </summary>
+        /// <param name="channelId">Id for the channel</param>
+        public static void DeleteNotificationChannel(string channelId)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                NotificationManager.FromContext(Application.Context).DeleteNotificationChannel(channelId);
+            }
+        }
+
+        /// <summary>
+        /// Create a Notification Channel Group
+        /// Afterwards you can set this group to a notification channel with SetGroup(groupId) prior to it's registration in NotificationManager
+        /// </summary>
+        /// <param name="groupId">Id for the group</param>
+        /// <param name="groupName">Name for the group (should be localized)</param>
+        /// <param name="description">Optional parameter to specify Description for this group</param>
+        public static void CreateNotificationChannelGroup(string groupId, string groupName, string description = null)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                var group = new NotificationChannelGroup(groupId, groupName);
+                if (description != null)
+                {
+                    group.Description = description;
+                }
+                NotificationManager.FromContext(Application.Context).CreateNotificationChannelGroup(group);
+            }
+        }
+
+        /// <summary>
+        /// Delete a Notification Channel Group
+        /// </summary>
+        /// <param name="groupId">Id for the group</param>
+        public static void DeleteNotificationChannelGroup(string groupId)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+            {
+                NotificationManager.FromContext(Application.Context).DeleteNotificationChannelGroup(groupId);
+            }
+        }
+    }
+}

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationIntentActivityInfo.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationIntentActivityInfo.cs
@@ -1,0 +1,31 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+
+namespace Softeq.XToolkit.PushNotifications.Droid
+{
+    /// <summary>
+    /// Information about which Activity and how should be opened on tap on Notification
+    /// </summary>
+    public class NotificationIntentActivityInfo
+    {
+        /// <summary>
+        /// Type of the Activity that shall be opened
+        /// </summary>
+        public Type ActivityType { get; set; }
+
+        /// <summary>
+        /// The value indicating whether parent stack should be created for this Activity
+        /// Note that to create parent stack or an activity in separate task you need to add some directives in manifest/activity declaration.
+        /// For more details <see cref="https://developer.android.com/training/notify-user/navigation"/>
+        /// </summary>
+        public bool DoCreateParentStack { get; set; }
+
+        public NotificationIntentActivityInfo(Type activityType, bool doCreateParentStack)
+        {
+            ActivityType = activityType;
+            DoCreateParentStack = doCreateParentStack;
+        }
+    }
+}

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -27,6 +27,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
                     var channelName = channel.Value;
                     var channelImportance = notificationsSettings.GetNotificationChannelImportance(channelId);
                     var notificationChannel = new NotificationChannel(channelId, channelName, channelImportance);
+                    notificationsSettings.ConfigureNotificationChannel(channelId, notificationChannel);
                     channelsList.Add(notificationChannel);
                 }
 
@@ -84,6 +85,8 @@ namespace Softeq.XToolkit.PushNotifications.Droid
 
             var pendingIntent = PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
             notificationBuilder.SetContentIntent(pendingIntent);
+
+            notificationBuilder = notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification);
 
             NotificationManager.FromContext(context).Notify(styles.Id, notificationBuilder.Build());
         }

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -86,7 +86,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             var pendingIntent = PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
             notificationBuilder.SetContentIntent(pendingIntent);
 
-            notificationBuilder = notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification);
+            notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification);
 
             NotificationManager.FromContext(context).Notify(styles.Id, notificationBuilder.Build());
         }

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -1,79 +1,92 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Support.V4.App;
+using TaskStackBuilder = Android.App.TaskStackBuilder;
 
 namespace Softeq.XToolkit.PushNotifications.Droid
 {
-    public class NotificationsHelper
+    internal static class NotificationsHelper
     {
-        public static void CreateNotificationChannels(Context context, INotificationsSettingsProvider notificationsSettings)
+        private static INotificationsSettingsProvider _notificationsSettings;
+
+        public static void Init(INotificationsSettingsProvider notificationsSettings)
         {
+            _notificationsSettings = notificationsSettings;
+        }
+
+        // You should call Init prior to using this method
+        public static void CreateNotificationChannels(Context context)
+        {
+            if (_notificationsSettings == null)
+            {
+                return;
+            }
+
             // Create the NotificationChannel, but only on API 26+ because
             // the NotificationChannel class is new and not in the support library
             if (context != null && Build.VERSION.SdkInt >= BuildVersionCodes.O)
             {
-                var channels = notificationsSettings.GetNotificationChannels(context);
+                var channels = _notificationsSettings.GetNotificationChannels(context);
                 var channelsList = new List<NotificationChannel>();
 
                 foreach (var channel in channels)
                 {
                     var channelId = channel.Key;
                     var channelName = channel.Value;
-                    var channelImportance = notificationsSettings.GetNotificationChannelImportance(channelId);
+                    var channelImportance = _notificationsSettings.GetNotificationChannelImportance(channelId);
                     var notificationChannel = new NotificationChannel(channelId, channelName, channelImportance);
-                    notificationsSettings.ConfigureNotificationChannel(channelId, notificationChannel);
+                    _notificationsSettings.ConfigureNotificationChannel(channelId, notificationChannel);
                     channelsList.Add(notificationChannel);
                 }
 
                 if (channelsList.Any())
                 {
-                    var notificationManager = NotificationManager.FromContext(context);
-                    notificationManager.CreateNotificationChannels(channelsList);
+                    NotificationManager.FromContext(context).CreateNotificationChannels(channelsList);
                 }
             }
         }
 
+        // You should call Init prior to using this method
         public static void CreateNotification(
             Context context,
             PushNotificationModel pushNotification,
-            IDictionary<string, string> notificationData,
-            INotificationsSettingsProvider notificationsSettings)
+            IDictionary<string, string> notificationData)
         {
-            if (context == null)
+            if (context == null || _notificationsSettings == null)
             {
                 return;
             }
 
-            var channelId = notificationsSettings.GetChannelIdForNotification(pushNotification);
+            var channelId = _notificationsSettings.GetChannelIdForNotification(pushNotification);
             if (string.IsNullOrEmpty(channelId))
             {
-                channelId = notificationsSettings.DefaultChannelId;
+                channelId = _notificationsSettings.DefaultChannelId;
             }
 
             var title = string.IsNullOrEmpty(pushNotification.Title) ? GetApplicationName(context) : pushNotification.Title;
             var message = pushNotification.Body;
 
-            var styles = notificationsSettings.GetStylesForNotification(pushNotification);
+            var styles = _notificationsSettings.GetStylesForNotification(pushNotification);
 
             var notificationBuilder = new NotificationCompat.Builder(context, channelId)
                 .SetContentTitle(title)
                 .SetContentText(message)
-                .SetAutoCancel(styles.AutoCancel)
-                .SetSound(styles.SoundUri)
                 .SetPriority((int) styles.Priority)
+                .SetAutoCancel(styles.AutoCancel)
                 .SetStyle(styles.Style)
+                .SetSound(styles.SoundUri)
                 .SetSmallIcon(styles.IconRes)
                 .SetColor(styles.IconArgbColor);
 
-            var startActivityType = notificationsSettings.GetStartActivityTypeFromPush(pushNotification);
-            var intent = new Intent(context, startActivityType);
-            intent.AddFlags(ActivityFlags.ClearTask | ActivityFlags.NewTask);
+            var intentActivityInfo = _notificationsSettings.GetIntentActivityInfoFromPush(pushNotification);
+            var intent = new Intent(context, intentActivityInfo.ActivityType);
 
             if (notificationData != null)
             {
@@ -83,12 +96,27 @@ namespace Softeq.XToolkit.PushNotifications.Droid
                 }
             }
 
-            var pendingIntent = PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
+            var pendingIntent = CreatePendingIntent(context, intent, intentActivityInfo.DoCreateParentStack);
             notificationBuilder.SetContentIntent(pendingIntent);
 
-            notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification);
+            _notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification, styles.Id);
 
-            NotificationManager.FromContext(context).Notify(styles.Id, notificationBuilder.Build());
+            NotificationManagerCompat.From(context).Notify(styles.Id, notificationBuilder.Build());
+        }
+
+        private static PendingIntent CreatePendingIntent(Context context, Intent intent, bool withParentStack)
+        {
+            if (withParentStack)
+            {
+                var stackBuilder = TaskStackBuilder.Create(context);
+                stackBuilder.AddNextIntentWithParentStack(intent);
+                return stackBuilder.GetPendingIntent(0, PendingIntentFlags.UpdateCurrent);
+            }
+            else
+            {
+                intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.ClearTask);
+                return PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
+            }
         }
 
         private static string GetApplicationName(Context context)

--- a/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
+++ b/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
@@ -52,6 +52,9 @@
     <Compile Include="DroidPushNotificationParser.cs" />
     <Compile Include="DroidPushNotificationsService.cs" />
     <Compile Include="PushNotificationStyles.cs" />
+    <Compile Include="LocaleChangeBroadcastReceiver.cs" />
+    <Compile Include="NotificationIntentActivityInfo.cs" />
+    <Compile Include="NotificationChannelsHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />

--- a/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
+++ b/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
@@ -64,6 +64,9 @@
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.Extensions">
       <Version>1.1.1.1</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.ShortcutBadger">
+      <Version>1.1.21</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Softeq.XToolkit.PushNotifications\Softeq.XToolkit.PushNotifications.csproj">

--- a/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
+++ b/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
@@ -55,6 +55,7 @@
     <Compile Include="LocaleChangeBroadcastReceiver.cs" />
     <Compile Include="NotificationIntentActivityInfo.cs" />
     <Compile Include="NotificationChannelsHelper.cs" />
+    <Compile Include="NotificationActionsHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />

--- a/Softeq.XToolkit.PushNotifications.iOS/IosPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications.iOS/IosPushNotificationsService.cs
@@ -57,6 +57,8 @@ namespace Softeq.XToolkit.PushNotifications.iOS
             {
                 var permissionGranted = await _permissionsService.RequestNotificationsPermissions();
 
+                // TODO: we should register token in any case to handle the possibility of user changing permission in Settings
+                // (the system itself will disregard notifications if permissions are not granted)
                 if (permissionGranted)
                 {
                     UIApplication.SharedApplication.RegisterForRemoteNotifications();

--- a/Softeq.XToolkit.PushNotifications.iOS/IosPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications.iOS/IosPushNotificationsService.cs
@@ -56,17 +56,11 @@ namespace Softeq.XToolkit.PushNotifications.iOS
             UIApplication.SharedApplication.InvokeOnMainThread(async () =>
             {
                 var permissionGranted = await _permissionsService.RequestNotificationsPermissions();
+                PushNotificationsHandler.OnPushPermissionsRequestCompleted(permissionGranted);
 
-                // TODO: we should register token in any case to handle the possibility of user changing permission in Settings
-                // (the system itself will disregard notifications if permissions are not granted)
-                if (permissionGranted)
-                {
-                    UIApplication.SharedApplication.RegisterForRemoteNotifications();
-                }
-                else
-                {
-                    OnFailedToRegisterForPushNotifications("Permission denied");
-                }
+                // We should register token in any case (even when permissions are not granted) to handle the possibility
+                // of user changing permission in Settings (the system itself will disregard notifications if permissions are not granted)
+                UIApplication.SharedApplication.RegisterForRemoteNotifications();
             });
         }
 

--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsHandler.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsHandler.cs
@@ -19,6 +19,13 @@ namespace Softeq.XToolkit.PushNotifications
         void OnPushRegistrationCompleted(bool isRegisteredInSystem, bool isSavedOnServer);
 
         /// <summary>
+        ///     Handle the result of push notifications permission request on iOS (this is not relevant for Android)
+        ///     Note that push notifications registration will be initiated anyway. You might want to use this callback for logging or analytics
+        /// </summary>
+        /// <param name="permissionsGranted">True if user allowed notification permissions, false if denied</param>
+        void OnPushPermissionsRequestCompleted(bool permissionsGranted);
+
+        /// <summary>
         ///     Handle the situation when push notification was received
         ///     (happens in foreground for iOS; in foreground for Android 'notification' messages; in all cases for Android 'data' messages)
         /// </summary>

--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
@@ -37,7 +37,7 @@ namespace Softeq.XToolkit.PushNotifications
 
         /// <summary>
         /// Set specific value for the app Badge number manually. Negative or zero value will remove the badge
-        /// NOTE: on Android <see cref="https://github.com/wcoder/ShortcutBadger"/> library is used. See wiki for details
+        /// NOTE: on Android <see cref="https://github.com/wcoder/ShortcutBadger"/> library is used. See wiki for details, not all devices are supported
         /// </summary>
         /// <param name="badgeNumber">Number to be displayed on the Badge</param>
         void SetBadgeNumber(int badgeNumber);

--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
@@ -37,7 +37,7 @@ namespace Softeq.XToolkit.PushNotifications
 
         /// <summary>
         /// Set specific value for the app Badge number manually. Negative or zero value will remove the badge
-        /// NOTE: not implemented on Android for now
+        /// NOTE: on Android <see cref="https://github.com/wcoder/ShortcutBadger"/> library is used. See wiki for details
         /// </summary>
         /// <param name="badgeNumber">Number to be displayed on the Badge</param>
         void SetBadgeNumber(int badgeNumber);


### PR DESCRIPTION
### Description of Change ###

Some updates to the Push Notifications library include:

- Added [ShortcutBadger](https://github.com/wcoder/ShortcutBadger) for showing badges on Android
- Added ability to customize notification channels and notifications showed with `NotificationCompat.Builder` on Android
- Added handling of localization change for Notification Channels
- Added ability to open Activity with parent stack from notification
- Added helper classes on Android like `NotificationChannelsHelper` and `NotificationActionsHelper`
- Now we register for iOS push notifications even if user declined permissions + added a callback for permissions request result

### API Changes ###

Added:
 - `void ConfigureNotificationChannel(string channelId, NotificationChannel channel)` to `INotificationsSettingsProvider`
 - `void CustomizeNotificationBuilder(NotificationCompat.Builder notificationBuilder, PushNotificationModel pushNotification, int notificationId)` to `INotificationsSettingsProvider`
 - `void OnPushPermissionsRequestCompleted(bool permissionsGranted)` to `IPushNotificationsHandler`

Changed:
- `Type GetStartActivityTypeFromPush(PushNotificationModel pushNotification)` for
   `NotificationIntentActivityInfo GetIntentActivityInfoFromPush(PushNotificationModel pushNotification)` in `INotificationsSettingsProvider`

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)