### PR TITLE
Refactor bootstrapper

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapper.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapper.cs
@@ -29,18 +29,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             // navigation
             builder.Singleton<ActivityPageNavigationService, IPlatformNavigationService>(IfRegistered.Keep);
             builder.Singleton<BundleService, IBundleService>(IfRegistered.Keep);
-            builder.Singleton<DroidViewLocator>(IfRegistered.Keep);
+            builder.Singleton<DroidViewLocator, IViewLocator>(IfRegistered.Keep);
             builder.PerDependency<DroidFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
-        }
-
-        protected override void RegisterViewLocator(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewMapping)
-        {
-            builder.Singleton<IViewLocator>(container =>
-            {
-                var viewLocator = container.Resolve<DroidViewLocator>();
-                viewLocator.Initialize(viewModelToViewMapping);
-                return viewLocator;
-            }, IfRegistered.Keep);
         }
 
         protected override void ConfigureIoc(IContainerBuilder builder)
@@ -50,7 +40,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
     public class DroidViewModelFinder : ViewModelFinderBase
     {
-        protected override IEnumerable<Type> SelectViewModelTypes(Assembly assembly)
+        protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
         {
             return assembly.GetTypes().View(typeof(AppCompatActivity), typeof(Fragment), typeof(DialogFragment));
         }

--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidViewLocator.cs
@@ -61,12 +61,11 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
             var targetTypeName = viewModelTypeName.Replace(".ViewModels.", ".Droid.Views.");
             targetTypeName = targetTypeName.Replace("ViewModel", viewType.ToString());
 
-            var targetType = Type.GetType(targetTypeName)
-                             ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
+            var targetType = Type.GetType(targetTypeName) ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
 
             if (targetType == null)
             {
-                throw new DllNotFoundException($"Can't find target type: {targetTypeName}");
+                throw new InvalidOperationException($"Can't find target type: {targetTypeName}");
             }
 
             return targetType;

--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/IViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/IViewLocator.cs
@@ -2,18 +2,16 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
 using Softeq.XToolkit.WhiteLabel.Mvvm;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
 {
     public interface IViewLocator
     {
-        void Initialize(Dictionary<Type, Type> viewModelToView);
-
+        [Obsolete("Never used inside components. Please use full signature: `GetTargetType(Type, ViewType)`")]
         Type GetTargetType<TViewModel>(ViewType viewType);
 
-        Type GetTargetType(Type type, ViewType viewType);
+        Type GetTargetType(Type viewModelType, ViewType viewType);
 
         object GetView(IViewModelBase viewModel, ViewType viewType);
     }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Helpers/ViewControllerHelper.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Helpers/ViewControllerHelper.cs
@@ -1,0 +1,59 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Foundation;
+using Softeq.XToolkit.Common.Logger;
+using Softeq.XToolkit.WhiteLabel.Threading;
+using UIKit;
+
+namespace Softeq.XToolkit.WhiteLabel.iOS.Helpers
+{
+    public static class ViewControllerHelper
+    {
+        /// <summary>
+        ///     Method for safety attempt to create <see cref="UIViewController"/> from storyboard
+        ///     otherwise creates a new instance of <see cref="viewControllerType"/>.
+        /// </summary>
+        /// <param name="storyboardName">Storyboard name.</param>
+        /// <param name="viewControllerType">Type of ViewController on Storyboard.</param>
+        /// <param name="logger">Instance of <see cref="ILogger"/>.</param>
+        /// <returns>Target instance of <see cref="viewControllerType"/></returns>
+        public static UIViewController? TryCreateViewController(string storyboardName, Type viewControllerType, ILogger logger)
+        {
+            UIViewController? newViewController = null;
+
+            try
+            {
+                Execute.OnUIThread(() =>
+                {
+                    newViewController = CreateViewControllerFromStoryboard(storyboardName, viewControllerType.Name)
+                                        ?? (UIViewController) Activator.CreateInstance(viewControllerType);
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex);
+            }
+
+            return newViewController;
+        }
+
+        /// <summary>
+        ///     Method for instantiating <see cref="UIViewController"/> from Storyboard if found, otherwise returns NULL.
+        /// </summary>
+        /// <param name="storyboardName">Storyboard name.</param>
+        /// <param name="viewControllerName">Name of ViewController on Storyboard.</param>
+        /// <returns></returns>
+        public static UIViewController? CreateViewControllerFromStoryboard(string storyboardName, string viewControllerName)
+        {
+            if (NSBundle.MainBundle.PathForResource(storyboardName, "storyboardc") == null)
+            {
+                return null;
+            }
+
+            var storyboard = UIStoryboard.FromName(storyboardName, null);
+            return storyboard?.InstantiateViewController(viewControllerName);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraper.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraper.cs
@@ -25,19 +25,9 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
             // navigation
             builder.Singleton<ViewControllerProvider, IViewControllerProvider>(IfRegistered.Keep);
-            builder.Singleton<StoryboardViewLocator>(IfRegistered.Keep);
+            builder.Singleton<StoryboardViewLocator, IViewLocator>(IfRegistered.Keep);
             builder.Singleton<StoryboardNavigation, IPlatformNavigationService>(IfRegistered.Keep);
             builder.PerDependency<StoryboardFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
-        }
-
-        protected override void RegisterViewLocator(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewDictionary)
-        {
-            builder.Singleton<IViewLocator>(container =>
-            {
-                var viewLocator = container.Resolve<StoryboardViewLocator>();
-                viewLocator.Initialize(viewModelToViewDictionary);
-                return viewLocator;
-            }, IfRegistered.Keep);
         }
 
         protected override void ConfigureIoc(IContainerBuilder builder)
@@ -47,7 +37,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
     public class IosViewModelFinder : ViewModelFinderBase
     {
-        protected override IEnumerable<Type> SelectViewModelTypes(Assembly assembly)
+        protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
         {
             return assembly.GetTypes().View(typeof(UIViewController));
         }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Navigation/IViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Navigation/IViewLocator.cs
@@ -1,8 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
-using System.Collections.Generic;
 using UIKit;
 
 namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
@@ -12,7 +10,5 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
         UIViewController GetView(object viewModel);
 
         UIViewController GetTopViewController();
-
-        void Initialize(Dictionary<Type, Type> viewmodelToView);
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardViewLocator.cs
@@ -55,14 +55,14 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             var storyboardName = controllerType.Name.Replace("ViewController", "Storyboard");
             var viewController = TryCreateViewController(storyboardName, controllerType);
 
+            if (viewController == null)
+            {
+                throw new InvalidOperationException("view not found");
+            }
+
             if (viewController is IBindable bindableViewController)
             {
                 bindableViewController.SetDataContext(viewModel);
-            }
-
-            if(viewController == null)
-            {
-                throw new Exception("view not found");
             }
 
             return viewController;
@@ -70,21 +70,18 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
 
         private Type GetTargetType(Type type)
         {
-            Type? targetType = default;
-
-            if (_modelToControllerTypes.TryGetValue(type, out targetType))
+            if (_modelToControllerTypes.TryGetValue(type, out var targetType))
             {
                 return targetType;
             }
 
             var targetTypeName = type.FullName.Replace(".ViewModels.", ".iOS.ViewControllers.");
             targetTypeName = targetTypeName.Replace("ViewModel", "ViewController");
-            targetType = Type.GetType(targetTypeName)
-                         ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
+            targetType = Type.GetType(targetTypeName) ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
 
             if (targetType == null)
             {
-                throw new Exception($"Can't find target type: {targetTypeName}");
+                throw new InvalidOperationException($"Can't find target type: {targetTypeName}");
             }
 
             return targetType;

--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardViewLocator.cs
@@ -2,14 +2,13 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Foundation;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Common.Logger;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.iOS.Helpers;
 using Softeq.XToolkit.WhiteLabel.iOS.Interfaces;
 using Softeq.XToolkit.WhiteLabel.iOS.Navigation;
-using Softeq.XToolkit.WhiteLabel.Threading;
 using UIKit;
 
 namespace Softeq.XToolkit.WhiteLabel.iOS.Services
@@ -18,26 +17,16 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
     {
         private readonly ILogger _logger;
         private readonly IViewControllerProvider _viewControllerProvider;
-
-        private Dictionary<Type, Type> _modelToControllerTypes;
+        private readonly ViewModelToViewMap _viewModelToViewMap;
 
         public StoryboardViewLocator(
             ILogManager logManager,
-            IViewControllerProvider viewControllerProvider)
+            IViewControllerProvider viewControllerProvider,
+            ViewModelToViewMap viewModelToViewMap)
         {
             _viewControllerProvider = viewControllerProvider;
             _logger = logManager.GetLogger<StoryboardViewLocator>();
-            _modelToControllerTypes = new Dictionary<Type, Type>();
-        }
-
-        public void Initialize(Dictionary<Type, Type> viewModelToViewController)
-        {
-            if (viewModelToViewController == null)
-            {
-                return;
-            }
-
-            _modelToControllerTypes = viewModelToViewController;
+            _viewModelToViewMap = viewModelToViewMap;
         }
 
         public UIViewController GetTopViewController()
@@ -50,14 +39,13 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
 
         public UIViewController GetView(object viewModel)
         {
-            var controllerType = GetTargetType(viewModel.GetType());
-
-            var storyboardName = controllerType.Name.Replace("ViewController", "Storyboard");
-            var viewController = TryCreateViewController(storyboardName, controllerType);
+            var viewControllerType = GetTargetViewType(viewModel.GetType());
+            var storyboardName = BuildStoryboardName(viewControllerType);
+            var viewController = ViewControllerHelper.TryCreateViewController(storyboardName, viewControllerType, _logger);
 
             if (viewController == null)
             {
-                throw new InvalidOperationException("view not found");
+                throw new InvalidOperationException($"Can't find VC for type: {viewControllerType}");
             }
 
             if (viewController is IBindable bindableViewController)
@@ -68,51 +56,40 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             return viewController;
         }
 
-        private Type GetTargetType(Type type)
+        // TODO YP: export to base, looks the same as Android impl.
+        protected virtual Type GetTargetViewType(Type viewModelType)
         {
-            if (_modelToControllerTypes.TryGetValue(type, out var targetType))
+            if (_viewModelToViewMap.TryGetValue(viewModelType, out var targetViewType))
             {
-                return targetType;
+                return targetViewType;
             }
 
-            var targetTypeName = type.FullName.Replace(".ViewModels.", ".iOS.ViewControllers.");
-            targetTypeName = targetTypeName.Replace("ViewModel", "ViewController");
-            targetType = Type.GetType(targetTypeName) ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
+            var targetTypeName = BuildViewTypeName(viewModelType);
+            targetViewType = Type.GetType(targetTypeName) ?? AssemblySource.FindTypeByNames(new[] { targetTypeName });
 
-            if (targetType == null)
+            if (targetViewType == null)
             {
-                throw new InvalidOperationException($"Can't find target type: {targetTypeName}");
+                throw new InvalidOperationException($"Can't find target view type: {targetTypeName}");
             }
 
-            return targetType;
+            return targetViewType;
         }
 
-        // TODO YP: export to another class
-        private UIViewController? TryCreateViewController(string storyBoardName, Type targetType)
+        protected virtual string BuildViewTypeName(Type viewType)
         {
-            UIViewController? newViewController = null;
-
-            try
+            if (viewType == null)
             {
-                Execute.OnUIThread(() =>
-                {
-                    if (NSBundle.MainBundle.PathForResource(storyBoardName, "storyboardc") != null)
-                    {
-                        var storyboard = UIStoryboard.FromName(storyBoardName, null);
-                        newViewController = storyboard.InstantiateViewController(targetType.Name);
-                    }
-                    else
-                    {
-                        newViewController = (UIViewController) Activator.CreateInstance(targetType);
-                    }
-                });
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn(ex);
+                throw new ArgumentNullException(nameof(viewType));
             }
 
-            return newViewController;
+            return viewType.FullName?
+                .Replace(".ViewModels.", ".iOS.ViewControllers.")
+                .Replace("ViewModel", "ViewController");
+        }
+
+        protected virtual string BuildStoryboardName(Type viewControllerType)
+        {
+            return viewControllerType.Name.Replace("ViewController", "Storyboard");
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Helpers\AvatarImageHelpers.cs" />
     <Compile Include="Helpers\UIImageHelper.cs" />
     <Compile Include="Helpers\UiTabBarControllerHelper.cs" />
+    <Compile Include="Helpers\ViewControllerHelper.cs" />
     <Compile Include="ImagePicker\SimpleImagePicker.cs" />
     <Compile Include="Interfaces\IViewControllerProvider.cs" />
     <Compile Include="IosPlatformProvider.cs" />

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -17,9 +17,10 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             var containerBuilder = CreateContainerBuilder();
 
             RegisterInternalServices(containerBuilder);
+            RegisterTypesFromAssemblies(containerBuilder, assemblies);
             ConfigureIoc(containerBuilder);
 
-            var container = BuildContainer(containerBuilder, assemblies);
+            var container = BuildContainer(containerBuilder);
 
             Dependencies.Initialize(container);
         }
@@ -39,9 +40,13 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             builder.Singleton<BackStackManager, IBackStackManager>(IfRegistered.Keep);
         }
 
+        protected virtual void RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)
+        {
+        }
+
         protected abstract void ConfigureIoc(IContainerBuilder builder);
 
-        protected virtual IContainer BuildContainer(IContainerBuilder builder, IList<Assembly> assemblies)
+        protected virtual IContainer BuildContainer(IContainerBuilder builder)
         {
             return builder.Build();
         }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
@@ -1,7 +1,6 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -21,20 +20,19 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 
         protected virtual void FindAndRegisterViewModels(IContainerBuilder builder, IList<Assembly> assemblies)
         {
-            var viewModelToViewMapping = ViewModelFinder.GetViewModelToViewMapping(assemblies);
+            var viewModelViewMap = ViewModelFinder.GetViewModelToViewMapping(assemblies);
 
-            RegisterViewModels(builder, viewModelToViewMapping);
-            RegisterViewLocator(builder, viewModelToViewMapping);
+            RegisterViewModels(builder, viewModelViewMap);
+
+            builder.Singleton(_ => viewModelViewMap, IfRegistered.Keep);
         }
 
-        protected virtual void RegisterViewModels(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewMapping)
+        protected virtual void RegisterViewModels(IContainerBuilder builder, ViewModelToViewMap viewModelToViewMap)
         {
-            foreach (var (viewModelType, _) in viewModelToViewMapping)
+            foreach (var (viewModelType, _) in viewModelToViewMap)
             {
                 builder.PerDependency(viewModelType, IfRegistered.Keep);
             }
         }
-
-        protected abstract void RegisterViewLocator(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewMapping);
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
@@ -11,11 +11,11 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
     {
         protected abstract ViewModelFinderBase ViewModelFinder { get; }
 
-        protected override IContainer BuildContainer(IContainerBuilder builder, IList<Assembly> assemblies)
+        protected override void RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)
         {
-            FindAndRegisterViewModels(builder, assemblies);
+            base.RegisterTypesFromAssemblies(builder, assemblies);
 
-            return base.BuildContainer(builder, assemblies);
+            FindAndRegisterViewModels(builder, assemblies);
         }
 
         protected virtual void FindAndRegisterViewModels(IContainerBuilder builder, IList<Assembly> assemblies)

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
@@ -1,0 +1,40 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
+
+namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
+{
+    public abstract class BootstrapperWithViewModelLookup : BootstrapperBase
+    {
+        protected abstract ViewModelFinderBase ViewModelFinder { get; }
+
+        protected override IContainer BuildContainer(IContainerBuilder builder, IList<Assembly> assemblies)
+        {
+            FindAndRegisterViewModels(builder, assemblies);
+
+            return base.BuildContainer(builder, assemblies);
+        }
+
+        protected virtual void FindAndRegisterViewModels(IContainerBuilder builder, IList<Assembly> assemblies)
+        {
+            var viewModelToViewMapping = ViewModelFinder.GetViewModelToViewMapping(assemblies);
+
+            RegisterViewModels(builder, viewModelToViewMapping);
+            RegisterViewLocator(builder, viewModelToViewMapping);
+        }
+
+        protected virtual void RegisterViewModels(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewMapping)
+        {
+            foreach (var (viewModelType, _) in viewModelToViewMapping)
+            {
+                builder.PerDependency(viewModelType, IfRegistered.Keep);
+            }
+        }
+
+        protected abstract void RegisterViewLocator(IContainerBuilder builder, Dictionary<Type, Type> viewModelToViewMapping);
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
@@ -10,7 +10,7 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
 {
     internal class DryIocContainerAdapter : IContainer
     {
-        private IDryContainer _container = default!;
+        private IDryContainer _container;
 
         internal void Initialize(IDryContainer container)
         {

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
@@ -1,0 +1,32 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
+{
+    public abstract class ViewModelFinderBase
+    {
+        public virtual Dictionary<Type, Type> GetViewModelToViewMapping(IEnumerable<Assembly> assemblies)
+        {
+            var viewModelToViewDictionary = new Dictionary<Type, Type>();
+
+            foreach (var type in assemblies.SelectMany(SelectViewModelTypes))
+            {
+                var viewModelType = type.BaseType.GetGenericArguments()[0];
+
+                if (!viewModelType.IsAbstract)
+                {
+                    viewModelToViewDictionary.Add(viewModelType, type);
+                }
+            }
+
+            return viewModelToViewDictionary;
+        }
+
+        protected abstract IEnumerable<Type> SelectViewModelTypes(Assembly assembly);
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
@@ -10,23 +10,27 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
     public abstract class ViewModelFinderBase
     {
-        public virtual Dictionary<Type, Type> GetViewModelToViewMapping(IEnumerable<Assembly> assemblies)
+        public virtual ViewModelToViewMap GetViewModelToViewMapping(IEnumerable<Assembly> assemblies)
         {
-            var viewModelToViewDictionary = new Dictionary<Type, Type>();
+            var viewModelToViewMap = new ViewModelToViewMap();
 
-            foreach (var type in assemblies.SelectMany(SelectViewModelTypes))
+            foreach (var viewType in assemblies.SelectMany(SelectViewsTypes))
             {
-                var viewModelType = type.BaseType.GetGenericArguments()[0];
+                var viewModelType = viewType.BaseType.GetGenericArguments()[0];
 
                 if (!viewModelType.IsAbstract)
                 {
-                    viewModelToViewDictionary.Add(viewModelType, type);
+                    viewModelToViewMap.Add(viewModelType, viewType);
                 }
             }
 
-            return viewModelToViewDictionary;
+            return viewModelToViewMap;
         }
 
-        protected abstract IEnumerable<Type> SelectViewModelTypes(Assembly assembly);
+        protected abstract IEnumerable<Type> SelectViewsTypes(Assembly assembly);
+    }
+
+    public class ViewModelToViewMap : Dictionary<Type, Type>
+    {
     }
 }


### PR DESCRIPTION
### Description of Change ###

Export duplicated logic to find view models by platform-specific view types.

### API Changes ###

Added:
 - class `BootstrapperWithViewModelLookup` - incapsulate logic about registering ViewModels and re-configuring ViewLocator;
 - class `ViewModelFinderBase` - incapsulate logic about lookup ViewModel types from known assemblies;
 - class `DroidViewModelFinder` - Android-specific finder;
 - class `IosViewModelFinder` - iOS-specific finder;
 - class `ViewModelToViewMap` - type alias to ViewModel to View mapping; 
 - class `ViewControllerHelper` - iOS helper with methods for instantiate ViewControllers;
 - class `BootstrapperBase`
   - method `RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)` - for make additional search and registrations from cached assemblies.

Changed:
 - class `BootstrapperBase`
   - method signature `BuildContainer(IContainerBuilder builder, IList<Assembly> assemblies)` to `BuildContainer(IContainerBuilder builder)`

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
- [ ] Check startup performance degradation