### PR TITLE
Push Notifications: Rework Unregister method a bit to allow unregiste…

### DIFF
--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
@@ -1,6 +1,7 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Threading.Tasks;
 
 namespace Softeq.XToolkit.PushNotifications
@@ -77,7 +78,20 @@ namespace Softeq.XToolkit.PushNotifications
         ///     On Android unsubscribing in system will only work when there is Internet Connection
         /// </param>
         /// <returns>Task with <see cref="PushNotificationsUnregisterResult" /> about unregistration status on server and in system as well.</returns>
+        [Obsolete("Use UnregisterFromPushNotifications with PushNotificationsUnregisterOptions param instead.")]
         Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(bool unregisterInSystem = false);
+
+        /// <summary>
+        ///     Unregisters application from push notifications
+        /// </summary>
+        /// <param name="options">
+        ///     Defines if we should unregister in system and if we should unregister on server
+        ///     Default value is OnServerOnly as it is not very recommended to unsubscribe in system by Apple and Firebase documentation,
+        ///     but it might be useful on logout.
+        ///     On Android unsubscribing in system will only work when there is Internet Connection
+        /// </param>
+        /// <returns>Task with <see cref="PushNotificationsUnregisterResult" /> about unregistration status on server and in system as well.</returns>
+        Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options = PushNotificationsUnregisterOptions.OnServerOnly);
 
         #endregion
 

--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
@@ -86,12 +86,11 @@ namespace Softeq.XToolkit.PushNotifications
         /// </summary>
         /// <param name="options">
         ///     Defines if we should unregister in system and if we should unregister on server
-        ///     Default value is OnServerOnly as it is not very recommended to unsubscribe in system by Apple and Firebase documentation,
-        ///     but it might be useful on logout.
+        ///     It is not very recommended to unsubscribe in system by Apple and Firebase documentation, but it might be useful on logout.
         ///     On Android unsubscribing in system will only work when there is Internet Connection
         /// </param>
         /// <returns>Task with <see cref="PushNotificationsUnregisterResult" /> about unregistration status on server and in system as well.</returns>
-        Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options = PushNotificationsUnregisterOptions.OnServerOnly);
+        Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options);
 
         #endregion
 

--- a/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
@@ -36,10 +36,11 @@ namespace Softeq.XToolkit.PushNotifications
 
         public abstract void RegisterForPushNotifications();
 
-        public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(bool unregisterInSystem = false)
+        public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(
+            PushNotificationsUnregisterOptions options = PushNotificationsUnregisterOptions.OnServerOnly)
         {
             // Unregister in system if needed
-            if (unregisterInSystem && PushTokenStorageService.IsTokenRegisteredInSystem)
+            if (options.ShouldUnregisterInSystem() && PushTokenStorageService.IsTokenRegisteredInSystem)
             {
                 var tokenRemovedFromSystem = await UnregisterFromPushTokenInSystem();
                 if (!tokenRemovedFromSystem)
@@ -56,20 +57,31 @@ namespace Softeq.XToolkit.PushNotifications
                 return PushNotificationsUnregisterResult.Success;
             }
 
-            // Unregister on server
-            var tokenRemovedFromServer = await RemotePushNotificationsService
-                .RemovePushNotificationsToken(token).ConfigureAwait(false);
-            if (!tokenRemovedFromServer)
+            // Unregister on server if needed
+            if (options.ShouldUnregisterOnServer() && PushTokenStorageService.IsTokenSavedOnServer)
             {
-                return PushNotificationsUnregisterResult.ServerFailed;
-            }
+                var tokenRemovedFromServer = await RemotePushNotificationsService
+                    .RemovePushNotificationsToken(token).ConfigureAwait(false);
+                if (!tokenRemovedFromServer)
+                {
+                    return PushNotificationsUnregisterResult.ServerFailed;
+                }
 
-            PushTokenStorageService.IsTokenSavedOnServer = false;
+                PushTokenStorageService.IsTokenSavedOnServer = false;
+            }
 
             // Clear token if it is unregistered both in the system (optional) and on server
             PushTokenStorageService.PushToken = string.Empty;
 
             return PushNotificationsUnregisterResult.Success;
+        }
+
+        [Obsolete("Use UnregisterFromPushNotifications with PushNotificationsUnregisterOptions param instead.")]
+        public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(bool unregisterInSystem = false)
+        {
+            return await UnregisterFromPushNotifications(unregisterInSystem
+                ? PushNotificationsUnregisterOptions.InSystemAndOnServer
+                : PushNotificationsUnregisterOptions.OnServerOnly);
         }
 
         public virtual void OnRegisteredForPushNotifications(string token)

--- a/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
@@ -36,8 +36,7 @@ namespace Softeq.XToolkit.PushNotifications
 
         public abstract void RegisterForPushNotifications();
 
-        public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(
-            PushNotificationsUnregisterOptions options = PushNotificationsUnregisterOptions.OnServerOnly)
+        public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options)
         {
             // Unregister in system if needed
             if (options.ShouldUnregisterInSystem() && PushTokenStorageService.IsTokenRegisteredInSystem)
@@ -196,7 +195,7 @@ namespace Softeq.XToolkit.PushNotifications
         {
             PushTokenStorageService.IsTokenRegisteredInSystem = false;
 
-            await UnregisterFromPushNotifications();
+            await UnregisterFromPushNotifications(PushNotificationsUnregisterOptions.OnServerOnly);
 
             PushNotificationsHandler.OnPushRegistrationCompleted(
                 PushTokenStorageService.IsTokenRegisteredInSystem,

--- a/Softeq.XToolkit.PushNotifications/PushNotificationsUnregisterOptions.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationsUnregisterOptions.cs
@@ -1,4 +1,4 @@
-﻿// Developed for PAWS-HALO by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 namespace Softeq.XToolkit.PushNotifications

--- a/Softeq.XToolkit.PushNotifications/PushNotificationsUnregisterOptions.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationsUnregisterOptions.cs
@@ -1,0 +1,37 @@
+﻿// Developed for PAWS-HALO by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.PushNotifications
+{
+    /// <summary>
+    /// Options of how to Unregister from Push Notifications
+    /// </summary>
+    public enum PushNotificationsUnregisterOptions
+    {
+        /// <summary>
+        /// Unregister in system only, but do not unregister on server
+        /// </summary>
+        InSystemOnly,
+
+        /// <summary>
+        /// Unregister on server only, but do not unregister in system
+        /// </summary>
+        OnServerOnly,
+
+        /// <summary>
+        /// Unregister both in system and on server
+        /// </summary>
+        InSystemAndOnServer
+    }
+
+    public static class PushNotificationsUnregisterOptionsExtensions
+    {
+        public static bool ShouldUnregisterInSystem(this PushNotificationsUnregisterOptions options) =>
+            options == PushNotificationsUnregisterOptions.InSystemOnly
+            || options == PushNotificationsUnregisterOptions.InSystemAndOnServer;
+
+        public static bool ShouldUnregisterOnServer(this PushNotificationsUnregisterOptions options) =>
+            options == PushNotificationsUnregisterOptions.OnServerOnly
+            || options == PushNotificationsUnregisterOptions.InSystemAndOnServer;
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Rework Unregister method a bit to allow unregister in system only

### API Changes ###

Added:
 - Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options = PushNotificationsUnregisterOptions.OnServerOnly)

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)