### PR TITLE
Rework boostrappers

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Extensions/ListExtensionsTests/ListExtensionsTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Extensions/ListExtensionsTests/ListExtensionsTests.cs
@@ -1,0 +1,50 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using System.Linq;
+using Softeq.XToolkit.Common.Extensions;
+using Xunit;
+
+namespace Softeq.XToolkit.Common.Tests.Extensions.ListExtensionsTests
+{
+    public class ListExtensionsTests
+    {
+        [Fact]
+        public void AddItem_EmptyList_ReturnsListWithAddedItem()
+        {
+            var list = new List<int>();
+
+            var result = list.AddItem(1);
+
+            Assert.Same(list, result);
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void AddItem_NotEmptyList_ReturnsListWithAddedItem()
+        {
+            const int Expected = 4;
+            var list = new List<int> { 1, 2, 3 };
+
+            var result = list.AddItem(Expected);
+
+            Assert.Same(list, result);
+            Assert.Equal(Expected, result.Last());
+        }
+
+        [Fact]
+        public void AddItem_EmptyListFilledFluent_ReturnsListWithAddedItems()
+        {
+            var list = new List<int>();
+
+            var result = list
+                .AddItem(1)
+                .AddItem(2)
+                .AddItem(3);
+
+            Assert.Same(list, result);
+            Assert.Equal(3, result.Count);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common/Extensions/EnumerableExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/EnumerableExtensions.cs
@@ -71,37 +71,5 @@ namespace Softeq.XToolkit.Common.Extensions
                 }
             }
         }
-
-        /// <summary>
-        ///     Adds the elements of the specified collection to the end of the <see cref="T:System.Collections.Generic.List`1" />.
-        /// </summary>
-        /// <param name="items">Initial collection.</param>
-        /// <param name="range">The collection whose elements should be added to the end of the list.</param>
-        /// <typeparam name="T">The type of collection.</typeparam>
-        public static void AddRange<T>(this IList<T> items, IList<T> range)
-        {
-            for (var i = 0; i < range.Count; i++)
-            {
-                items.Add(range[i]);
-            }
-        }
-
-        /// <summary>
-        ///     Inserts the elements of a collection into the <see cref="T:System.Collections.Generic.List`1" />
-        ///     at the specified <paramref name="index"/>.
-        /// </summary>
-        /// <param name="items">Source collection.</param>
-        /// <param name="index">The zero-based index at which the new elements should be inserted.</param>
-        /// <param name="range">The collection whose elements should be added to the end of the list.</param>
-        /// <typeparam name="T">The type of collection.</typeparam>
-        public static void InsertRange<T>(this IList<T> items, int index, IList<T> range)
-        {
-            int i = index;
-            foreach (var item in range)
-            {
-                items.Insert(i, item);
-                i++;
-            }
-        }
     }
 }

--- a/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
@@ -42,5 +42,18 @@ namespace Softeq.XToolkit.Common.Extensions
                 i++;
             }
         }
+
+        /// <summary>
+        ///     Adds the element to the end of the collection in a fluent manner.
+        /// </summary>
+        /// <param name="list">Initial collection.</param>
+        /// <param name="item">Item to add.</param>
+        /// <typeparam name="T">Type of item.</typeparam>
+        /// <returns>Initial collection with an added item.</returns>
+        public static IList<T> AddItem<T>(this IList<T> list, T item)
+        {
+            list.Add(item);
+            return list;
+        }
     }
 }

--- a/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
@@ -1,0 +1,46 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+
+namespace Softeq.XToolkit.Common.Extensions
+{
+    /// <summary>
+    ///     Extension methods for <see cref="T:System.Collections.Generic.IList`1" />
+    /// </summary>
+    public static class ListExtensions
+    {
+        /// <summary>
+        ///     Adds the elements of the specified collection to the end
+        ///     of the <see cref="T:System.Collections.Generic.IList`1" />.
+        /// </summary>
+        /// <param name="items">Initial collection.</param>
+        /// <param name="range">The collection whose elements should be added to the end of the list.</param>
+        /// <typeparam name="T">The type of collection.</typeparam>
+        public static void AddRange<T>(this IList<T> items, IList<T> range)
+        {
+            for (var i = 0; i < range.Count; i++)
+            {
+                items.Add(range[i]);
+            }
+        }
+
+        /// <summary>
+        ///     Inserts the elements of a collection into the <see cref="T:System.Collections.Generic.List`1" />
+        ///     at the specified <paramref name="index"/>.
+        /// </summary>
+        /// <param name="items">Source collection.</param>
+        /// <param name="index">The zero-based index at which the new elements should be inserted.</param>
+        /// <param name="range">The collection whose elements should be added to the end of the list.</param>
+        /// <typeparam name="T">The type of collection.</typeparam>
+        public static void InsertRange<T>(this IList<T> items, int index, IList<T> range)
+        {
+            int i = index;
+            foreach (var item in range)
+            {
+                items.Insert(i, item);
+                i++;
+            }
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Android.Support.V4.App;
-using Android.Support.V7.App;
 using Plugin.CurrentActivity;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -33,6 +32,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             builder.PerDependency<DroidFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
         }
 
+        /// <inheritdoc />
         protected override IList<Assembly> SelectAssemblies()
         {
             return new List<Assembly>
@@ -40,17 +40,17 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
                 typeof(DroidBootstrapperBase).Assembly
             };
         }
+    }
 
-        protected override bool IsExtractToAssembliesCache(Type type)
+    public class DroidViewModelFinder : ViewModelFinderBase
+    {
+        public override bool IsViewType(Type type)
         {
             return typeof(FragmentActivity).IsAssignableFrom(type)
                 || typeof(DialogFragment).IsAssignableFrom(type)
                 || typeof(Fragment).IsAssignableFrom(type);
         }
-    }
 
-    public class DroidViewModelFinder : ViewModelFinderBase
-    {
         protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
         {
             return assembly.GetTypes().View(

--- a/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
@@ -15,7 +15,7 @@ using Softeq.XToolkit.WhiteLabel.Navigation;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid
 {
-    public class DroidBootstrapper : BootstrapperWithViewModelLookup
+    public abstract class DroidBootstrapperBase : BootstrapperWithViewModelLookup
     {
         protected override ViewModelFinderBase ViewModelFinder { get; } = new DroidViewModelFinder();
 
@@ -33,8 +33,19 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             builder.PerDependency<DroidFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
         }
 
-        protected override void ConfigureIoc(IContainerBuilder builder)
+        protected override IList<Assembly> SelectAssemblies()
         {
+            return new List<Assembly>
+            {
+                typeof(DroidBootstrapperBase).Assembly
+            };
+        }
+
+        protected override bool IsExtractToAssembliesCache(Type type)
+        {
+            return typeof(FragmentActivity).IsAssignableFrom(type)
+                || typeof(DialogFragment).IsAssignableFrom(type)
+                || typeof(Fragment).IsAssignableFrom(type);
         }
     }
 
@@ -42,7 +53,10 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
     {
         protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
         {
-            return assembly.GetTypes().View(typeof(AppCompatActivity), typeof(Fragment), typeof(DialogFragment));
+            return assembly.GetTypes().View(
+                typeof(FragmentActivity),
+                typeof(DialogFragment),
+                typeof(Fragment));
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/DroidBootstrapperBase.cs
@@ -1,7 +1,6 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Android.Support.V4.App;
@@ -9,14 +8,17 @@ using Plugin.CurrentActivity;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Droid.Navigation;
-using Softeq.XToolkit.WhiteLabel.Extensions;
 using Softeq.XToolkit.WhiteLabel.Navigation;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid
 {
     public abstract class DroidBootstrapperBase : BootstrapperWithViewModelLookup
     {
-        protected override ViewModelFinderBase ViewModelFinder { get; } = new DroidViewModelFinder();
+        protected override IViewModelFinder ViewModelFinder { get; } =
+            new DefaultViewModelFinder(
+                typeof(FragmentActivity),
+                typeof(DialogFragment),
+                typeof(Fragment));
 
         protected override void RegisterInternalServices(IContainerBuilder builder)
         {
@@ -39,24 +41,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             {
                 typeof(DroidBootstrapperBase).Assembly
             };
-        }
-    }
-
-    public class DroidViewModelFinder : ViewModelFinderBase
-    {
-        public override bool IsViewType(Type type)
-        {
-            return typeof(FragmentActivity).IsAssignableFrom(type)
-                || typeof(DialogFragment).IsAssignableFrom(type)
-                || typeof(Fragment).IsAssignableFrom(type);
-        }
-
-        protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
-        {
-            return assembly.GetTypes().View(
-                typeof(FragmentActivity),
-                typeof(DialogFragment),
-                typeof(Fragment));
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Droid/MainApplicationBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/MainApplicationBase.cs
@@ -2,13 +2,9 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 using Android.OS;
 using Android.Runtime;
-using Android.Support.V4.App;
 using Plugin.CurrentActivity;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.Droid;
@@ -31,20 +27,12 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
             base.OnCreate();
 
-            InitBootstrapper();
+            InitializeExternalDependencies();
 
-            CrossCurrentActivity.Current.Init(this);
-
-            // init Bindings
-            BindingExtensions.Initialize(new DroidBindingFactory());
-
-            // init UI thread helper
-            PlatformProvider.Current = new DroidPlatformProvider();
+            InitializeWhiteLabelRuntime();
         }
 
         protected abstract IBootstrapper Bootstrapper { get; }
-
-        protected abstract IList<Assembly> SelectAssemblies();
 
         [Conditional("DEBUG")]
         protected void InitStrictMode()
@@ -69,20 +57,21 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
                     .Build());
         }
 
-        private void InitBootstrapper()
+        protected virtual void InitializeExternalDependencies()
         {
-            // init assembly sources
-            AssemblySourceCache.Install();
-            AssemblySourceCache.ExtractTypes = assembly =>
-                assembly.GetExportedTypes()
-                    .Where(t => typeof(FragmentActivity).IsAssignableFrom(t)
-                        || typeof(DialogFragment).IsAssignableFrom(t)
-                        || typeof(Fragment).IsAssignableFrom(t));
-            var assemblies = SelectAssemblies();
-            AssemblySource.Instance.AddRange(assemblies);
+            CrossCurrentActivity.Current.Init(this);
+        }
 
-            // init dependencies
-            Bootstrapper.Init(assemblies);
+        protected virtual void InitializeWhiteLabelRuntime()
+        {
+            // Init Bindings
+            BindingExtensions.Initialize(new DroidBindingFactory());
+
+            // Init platform helpers
+            PlatformProvider.Current = new DroidPlatformProvider();
+
+            // Init dependencies
+            Bootstrapper.Initialize();
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
@@ -108,7 +108,7 @@
     <Compile Include="Controls\ColoredClickableSpan.cs" />
     <Compile Include="Controls\NonConsumingTouchesToolbar.cs" />
     <Compile Include="Controls\SwipeControlViewPager.cs" />
-    <Compile Include="DroidBootstrapper.cs" />
+    <Compile Include="DroidBootstrapperBase.cs" />
     <Compile Include="ImagePicker\DroidImagePickerService.cs" />
     <Compile Include="ImagePicker\ImagePickerActivity.cs" />
     <Compile Include="ImagePicker\DroidImagePickerResult.cs" />

--- a/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
@@ -1,9 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Foundation;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.iOS;
@@ -21,28 +18,21 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
-            //init factory for bindings
-            BindingExtensions.Initialize(new AppleBindingFactory());
-
-            //init assembly sources for Activator.cs
-            AssemblySourceCache.Install();
-            AssemblySourceCache.ExtractTypes = assembly =>
-                assembly.GetExportedTypes()
-                    .Where(t => typeof(UIViewController).IsAssignableFrom(t));
-
-            var assemblies = SelectAssemblies();
-
-            AssemblySource.Instance.AddRange(assemblies);
-
-            //init dependencies
-            Bootstrapper.Init(assemblies);
-
-            //init ui thread helper
-            PlatformProvider.Current = new IosPlatformProvider();
+            InitializeWhiteLabelRuntime();
 
             return true;
         }
 
-        protected abstract IList<Assembly> SelectAssemblies();
+        protected virtual void InitializeWhiteLabelRuntime()
+        {
+            // Init Bindings
+            BindingExtensions.Initialize(new AppleBindingFactory());
+
+            // Init platform helpers
+            PlatformProvider.Current = new IosPlatformProvider();
+
+            // Init dependencies
+            Bootstrapper.Initialize();
+        }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
@@ -1,12 +1,10 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
-using Softeq.XToolkit.WhiteLabel.Extensions;
 using Softeq.XToolkit.WhiteLabel.iOS.Interfaces;
 using Softeq.XToolkit.WhiteLabel.iOS.Navigation;
 using Softeq.XToolkit.WhiteLabel.iOS.Services;
@@ -17,7 +15,8 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 {
     public abstract class IosBootstrapperBase : BootstrapperWithViewModelLookup
     {
-        protected override ViewModelFinderBase ViewModelFinder { get; } = new IosViewModelFinder();
+        protected override IViewModelFinder ViewModelFinder { get; } =
+            new DefaultViewModelFinder(typeof(UIViewController));
 
         protected override void RegisterInternalServices(IContainerBuilder builder)
         {
@@ -37,19 +36,6 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             {
                 typeof(IosBootstrapperBase).Assembly
             };
-        }
-    }
-
-    public class IosViewModelFinder : ViewModelFinderBase
-    {
-        public override bool IsViewType(Type type)
-        {
-            return typeof(UIViewController).IsAssignableFrom(type);
-        }
-
-        protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
-        {
-            return assembly.GetTypes().View(typeof(UIViewController));
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
@@ -15,7 +15,7 @@ using UIKit;
 
 namespace Softeq.XToolkit.WhiteLabel.iOS
 {
-    public class IosBootstrapper : BootstrapperWithViewModelLookup
+    public abstract class IosBootstrapperBase : BootstrapperWithViewModelLookup
     {
         protected override ViewModelFinderBase ViewModelFinder { get; } = new IosViewModelFinder();
 
@@ -30,8 +30,17 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             builder.PerDependency<StoryboardFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
         }
 
-        protected override void ConfigureIoc(IContainerBuilder builder)
+        protected override IList<Assembly> SelectAssemblies()
         {
+            return new List<Assembly>
+            {
+                typeof(IosBootstrapperBase).Assembly
+            };
+        }
+
+        protected override bool IsExtractToAssembliesCache(Type type)
+        {
+            return typeof(UIViewController).IsAssignableFrom(type);
         }
     }
 

--- a/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/IosBootstraperBase.cs
@@ -30,6 +30,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             builder.PerDependency<StoryboardFrameNavigationService, IFrameNavigationService>(IfRegistered.Keep);
         }
 
+        /// <inheritdoc />
         protected override IList<Assembly> SelectAssemblies()
         {
             return new List<Assembly>
@@ -37,15 +38,15 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
                 typeof(IosBootstrapperBase).Assembly
             };
         }
-
-        protected override bool IsExtractToAssembliesCache(Type type)
-        {
-            return typeof(UIViewController).IsAssignableFrom(type);
-        }
     }
 
     public class IosViewModelFinder : ViewModelFinderBase
     {
+        public override bool IsViewType(Type type)
+        {
+            return typeof(UIViewController).IsAssignableFrom(type);
+        }
+
         protected override IEnumerable<Type> SelectViewsTypes(Assembly assembly)
         {
             return assembly.GetTypes().View(typeof(UIViewController));

--- a/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
@@ -93,7 +93,7 @@
     <Compile Include="Services\KeyboardService.cs" />
     <Compile Include="ViewControllers\ToolbarViewControllerBase.cs" />
     <Compile Include="Controls\BindableTabBarItem.cs" />
-    <Compile Include="IosBootstraper.cs" />
+    <Compile Include="IosBootstraperBase.cs" />
     <Compile Include="Services\ViewControllerProvider.cs" />
     <Compile Include="ImagePicker\IosImagePickerService.cs" />
     <Compile Include="ImagePicker\IosImagePickerResult.cs" />

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -27,12 +27,9 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 
             var containerBuilder = CreateContainerBuilder();
 
+            // framework level
             RegisterInternalServices(containerBuilder);
-
-            // assemblies
-            var assemblies = SelectAssemblies();
-            InitializeAssemblySource(assemblies);
-            RegisterTypesFromAssemblies(containerBuilder, assemblies);
+            RegisterFromAssemblies(containerBuilder);
 
             // application level
             ConfigureIoc(containerBuilder);
@@ -57,6 +54,13 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             builder.Singleton<BackStackManager, IBackStackManager>(IfRegistered.Keep);
         }
 
+        protected virtual void RegisterFromAssemblies(IContainerBuilder builder)
+        {
+            var assemblies = SelectAssemblies();
+            InitializeAssemblySource(assemblies);
+            RegisterTypesFromAssemblies(builder, assemblies);
+        }
+
         /// <summary>
         ///     Override to tell the framework where to find assemblies to inspect for views, etc.
         /// </summary>
@@ -77,9 +81,9 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         }
 
         /// <summary>
-        ///     The predicate of extracting type for storing in the cache
+        ///     The predicate of extracting type for storing in the cache.
         /// </summary>
-        /// <param name="type"></param>
+        /// <param name="type"><see cref="Type"/> of the object.</param>
         /// <returns></returns>
         protected abstract bool IsExtractToAssembliesCache(Type type);
 

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -1,7 +1,9 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Softeq.XToolkit.Common.Logger;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -12,12 +14,27 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
     public abstract class BootstrapperBase : IBootstrapper
     {
-        public void Init(IList<Assembly> assemblies)
+        private bool _isInitialized;
+
+        public void Initialize()
         {
+            if (_isInitialized)
+            {
+                return;
+            }
+
+            _isInitialized = true;
+
             var containerBuilder = CreateContainerBuilder();
 
             RegisterInternalServices(containerBuilder);
+
+            // assemblies
+            var assemblies = SelectAssemblies();
+            InitializeAssemblySource(assemblies);
             RegisterTypesFromAssemblies(containerBuilder, assemblies);
+
+            // application level
             ConfigureIoc(containerBuilder);
 
             var container = BuildContainer(containerBuilder);
@@ -40,10 +57,40 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             builder.Singleton<BackStackManager, IBackStackManager>(IfRegistered.Keep);
         }
 
+        /// <summary>
+        ///     Override to tell the framework where to find assemblies to inspect for views, etc.
+        /// </summary>
+        /// <returns>A list of assemblies to inspect.</returns>
+        protected abstract IList<Assembly> SelectAssemblies();
+
+        protected virtual void InitializeAssemblySource(IEnumerable<Assembly> assemblies)
+        {
+            AssemblySourceCache.Install();
+
+            AssemblySourceCache.ExtractTypes = assembly =>
+            {
+                var types = assembly.GetExportedTypes().Where(IsExtractToAssembliesCache);
+                return types;
+            };
+
+            AssemblySource.Instance.ReplaceRange(assemblies);
+        }
+
+        /// <summary>
+        ///     The predicate of extracting type for storing in the cache
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        protected abstract bool IsExtractToAssembliesCache(Type type);
+
         protected virtual void RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)
         {
         }
 
+        /// <summary>
+        ///     Override to configure the framework and setup your IoC container
+        /// </summary>
+        /// <param name="builder"></param>
         protected abstract void ConfigureIoc(IContainerBuilder builder);
 
         protected virtual IContainer BuildContainer(IContainerBuilder builder)

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
@@ -10,7 +10,7 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
     public abstract class BootstrapperWithViewModelLookup : BootstrapperBase
     {
-        protected abstract ViewModelFinderBase ViewModelFinder { get; }
+        protected abstract IViewModelFinder ViewModelFinder { get; }
 
         protected override void RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)
         {

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperWithViewModelLookup.cs
@@ -1,6 +1,7 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -33,6 +34,12 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             {
                 builder.PerDependency(viewModelType, IfRegistered.Keep);
             }
+        }
+
+        /// <inheritdoc />
+        protected override bool IsExtractToAssembliesCache(Type type)
+        {
+            return ViewModelFinder.IsViewType(type);
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/DefaultViewModelFinder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/DefaultViewModelFinder.cs
@@ -5,11 +5,26 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Softeq.XToolkit.WhiteLabel.Extensions;
 
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
-    public abstract class ViewModelFinderBase
+    public interface IViewModelFinder
     {
+        ViewModelToViewMap GetViewModelToViewMapping(IEnumerable<Assembly> assemblies);
+
+        bool IsViewType(Type type);
+    }
+
+    public class DefaultViewModelFinder : IViewModelFinder
+    {
+        private readonly Type[] _viewsTypes;
+
+        public DefaultViewModelFinder(params Type[] viewsTypes)
+        {
+            _viewsTypes = viewsTypes;
+        }
+
         public virtual ViewModelToViewMap GetViewModelToViewMapping(IEnumerable<Assembly> assemblies)
         {
             var viewModelToViewMap = new ViewModelToViewMap();
@@ -27,9 +42,15 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             return viewModelToViewMap;
         }
 
-        public abstract bool IsViewType(Type type);
+        public virtual bool IsViewType(Type type)
+        {
+            return _viewsTypes.Any(t => t.IsAssignableFrom(type));
+        }
 
-        protected abstract IEnumerable<Type> SelectViewsTypes(Assembly assembly);
+        protected virtual IEnumerable<Type> SelectViewsTypes(Assembly assembly)
+        {
+            return assembly.GetTypes().View(_viewsTypes);
+        }
     }
 
     public class ViewModelToViewMap : Dictionary<Type, Type>

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/IBootstrapper.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/IBootstrapper.cs
@@ -1,13 +1,10 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Collections.Generic;
-using System.Reflection;
-
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
     public interface IBootstrapper
     {
-        void Init(IList<Assembly> assemblies);
+        void Initialize();
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/ViewModelFinderBase.cs
@@ -27,6 +27,8 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             return viewModelToViewMap;
         }
 
+        public abstract bool IsViewType(Type type);
+
         protected abstract IEnumerable<Type> SelectViewsTypes(Assembly assembly);
     }
 

--- a/Softeq.XToolkit.WhiteLabel/Dependencies.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dependencies.cs
@@ -22,7 +22,7 @@ namespace Softeq.XToolkit.WhiteLabel
         {
             if (IsInitialized)
             {
-                throw new ArgumentException($"{nameof(Dependencies)} already initialized");
+                throw new InvalidOperationException($"{nameof(Dependencies)} already initialized");
             }
 
             Container = iocContainer;

--- a/Softeq.XToolkit.WhiteLabel/Extensions/ReflectionExtensions.cs
+++ b/Softeq.XToolkit.WhiteLabel/Extensions/ReflectionExtensions.cs
@@ -10,6 +10,7 @@ namespace Softeq.XToolkit.WhiteLabel.Extensions
 {
     public static class ReflectionExtensions
     {
+        // TODO YP: add tests and refactor
         public static IEnumerable<Type> View(this IEnumerable<Type> types, params Type[] viewEndWith)
         {
             return types.Where(type => viewEndWith.Any(type.IsSubclassOf) &&

--- a/Softeq.XToolkit.WhiteLabel/Mvvm/ViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Mvvm/ViewModelBase.cs
@@ -27,7 +27,6 @@ namespace Softeq.XToolkit.WhiteLabel.Mvvm
 
         public bool IsInitialized { get; private set; }
 
-        // TODO YP: Review using lifetime methods here
         public virtual void OnInitialize()
         {
             IsInitialized = true;

--- a/Softeq.XToolkit.Whitelabel.Tests/Bootstrapper/DefaultViewModelFinderTests/DefaultViewModelFinderTests.cs
+++ b/Softeq.XToolkit.Whitelabel.Tests/Bootstrapper/DefaultViewModelFinderTests/DefaultViewModelFinderTests.cs
@@ -1,0 +1,104 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Xunit;
+
+namespace Softeq.XToolkit.Whitelabel.Tests.Bootstrapper.DefaultViewModelFinderTests
+{
+    public class DefaultViewModelFinderTests
+    {
+        [Fact]
+        public void NewObject_EmptyCtor_Creates()
+        {
+            var obj = new DefaultViewModelFinder();
+
+            Assert.IsAssignableFrom<IViewModelFinder>(obj);
+        }
+
+        [Fact]
+        public void NewObject_NotEmptyCtor_Creates()
+        {
+            var obj = new DefaultViewModelFinder(typeof(Assert));
+
+            Assert.IsAssignableFrom<IViewModelFinder>(obj);
+        }
+
+        [Theory]
+        [InlineData(typeof(string), false)]
+        [InlineData(typeof(CustomViewControllerStub), true)]
+        [InlineData(typeof(CustomActivityStub), true)]
+        [InlineData(typeof(CustomViewStub), true)]
+        [InlineData(typeof(VmActivityStub), true)]
+        [InlineData(typeof(VmViewControllerStub), true)]
+        public void IsViewType_CorrectType_ReturnsExpectedResult(Type type, bool expectedResult)
+        {
+            var obj = new DefaultViewModelFinder(
+                typeof(ViewControllerStub),
+                typeof(ActivityStub),
+                typeof(IDroidViewStub));
+
+            var result = obj.IsViewType(type);
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void IsViewType_CheckNullTypeForEmptyViewTypes_ReturnsFalse()
+        {
+            var obj = new DefaultViewModelFinder();
+
+            var result = obj.IsViewType(null);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsViewType_CheckNullType_ReturnsFalse()
+        {
+            var obj = new DefaultViewModelFinder(typeof(Assert));
+
+            var result = obj.IsViewType(null);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void GetViewModelToViewMapping_NullAssembliesList_ThrowsArgumentNullException()
+        {
+            var obj = new DefaultViewModelFinder();
+
+            Assert.Throws<ArgumentNullException>(() => obj.GetViewModelToViewMapping(null));
+        }
+
+        [Fact]
+        public void GetViewModelToViewMapping_EmptyAssembliesList_ReturnsEmptyMap()
+        {
+            var obj = new DefaultViewModelFinder();
+
+            var result = obj.GetViewModelToViewMapping(Enumerable.Empty<Assembly>());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetViewModelToViewMapping_AssembliesList_ReturnsCorrectMap()
+        {
+            var obj = new DefaultViewModelFinder(typeof(ActivityStub), typeof(ViewControllerStub));
+            var assemblies = new[]
+            {
+                typeof(DefaultViewModelFinder).Assembly,
+                typeof(DefaultViewModelFinderTests).Assembly
+            };
+
+            var result = obj.GetViewModelToViewMapping(assemblies);
+
+            Assert.NotEmpty(result);
+            Assert.Equal(typeof(VmActivityStub), result[typeof(ViewModelStub1)]);
+            Assert.Equal(typeof(VmViewControllerStub), result[typeof(ViewModelStub2)]);
+        }
+    }
+}

--- a/Softeq.XToolkit.Whitelabel.Tests/Bootstrapper/DefaultViewModelFinderTests/TypeStubs.cs
+++ b/Softeq.XToolkit.Whitelabel.Tests/Bootstrapper/DefaultViewModelFinderTests/TypeStubs.cs
@@ -1,0 +1,30 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Softeq.XToolkit.WhiteLabel.Mvvm;
+
+namespace Softeq.XToolkit.Whitelabel.Tests.Bootstrapper.DefaultViewModelFinderTests
+{
+    interface IDroidViewStub {}
+
+    // simulate ios types
+    class ViewControllerStub {}
+    class ViewControllerStub<T> : ViewControllerStub where T : ViewModelBase {}
+
+    // simulate android types
+    class ActivityStub : IDroidViewStub  {}
+    class ActivityStub<T> : ActivityStub where T : ViewModelBase {}
+
+    // simulate VM types
+    class ViewModelStub1 : ViewModelBase {}
+    class ViewModelStub2 : ViewModelBase {}
+
+    // simulate simple custom views types
+    class CustomViewControllerStub : ViewControllerStub {}
+    class CustomActivityStub : ActivityStub {}
+    class CustomViewStub :  IDroidViewStub {}
+
+    // simulate simple custom views types with VM
+    class VmActivityStub : ActivityStub<ViewModelStub1> {}
+    class VmViewControllerStub : ViewControllerStub<ViewModelStub2> {}
+}

--- a/samples/Playground/Playground.Droid/CustomDroidBootstrapper.cs
+++ b/samples/Playground/Playground.Droid/CustomDroidBootstrapper.cs
@@ -4,6 +4,7 @@
 using Softeq.XToolkit.Connectivity;
 using System.Collections.Generic;
 using System.Reflection;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.Permissions;
 using Softeq.XToolkit.Permissions.Droid;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -20,9 +21,8 @@ namespace Playground.Droid
     {
         protected override IList<Assembly> SelectAssemblies()
         {
-            var assemblies = base.SelectAssemblies(); // Softeq.XToolkit.WhiteLabel.Droid
-            assemblies.Add(GetType().Assembly);       // Playground.Droid
-            return assemblies;
+            return base.SelectAssemblies()     // Softeq.XToolkit.WhiteLabel.Droid
+                .AddItem(GetType().Assembly);  // Playground.Droid
         }
 
         protected override void ConfigureIoc(IContainerBuilder builder)

--- a/samples/Playground/Playground.Droid/CustomDroidBootstrapper.cs
+++ b/samples/Playground/Playground.Droid/CustomDroidBootstrapper.cs
@@ -2,6 +2,8 @@
 // http://www.softeq.com
 
 using Softeq.XToolkit.Connectivity;
+using System.Collections.Generic;
+using System.Reflection;
 using Softeq.XToolkit.Permissions;
 using Softeq.XToolkit.Permissions.Droid;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
@@ -14,8 +16,15 @@ using Softeq.XToolkit.WhiteLabel.Navigation;
 
 namespace Playground.Droid
 {
-    internal class CustomDroidBootstrapper : DroidBootstrapper
+    internal class CustomDroidBootstrapper : DroidBootstrapperBase
     {
+        protected override IList<Assembly> SelectAssemblies()
+        {
+            var assemblies = base.SelectAssemblies(); // Softeq.XToolkit.WhiteLabel.Droid
+            assemblies.Add(GetType().Assembly);       // Playground.Droid
+            return assemblies;
+        }
+
         protected override void ConfigureIoc(IContainerBuilder builder)
         {
             // core

--- a/samples/Playground/Playground.Droid/MainApplication.cs
+++ b/samples/Playground/Playground.Droid/MainApplication.cs
@@ -2,8 +2,6 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Android.App;
 using Android.Runtime;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
@@ -24,11 +22,5 @@ namespace Playground.Droid
         }
 
         protected override IBootstrapper Bootstrapper => new CustomDroidBootstrapper();
-
-        protected override IList<Assembly> SelectAssemblies() => new List<Assembly>
-        {
-            GetType().Assembly,                  // Playground.Droid
-            typeof(MainApplicationBase).Assembly // Softeq.XToolkit.WhiteLabel.Droid
-        };
     }
 }

--- a/samples/Playground/Playground.iOS/AppDelegate.cs
+++ b/samples/Playground/Playground.iOS/AppDelegate.cs
@@ -1,8 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Collections.Generic;
-using System.Reflection;
 using Foundation;
 using Playground.ViewModels;
 using Softeq.XToolkit.WhiteLabel;
@@ -35,12 +33,6 @@ namespace Playground.iOS
         }
 
         protected override IBootstrapper Bootstrapper => new CustomIosBootstrapper();
-
-        protected override IList<Assembly> SelectAssemblies() => new List<Assembly>
-        {
-            GetType().Assembly,              // Playground.iOS
-            typeof(AppDelegateBase).Assembly // Softeq.XToolkit.WhiteLabel.iOS
-        };
 
         private void InitNavigation()
         {

--- a/samples/Playground/Playground.iOS/CustomIosBootstraper.cs
+++ b/samples/Playground/Playground.iOS/CustomIosBootstraper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.Connectivity;
 using Softeq.XToolkit.Connectivity.iOS;
 using Softeq.XToolkit.Permissions;
@@ -20,9 +21,8 @@ namespace Playground.iOS
     {
         protected override IList<Assembly> SelectAssemblies()
         {
-            var assemblies = base.SelectAssemblies(); // Softeq.XToolkit.WhiteLabel.iOS
-            assemblies.Add(GetType().Assembly);       // Playground.iOS
-            return assemblies;
+            return base.SelectAssemblies()     // Softeq.XToolkit.WhiteLabel.iOS
+                .AddItem(GetType().Assembly);  // Playground.iOS
         }
 
         protected override void ConfigureIoc(IContainerBuilder builder)

--- a/samples/Playground/Playground.iOS/CustomIosBootstraper.cs
+++ b/samples/Playground/Playground.iOS/CustomIosBootstraper.cs
@@ -1,6 +1,8 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System.Collections.Generic;
+using System.Reflection;
 using Softeq.XToolkit.Connectivity;
 using Softeq.XToolkit.Connectivity.iOS;
 using Softeq.XToolkit.Permissions;
@@ -14,8 +16,15 @@ using Softeq.XToolkit.WhiteLabel.Navigation;
 
 namespace Playground.iOS
 {
-    internal class CustomIosBootstrapper : IosBootstrapper
+    internal class CustomIosBootstrapper : IosBootstrapperBase
     {
+        protected override IList<Assembly> SelectAssemblies()
+        {
+            var assemblies = base.SelectAssemblies(); // Softeq.XToolkit.WhiteLabel.iOS
+            assemblies.Add(GetType().Assembly);       // Playground.iOS
+            return assemblies;
+        }
+
         protected override void ConfigureIoc(IContainerBuilder builder)
         {
             // core
@@ -29,7 +38,7 @@ namespace Playground.iOS
 
             // image picker
             builder.Singleton<IosImagePickerService, IImagePickerService>();
-            
+
             // connectivity
             builder.Singleton<IosConnectivityService, IConnectivityService>();
         }


### PR DESCRIPTION
### Description of Change ###

The new definition of `Boostraper`:
- Describing WhiteLabel setup
- Contains declarations for setup:
  - Assemblies
  - External dependencies
  - Internal dependencies
  - Internal auto-registrations
  - WhiteLabel runtime

Features:
- Clean `AppDelegateBase`, `MainApplicationBase`;
- Remove duplicated logic;
- Simple integration and setup for the new projects;
- Ready for Xamarin.Forms integration;
- Auto-register view models can be simply disabled;


### API Changes ###

Changed:

- `class DroidBootstrapper` -> `abstract class DroidBootstrapperBase`

- `class IosBootstrapper` -> `abstract class IosBootstrapperBase` 

- `IBootstrapper.Init(IList<Assembly>)` -> `IBootstrapper.Initialize()`

- `MainApplicationBase.SelectAssemblies` -> `DroidBootstrapperBase.SelectAssemblies`

- `AppDelegateBase.SelectAssemblies` -> `IosBootstrapperBase.SelectAssemblies`

- `IosViewModelFinder`, `DroidViewModelFinder` -> `DefaultViewModelFinder`, `IViewModelFinder` - describes of finding views, related ViewModels on target assemblies


Added:

- `ListExtensions.AddItem`

### Platforms Affected ### 

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)