### PR TITLE
Share common build properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Softeq.XToolkit.Bindings.Droid/Softeq.XToolkit.Bindings.Droid.csproj
+++ b/Softeq.XToolkit.Bindings.Droid/Softeq.XToolkit.Bindings.Droid.csproj
@@ -15,7 +15,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Bindings.iOS/Softeq.XToolkit.Bindings.iOS.csproj
+++ b/Softeq.XToolkit.Bindings.iOS/Softeq.XToolkit.Bindings.iOS.csproj
@@ -9,9 +9,8 @@
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Softeq.XToolkit.Bindings.iOS</RootNamespace>
-    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Softeq.XToolkit.Bindings.iOS</AssemblyName>
-    <LangVersion>8.0</LangVersion>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Bindings/Softeq.XToolkit.Bindings.csproj
+++ b/Softeq.XToolkit.Bindings/Softeq.XToolkit.Bindings.csproj
@@ -2,14 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Handlers\" />
-  </ItemGroup>
 </Project>

--- a/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
+++ b/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
@@ -15,8 +15,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Common.Tests/Softeq.XToolkit.Common.Tests.csproj
+++ b/Softeq.XToolkit.Common.Tests/Softeq.XToolkit.Common.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
+++ b/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
@@ -11,8 +11,6 @@
     <RootNamespace>Softeq.XToolkit.Common.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Softeq.XToolkit.Common.iOS</AssemblyName>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Common/Softeq.XToolkit.Common.csproj
+++ b/Softeq.XToolkit.Common/Softeq.XToolkit.Common.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<LangVersion>8.0</LangVersion>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
 </Project>

--- a/Softeq.XToolkit.Connectivity.iOS/Softeq.XToolkit.Connectivity.iOS.csproj
+++ b/Softeq.XToolkit.Connectivity.iOS/Softeq.XToolkit.Connectivity.iOS.csproj
@@ -13,8 +13,6 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Softeq.XToolkit.Connectivity.iOS</AssemblyName>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Connectivity/Softeq.XToolkit.Connectivity.csproj
+++ b/Softeq.XToolkit.Connectivity/Softeq.XToolkit.Connectivity.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Xam.Plugin.Connectivity" Version="3.2.0" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Softeq.XToolkit.Permissions.Droid/Softeq.XToolkit.Permissions.Droid.csproj
+++ b/Softeq.XToolkit.Permissions.Droid/Softeq.XToolkit.Permissions.Droid.csproj
@@ -13,8 +13,6 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Permissions.iOS/Softeq.XToolkit.Permissions.iOS.csproj
+++ b/Softeq.XToolkit.Permissions.iOS/Softeq.XToolkit.Permissions.iOS.csproj
@@ -9,8 +9,6 @@
         <RootNamespace>Softeq.XToolkit.Permissions.iOS</RootNamespace>
         <AssemblyName>Softeq.XToolkit.Permissions.iOS</AssemblyName>
         <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-        <LangVersion>8.0</LangVersion>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.Permissions/Softeq.XToolkit.Permissions.csproj
+++ b/Softeq.XToolkit.Permissions/Softeq.XToolkit.Permissions.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
   </ItemGroup>
+
 </Project>

--- a/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
+++ b/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
@@ -16,8 +16,6 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.PushNotifications.iOS/Softeq.XToolkit.PushNotifications.iOS.csproj
+++ b/Softeq.XToolkit.PushNotifications.iOS/Softeq.XToolkit.PushNotifications.iOS.csproj
@@ -12,8 +12,6 @@
     <RootNamespace>Softeq.XToolkit.PushNotifications.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Softeq.XToolkit.PushNotifications.iOS</AssemblyName>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.PushNotifications/Softeq.XToolkit.PushNotifications.csproj
+++ b/Softeq.XToolkit.PushNotifications/Softeq.XToolkit.PushNotifications.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Softeq.XToolkit.Remote.Tests/Softeq.XToolkit.Remote.Tests.csproj
+++ b/Softeq.XToolkit.Remote.Tests/Softeq.XToolkit.Remote.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>8</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Softeq.XToolkit.Remote/Softeq.XToolkit.Remote.csproj
+++ b/Softeq.XToolkit.Remote/Softeq.XToolkit.Remote.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
@@ -15,8 +15,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Softeq.XToolkit.WhiteLabel.iOS.csproj
@@ -11,8 +11,6 @@
     <RootNamespace>Softeq.XToolkit.WhiteLabel.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Softeq.XToolkit.WhiteLabel.iOS</AssemblyName>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Softeq.XToolkit.WhiteLabel/Softeq.XToolkit.WhiteLabel.csproj
+++ b/Softeq.XToolkit.WhiteLabel/Softeq.XToolkit.WhiteLabel.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Softeq.XToolkit.Whitelabel.Tests/Softeq.XToolkit.Whitelabel.Tests.csproj
+++ b/Softeq.XToolkit.Whitelabel.Tests/Softeq.XToolkit.Whitelabel.Tests.csproj
@@ -1,20 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Description of Change ###

Added `Directory.Build.props` to share common build properties (LangVersion, Nullable) between all XToolkit projects.

### Issues Resolved ### 

- fixes #246

### API Changes ###
 
 None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)