### PR TITLE
Make list extensions more versatile

### DIFF
--- a/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/ListExtensions.cs
@@ -17,11 +17,11 @@ namespace Softeq.XToolkit.Common.Extensions
         /// <param name="items">Initial collection.</param>
         /// <param name="range">The collection whose elements should be added to the end of the list.</param>
         /// <typeparam name="T">The type of collection.</typeparam>
-        public static void AddRange<T>(this IList<T> items, IList<T> range)
+        public static void AddRange<T>(this IList<T> items, IEnumerable<T> range)
         {
-            for (var i = 0; i < range.Count; i++)
+            foreach (var item in range)
             {
-                items.Add(range[i]);
+                items.Add(item);
             }
         }
 
@@ -33,7 +33,7 @@ namespace Softeq.XToolkit.Common.Extensions
         /// <param name="index">The zero-based index at which the new elements should be inserted.</param>
         /// <param name="range">The collection whose elements should be added to the end of the list.</param>
         /// <typeparam name="T">The type of collection.</typeparam>
-        public static void InsertRange<T>(this IList<T> items, int index, IList<T> range)
+        public static void InsertRange<T>(this IList<T> items, int index, IEnumerable<T> range)
         {
             int i = index;
             foreach (var item in range)


### PR DESCRIPTION
# Description

Makeing List<T> extensions more versatile by accepting IEnumerable<T> parameters

### API Changes

Changed:
 - void AddRange<T>(this IList<T> items, IList<T> range) => void AddRange<T>(this IList<T> items, IEnumerable<T> range)
 - void InsertRange<T>(this IList<T> items, int index, IList<T> range) => void InsertRange<T>(this IList<T> items, int index, IEnumerable<T> range)

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
