### PR TITLE
Push notifications: add asynchronous method for subscribe

### DIFF
--- a/Softeq.XToolkit.Permissions.iOS/PermissionsService.cs
+++ b/Softeq.XToolkit.Permissions.iOS/PermissionsService.cs
@@ -61,6 +61,11 @@ namespace Softeq.XToolkit.Permissions.iOS
         {
             var notificationCenter = UNUserNotificationCenter.Current;
             var notificationSettings = await notificationCenter.GetNotificationSettingsAsync().ConfigureAwait(false);
+            if (notificationSettings.AuthorizationStatus == UNAuthorizationStatus.NotDetermined)
+            {
+                return PermissionStatus.Unknown;
+            }
+
             var notificationsSettingsEnabled = notificationSettings.SoundSetting == UNNotificationSetting.Enabled
                                                && notificationSettings.AlertSetting == UNNotificationSetting.Enabled;
             return notificationsSettingsEnabled

--- a/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationParser.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/DroidPushNotificationParser.cs
@@ -52,7 +52,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             pushNotification.Title = pushMessage == null ? GetStringFromDictionary(pushData, DataTitleKey) : pushMessage.Title;
             pushNotification.Body = pushMessage == null ? GetStringFromDictionary(pushData, DataBodyKey) : pushMessage.Body;
 
-            pushNotification.IsSilent = string.IsNullOrEmpty(pushNotification.Body); // TODO: possibly other way to determine (?client-side)
+            pushNotification.IsSilent = string.IsNullOrEmpty(pushNotification.Body);
 
             pushNotification.Type = ParseNotificationTypeFromData(pushData);
             pushNotification.AdditionalData = GetStringFromDictionary(pushData, DataKey);

--- a/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
+++ b/Softeq.XToolkit.PushNotifications/IPushNotificationsService.cs
@@ -53,6 +53,12 @@ namespace Softeq.XToolkit.PushNotifications
         void RegisterForPushNotifications();
 
         /// <summary>
+        ///     Registers application for push notifications asynchronously
+        /// </summary>
+        /// <returns>Task with <see cref="PushNotificationRegistrationResult" /> about registration status in system and on server.</returns>
+        Task<PushNotificationRegistrationResult> RegisterForPushNotificationsAsync();
+
+        /// <summary>
         ///     Callback to notify the service that registration for push notifications finished successfully.
         ///     On iOS should be called in AppDelegate's RegisteredForRemoteNotifications
         ///     On Android is called internally

--- a/Softeq.XToolkit.PushNotifications/PushNotificationModel.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationModel.cs
@@ -17,6 +17,8 @@ namespace Softeq.XToolkit.PushNotifications
 
         /// <summary>
         ///     Value to determine if notification is silent (not visible to the user, for some inner updates)
+        ///     On iOS: contains content-available key with value 1
+        ///     On Android: does not contain Body
         /// </summary>
         public bool IsSilent { get; set; }
 

--- a/Softeq.XToolkit.PushNotifications/PushNotificationRegistrationResult.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationRegistrationResult.cs
@@ -1,0 +1,29 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.PushNotifications
+{
+    /// <summary>
+    ///     Class containing push notifications registration result
+    ///     If one of the properties is false - we won't be able to receive push notifications
+    /// </summary>
+    public class PushNotificationRegistrationResult
+    {
+        /// <summary>
+        ///     Value that indicates if we are registered to push notifications in system with token stored in
+        ///     IPushTokenStorageService
+        /// </summary>
+        public bool IsRegisteredInSystem { get; set; }
+
+        /// <summary> Value that indicates if current token was saved on server </summary>
+        public bool IsSavedOnServer { get; set; }
+
+        public PushNotificationRegistrationResult() { }
+
+        public PushNotificationRegistrationResult(bool isRegisteredInSystem, bool isSavedOnServer)
+        {
+            IsRegisteredInSystem = isRegisteredInSystem;
+            IsSavedOnServer = isSavedOnServer;
+        }
+    }
+}

--- a/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
+++ b/Softeq.XToolkit.PushNotifications/PushNotificationsServiceBase.cs
@@ -16,6 +16,8 @@ namespace Softeq.XToolkit.PushNotifications
         protected readonly IPushTokenStorageService PushTokenStorageService;
         protected readonly IRemotePushNotificationsService RemotePushNotificationsService;
 
+        private TaskCompletionSource<PushNotificationRegistrationResult> _registrationCompletionSource;
+
         protected PushNotificationsServiceBase(
             IRemotePushNotificationsService remotePushNotificationsService,
             IPushTokenStorageService pushTokenStorageService,
@@ -35,6 +37,16 @@ namespace Softeq.XToolkit.PushNotifications
         public abstract void ClearAllNotifications();
 
         public abstract void RegisterForPushNotifications();
+
+        public Task<PushNotificationRegistrationResult> RegisterForPushNotificationsAsync()
+        {
+            if (_registrationCompletionSource == null || _registrationCompletionSource.Task.IsCompleted)
+            {
+                _registrationCompletionSource = new TaskCompletionSource<PushNotificationRegistrationResult>();
+                RegisterForPushNotifications();
+            }
+            return _registrationCompletionSource.Task;
+        }
 
         public async Task<PushNotificationsUnregisterResult> UnregisterFromPushNotifications(PushNotificationsUnregisterOptions options)
         {
@@ -189,6 +201,9 @@ namespace Softeq.XToolkit.PushNotifications
             PushNotificationsHandler.OnPushRegistrationCompleted(
                 PushTokenStorageService.IsTokenRegisteredInSystem,
                 PushTokenStorageService.IsTokenSavedOnServer);
+
+            _registrationCompletionSource?.TrySetResult(new PushNotificationRegistrationResult(
+                PushTokenStorageService.IsTokenRegisteredInSystem, PushTokenStorageService.IsTokenSavedOnServer));
         }
 
         private async Task OnRegisterFailedInternal()
@@ -200,6 +215,9 @@ namespace Softeq.XToolkit.PushNotifications
             PushNotificationsHandler.OnPushRegistrationCompleted(
                 PushTokenStorageService.IsTokenRegisteredInSystem,
                 PushTokenStorageService.IsTokenSavedOnServer);
+
+            _registrationCompletionSource?.TrySetResult(new PushNotificationRegistrationResult(
+                PushTokenStorageService.IsTokenRegisteredInSystem, PushTokenStorageService.IsTokenSavedOnServer));
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Added an async Register for push notifications method

### API Changes ###

Added:
 - `Task<PushNotificationRegistrationResult> RegisterForPushNotificationsAsync();` to `IPushNotificationsService`
- `PushNotificationRegistrationResult` class

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

`CheckPermissionsAsync` for `NotificationsPermission` now returns `PermissionStatus.Unknown` if permission was not requested yet

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)