### PR TITLE
Apply converter for fallback value

### DIFF
--- a/Softeq.XToolkit.Bindings/BindingGeneric.cs
+++ b/Softeq.XToolkit.Bindings/BindingGeneric.cs
@@ -1384,7 +1384,7 @@ namespace Softeq.XToolkit.Bindings
         {
             if (_isFallbackValueActive)
             {
-                _targetProperty.SetValue(PropertyTarget.Target, FallbackValue, null);
+                _targetProperty.SetValue(PropertyTarget.Target, _converter.Convert(FallbackValue), null);
                 return true;
             }
 


### PR DESCRIPTION
### Description of Change ###

Fixing bug in bindings regarding using of fallback value for source property. Previously, fallback value was used without conversion to target type, which causes an InvalidCastException if source and target properties are not of the same type.

### API Changes ###
 
 None

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)