### PR TITLE
New beta version 4

### DIFF
--- a/nuget/Softeq.XToolkit.Bindings.nuspec
+++ b/nuget/Softeq.XToolkit.Bindings.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Bindings</id>
-    <version>2.0.0-beta3</version>
+    <version>2.0.0-beta4</version>
     <title>Softeq.XToolkit.Bindings</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -10,30 +10,30 @@
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Bindings implementation based on INotifyPropertyChanged interface.</description>
-    <copyright>Copyright 2019 Softeq Development Corp.</copyright>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android Bindings</tags>
     <releaseNotes/>
     <dependencies>
-     <group targetFramework="netstandard2.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+     <group targetFramework="netstandard2.1">
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
       </group>
      <group targetFramework="MonoAndroid10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
-        <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0.1" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0.3" />
       </group>
      <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
       </group>
    </dependencies>
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.0/Softeq.XToolkit.Bindings.dll" target="lib\netstandard2.0" />
+    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\netstandard2.1" />
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.0/Softeq.XToolkit.Bindings.dll" target="lib\MonoAndroid10" />
+    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\MonoAndroid10" />
     <file src="../Softeq.XToolkit.Bindings.Droid/bin/Release/Softeq.XToolkit.Bindings.Droid.dll" target="lib\MonoAndroid10" />
     <!-- iOS -->
-    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.0/Softeq.XToolkit.Bindings.dll" target="lib\Xamarin.iOS10" />
+    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\Xamarin.iOS10" />
     <file src="../Softeq.XToolkit.Bindings.iOS/bin/Release/Softeq.XToolkit.Bindings.iOS.dll" target="lib\Xamarin.iOS10" />
   </files>
 </package>

--- a/nuget/Softeq.XToolkit.Common.nuspec
+++ b/nuget/Softeq.XToolkit.Common.nuspec
@@ -2,26 +2,27 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Common</id>
-    <version>1.1.0-beta3</version>
+    <version>1.1.0-beta4</version>
     <title>Softeq.XToolkit.Common</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="bdc6c7e673954012a7dd2bca6f187c547c889c85" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The most common components without dependencies that can be reused in any project.</description>
-    <copyright>Copyright 2019 Softeq Development Corp.</copyright>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android</tags>
-    <releaseNotes/>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.0/Softeq.XToolkit.Common.dll" target="lib\netstandard2.0" />
+    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.1/Softeq.XToolkit.Common.dll" target="lib\netstandard2.1" />
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.0/Softeq.XToolkit.Common.dll" target="lib\MonoAndroid10" />
+    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.1/Softeq.XToolkit.Common.dll" target="lib\MonoAndroid10" />
     <file src="../Softeq.XToolkit.Common.Droid/bin/Release/Softeq.XToolkit.Common.Droid.dll" target="lib\MonoAndroid10" />
     <!-- iOS -->
-    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.0/Softeq.XToolkit.Common.dll" target="lib\Xamarin.iOS10" />
+    <file src="../Softeq.XToolkit.Common/bin/Release/netstandard2.1/Softeq.XToolkit.Common.dll" target="lib\Xamarin.iOS10" />
     <file src="../Softeq.XToolkit.Common.iOS/bin/Release/Softeq.XToolkit.Common.iOS.dll" target="lib\Xamarin.iOS10" />
   </files>
 </package>

--- a/nuget/Softeq.XToolkit.Permissions.nuspec
+++ b/nuget/Softeq.XToolkit.Permissions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Softeq.XToolkit.Permissions</id>
-    <version>2.0.0-beta2</version>
+    <version>2.0.0-beta3</version>
     <title>Softeq.XToolkit.Permissions</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -10,11 +10,11 @@
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Simple cross platform plugin to request and check permissions for Android and iOS.</description>
-    <copyright>Copyright 2019 Softeq Development Corp.</copyright>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin Permissions iOS Android</tags>
     <releaseNotes/>
     <dependencies>
-      <group targetFramework="netstandard2.0">
+      <group targetFramework="netstandard2.1">
         <dependency id="Plugin.Permissions" version="5.0.0-beta"/>
         <dependency id="Xam.Plugins.Settings" version="3.1.1"/>
       </group>
@@ -30,12 +30,12 @@
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.0/Softeq.XToolkit.Permissions.dll" target="lib\netstandard2.0"/>
+    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.1/Softeq.XToolkit.Permissions.dll" target="lib\netstandard2.1"/>
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.0/Softeq.XToolkit.Permissions.dll" target="lib\MonoAndroid10"/>
+    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.1/Softeq.XToolkit.Permissions.dll" target="lib\MonoAndroid10"/>
     <file src="../Softeq.XToolkit.Permissions.Droid/bin/Release/Softeq.XToolkit.Permissions.Droid.dll" target="lib\MonoAndroid10"/>
     <!-- iOS -->
-    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.0/Softeq.XToolkit.Permissions.dll" target="lib\Xamarin.iOS10"/>
+    <file src="../Softeq.XToolkit.Permissions/bin/Release/netstandard2.1/Softeq.XToolkit.Permissions.dll" target="lib\Xamarin.iOS10"/>
     <file src="../Softeq.XToolkit.Permissions.iOS/bin/Release/Softeq.XToolkit.Permissions.iOS.dll" target="lib\Xamarin.iOS10"/>
   </files>
 </package>

--- a/nuget/Softeq.XToolkit.PushNotifications.nuspec
+++ b/nuget/Softeq.XToolkit.PushNotifications.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Softeq.XToolkit.PushNotifications</id>
-    <version>1.0.0-beta3</version>
+    <version>1.0.0-beta4</version>
     <title>Softeq.XToolkit.PushNotifications</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -10,22 +10,22 @@
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Simple cross platform plugin to use push-notifications for Android and iOS.</description>
-    <copyright>Copyright 2019 Softeq Development Corp.</copyright>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Push Notifications Firebase FCM APNS iOS Android Xamarin</tags>
     <releaseNotes/>
     <dependencies>
-      <group targetFramework="netstandard2.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+      <group targetFramework="netstandard2.1">
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
       </group>
       <group targetFramework="MonoAndroid9.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
         <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1" />
         <dependency id="Xamarin.Android.Support.Media.Compat" version="28.0.0.1" />
         <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
         <dependency id="Xamarin.Android.Arch.Lifecycle.Extensions" version="1.1.1.1" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -34,12 +34,12 @@
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.0/Softeq.XToolkit.PushNotifications.dll" target="lib\netstandard2.0"/>
+    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\netstandard2.1"/>
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.0/Softeq.XToolkit.PushNotifications.dll" target="lib\MonoAndroid9.0"/>
+    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\MonoAndroid9.0"/>
     <file src="../Softeq.XToolkit.PushNotifications.Droid/bin/Release/Softeq.XToolkit.PushNotifications.Droid.dll" target="lib\MonoAndroid9.0"/>
     <!-- iOS -->
-    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.0/Softeq.XToolkit.PushNotifications.dll" target="lib\Xamarin.iOS10"/>
+    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\Xamarin.iOS10"/>
     <file src="../Softeq.XToolkit.PushNotifications.iOS/bin/Release/Softeq.XToolkit.PushNotifications.iOS.dll" target="lib\Xamarin.iOS10"/>
   </files>
 </package>

--- a/nuget/Softeq.XToolkit.Remote.nuspec
+++ b/nuget/Softeq.XToolkit.Remote.nuspec
@@ -8,16 +8,17 @@
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="bdc6c7e673954012a7dd2bca6f187c547c889c85" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced HttpClient infrastructure for mobile applications.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android Remote Http Rest Api Auth</tags>
-    <releaseNotes/>
+    <releaseNotes>First release.</releaseNotes>
     <dependencies>
       <dependency id="Polly" version="7.1.1" />
       <dependency id="refit" version="4.7.51" />
       <!-- XToolkit -->
-      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta3]" />
+      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
     </dependencies>
   </metadata>
   <files>

--- a/nuget/Softeq.XToolkit.Remote.nuspec
+++ b/nuget/Softeq.XToolkit.Remote.nuspec
@@ -23,7 +23,7 @@
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.Remote/bin/Release/netstandard2.0/Softeq.XToolkit.Remote.dll" target="lib\netstandard2.0" />
-    <file src="../Softeq.XToolkit.Remote/bin/Release/netstandard2.0/Softeq.XToolkit.Remote.pdb" target="lib\netstandard2.0" />
+    <file src="../Softeq.XToolkit.Remote/bin/Release/netstandard2.1/Softeq.XToolkit.Remote.dll" target="lib\netstandard2.1" />
+    <file src="../Softeq.XToolkit.Remote/bin/Release/netstandard2.1/Softeq.XToolkit.Remote.pdb" target="lib\netstandard2.1" />
   </files>
 </package>

--- a/nuget/Softeq.XToolkit.WhiteLabel.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.WhiteLabel</id>
-    <version>2.0.0-beta4</version>
+    <version>2.0.0-beta5</version>
     <title>Softeq.XToolkit.WhiteLabel</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -10,17 +10,17 @@
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>XToolkit.WhiteLabel is a collection of "lego" components for fast create cross-platform mobile applications with Xamarin, based on XToolkit.</description>
-    <copyright>Copyright 2019 Softeq Development Corp.</copyright>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android</tags>
     <releaseNotes/>
     <dependencies>
-     <group targetFramework="netstandard2.0">
+     <group targetFramework="netstandard2.1">
         <dependency id="DryIoc.dll" version="4.0.5" />
         <dependency id="Newtonsoft.Json" version="12.0.2" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta2" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta3" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
       </group>
      <group targetFramework="MonoAndroid10">
         <dependency id="DryIoc.dll" version="4.0.5" />
@@ -28,14 +28,14 @@
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta2" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta3" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
         <!-- Android specific -->
         <dependency id="Plugin.CurrentActivity" version="2.1.0.4" />
-        <dependency id="Xamarin.Android.Support.Design" version="28.0.0.1" />
-        <dependency id="Xamarin.Android.Support.v4" version="28.0.0.1" />
-        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1" />
+        <dependency id="Xamarin.Android.Support.Design" version="28.0.0.3" />
+        <dependency id="Xamarin.Android.Support.v4" version="28.0.0.3" />
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.3" />
       </group>
      <group targetFramework="Xamarin.iOS10">
         <dependency id="DryIoc.dll" version="4.0.5" />
@@ -43,20 +43,20 @@
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta2" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta3" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
       </group>
    </dependencies>
   </metadata>
   <files>
     <!-- Core -->
-    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.0/Softeq.XToolkit.WhiteLabel.dll" target="lib\netstandard2.0" />
+    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\netstandard2.1" />
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.0/Softeq.XToolkit.WhiteLabel.dll" target="lib\MonoAndroid10" />
+    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\MonoAndroid10" />
     <file src="../Softeq.XToolkit.WhiteLabel.Droid/bin/Release/Softeq.XToolkit.WhiteLabel.Droid.dll" target="lib\MonoAndroid10" />
     <!-- iOS -->
-    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.0/Softeq.XToolkit.WhiteLabel.dll" target="lib\Xamarin.iOS10" />
+    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\Xamarin.iOS10" />
     <file src="../Softeq.XToolkit.WhiteLabel.iOS/bin/Release/Softeq.XToolkit.WhiteLabel.iOS.dll" target="lib\Xamarin.iOS10" />
   </files>
 </package>


### PR DESCRIPTION
### Description of Change ###

New beta release XToolkit components.

Main changes: 🚀 

- C# 8.0, Nullable enabled PR #213 
- Android.Support libraries -> 28.0.0.3
- Android TargetFramework -> v10.0
- Net Standard libraries -> netstandard2.1

### API Changes ###

## Common

### XToolkit.Common

- C# 7.3 -> 8.0 & Nullable
- netstandard2.0 -> netstandard2.1
- `BiDictionary` reworked PR #225
- Changed `DateTimeExtensions`, `StringExtensions` PR #236
- Changed `TagsHelper`, `TextRange` PR #234
- ConsoleLogger PR #231

### XToolkit.Common.Droid

- C# 7.3 -> 8.0 & Nullable
- TargetFramework v9.0 -> v10.0

### XToolkit.Common.iOS

- C# 7.3 -> 8.0 & Nullable
- DateTimeExtensions PR #210

### XToolkit.Common.Tests

- C# 7.3 -> 8.0 & Nullable
- `TextRangeTests`
- `TagsHelperTests`
- `HashHelperTests`
- `BiDictionaryTests`
- `AssemblyExtensionsTests`
- `DateTimeExtensionsTests`
- `InternalSettingsExtensionsTests`
- `ConsoleLogManagerTests`
- `ConsoleLoggerTests`
- `LoggerInterfacesTests`

## Connectivity

### XToolkit.Connectivity

- C# 7.3 -> 8.0 & Nullable
- netstandard2.0 -> netstandard2.1

### XToolkit.Connectivity.iOS

- C# 7.3 -> 8.0 & Nullable

## Bindings

### XToolkit.Bindings

- C# 7.3 -> 8.0 & Nullable
- Converter - Apply converter for fallback value PR #219

### XToolkit.Bindings.Droid

- C# 7.3 -> 8.0 & Nullable
- TargetFramework v9.0 -> v10.0
- `Xamarin.Android.Support.v7.RecyclerView` 28.0.0.1 -> 28.0.0.3

### XToolkit.Bindings.iOS

- C# 7.3 -> 8.0 & Nullable
- Moved GestureRecognizerBinding -> Softeq.XToolkit.Bindings.iOS.Bindable.Abstract to Softeq.XToolkit.Bindings.iOS

## Permissions

### XToolkit.Permissions

- C# 7.3 -> 8.0 & Nullable
- netstandard2.0 -> netstandard2.1

### XToolkit.Permissions.Droid

- C# 7.3 -> 8.0 & Nullable
- TargetFramework v9.0 -> v10.0

### XToolkit.Permissions.iOS

- C# 7.3 -> 8.0 & Nullable
- `PermissionsService` - Return Unknown status if notifications permissions were not requested yet. PR #233

## PushNotifications

### XToolkit.PushNotifications

- C# 7.3 -> 8.0 & Nullable
- netstandard2.0 -> netstandard2.1
- `IPushNotificationsHandler`, `IPushNotificationsService`, `PushNotificationRegistrationResult`, `PushNotificationsServiceBase`, 'PushNotificationsUnregisterOptions' and etc. PR #215

### XToolkit.PushNotifications.Droid

- C# 7.3 -> 8.0 & Nullable
- TargetFramework v9.0 -> v10.0
- Changed `DroidPushNotificationsService`, `INotificationsSettingsProvider` PR #215

### XToolkit.PushNotifications.iOS

- C# 7.3 -> 8.0 & Nullable
- Changed `IosPushNotificationsService` PR #215

## WhiteLabel

### XToolkit.WhiteLabel

- C# 7.3 -> 8.0 & Nullable
- netstandard2.0 -> netstandard2.1
- Refactored FrameNavigation PR #221
- `DryIocContainerAdapter` PR #221
- Removed default registrations tab navigation from `BootstrapperBase` PR #221
- `IContainer` added `Decorator` registration PR #238

### XToolkit.WhiteLabel.Droid

- C# 7.3 -> 8.0 & Nullable
- TargetFramework v9.0 -> v10.0
- `Xamarin.Android.Support.Design` 28.0.0.1 -> 28.0.0.3
- `Xamarin.Android.Support.v7.AppCompat` 28.0.0.1 -> 28.0.0.3
- `Xamarin.Android.Support.v4` 28.0.0.1 -> 28.0.0.3
- `ImagePicker` - `OpenGallery`, `OpenCamera` returns `Task`
- Refactored FrameNavigation PR #221

### XToolkit.WhiteLabel.iOS

- C# 7.3 -> 8.0 & Nullable
- Fix navigation keyboard issues in `StoryboardNavigation` PR #235
- `CustomViewBase` make nibName virtual PR #223

## Remote

- Added new `Remote`, `Remote.Tests` projects

## Samples

- Added `samples/RemoteApp`
- Changed ` samples/Playground`

## CI/DI

- Reworked azure-pipelines


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)
- iOS
- Android

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)