### PR TITLE
Implement versatile Hash helper based on generic values, instead of objects

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Helpers/HashHelperTests/HashHelperDataProvider.cs
+++ b/Softeq.XToolkit.Common.Tests/Helpers/HashHelperTests/HashHelperDataProvider.cs
@@ -230,5 +230,37 @@ namespace Softeq.XToolkit.Common.Tests.Helpers.HashHelperTests
                 }; // mixed
             }
         }
+
+        public static IEnumerable<object[]> HashValueTypeArgumentsData
+        {
+            get { yield return new object[] { 1, 1.0, 1f, DateTime.MinValue, '1', true }; }
+        }
+
+        public static IEnumerable<object[]> HashNullableValueTypeArgumentsData
+        {
+            get
+            {
+                yield return new object[] { null, 1.0, 1f, DateTime.MinValue, '1', true };
+                yield return new object[] { 1, null, 1f, DateTime.MinValue, '1', true };
+                yield return new object[] { 1, 1.0, null, DateTime.MinValue, '1', true };
+                yield return new object[] { 1, 1.0, 1f, null, '1', true };
+                yield return new object[] { 1, 1.0, 1f, DateTime.MinValue, null, true };
+                yield return new object[] { 1, 1.0, 1f, DateTime.MinValue, '1', null };
+                yield return new object[] { null, null, null, null, null, null };
+            }
+        }
+
+        public static IEnumerable<object[]> HashReferenceTypeArgumentsData
+        {
+            get
+            {
+                yield return new object[] {"42", new object(), new object[]{}, new TestHashObject(0)};
+                yield return new object[] {null, new object(), new object[]{}, new TestHashObject(0)};
+                yield return new object[] {"42", null, new object[]{}, new TestHashObject(0)};
+                yield return new object[] {"42", new object(), null, new TestHashObject(0)};
+                yield return new object[] {"42", new object(), new object[]{}, null};
+                yield return new object[] {null, null, null, null};
+            }
+        }
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Helpers/HashHelperTests/TestHashObject.cs
+++ b/Softeq.XToolkit.Common.Tests/Helpers/HashHelperTests/TestHashObject.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace Softeq.XToolkit.Common.Tests.Helpers.HashHelperTests
 {
-    internal class TestHashObject : IXunitSerializable
+    public class TestHashObject : IXunitSerializable
     {
         private static readonly string _key = $"{nameof(TestHashObject)}_{nameof(_value)}";
         private int _value;

--- a/Softeq.XToolkit.Common.Tests/Helpers/Hashing/HashCalculatorTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Helpers/Hashing/HashCalculatorTests.cs
@@ -1,0 +1,101 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Softeq.XToolkit.Common.Helpers.Hashing;
+using Softeq.XToolkit.Common.Tests.Helpers.HashHelperTests;
+using Xunit;
+
+namespace Softeq.XToolkit.Common.Tests.Helpers.Hashing
+{
+    public class HashCalculatorTests
+    {
+        [Theory]
+        [MemberData(nameof(HashHelperDataProvider.HashValueTypeArgumentsData), MemberType = typeof(HashHelperDataProvider))]
+        public void CalculateHashCode_ValueTypes_SameValue(int arg1, double arg2, float arg3, DateTime arg4, char arg5, bool arg6)
+        {
+            var hash1 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Using(arg5)
+                .Using(arg6)
+                .Calculate();
+            var hash2 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Using(arg5)
+                .Using(arg6)
+                .Calculate();
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Theory]
+        [MemberData(nameof(HashHelperDataProvider.HashNullableValueTypeArgumentsData), MemberType = typeof(HashHelperDataProvider))]
+        public void CalculateHashCode_NullableValueTypes_SameValue(int? arg1, double? arg2, float? arg3, DateTime? arg4, char? arg5, bool? arg6)
+        {
+            var hash1 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Using(arg5)
+                .Using(arg6)
+                .Calculate();
+            var hash2 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Using(arg5)
+                .Using(arg6)
+                .Calculate();
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Theory]
+        [MemberData(nameof(HashHelperDataProvider.HashReferenceTypeArgumentsData), MemberType = typeof(HashHelperDataProvider))]
+        public void CalculateHashCode_ReferenceTypes_SameValue(string arg1, object arg2, object[] arg3, TestHashObject arg4)
+        {
+            var hash1 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Calculate();
+            var hash2 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Calculate();
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Theory]
+        [InlineData(42, null, "42", null)]
+        public void CalculateHashCode_MixedTypes_SameValue(int arg1, int? arg2, string arg3, object arg4)
+        {
+            var hash1 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Calculate();
+            var hash2 = Hash.Get()
+                .Using(arg1)
+                .Using(arg2)
+                .Using(arg3)
+                .Using(arg4)
+                .Calculate();
+
+            Assert.Equal(hash1, hash2);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common/Helpers/HashHelper.cs
+++ b/Softeq.XToolkit.Common/Helpers/HashHelper.cs
@@ -1,12 +1,13 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Linq;
 
 namespace Softeq.XToolkit.Common.Helpers
 {
     /// <summary>
-    /// Class helps to get a hash code for a number of objects combined (2-10)
+    /// Class helps to get a hash code for a number of objects combined
     /// </summary>
     public static class HashHelper
     {
@@ -19,6 +20,7 @@ namespace Softeq.XToolkit.Common.Helpers
         /// <returns>The hash code.</returns>
         /// <param name="arg1">Mandatory argument</param>
         /// <param name="otherArgs">Optional arguments</param>
+        [Obsolete("This implementation causes boxing of value types on each call. Please use Hash.Get() instead")]
         public static int GetHashCode(object? arg1, params object?[] otherArgs)
         {
             unchecked

--- a/Softeq.XToolkit.Common/Helpers/Hashing/Hash.cs
+++ b/Softeq.XToolkit.Common/Helpers/Hashing/Hash.cs
@@ -1,0 +1,13 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.Common.Helpers.Hashing
+{
+    /// <summary>
+    /// Class helps to get a hash code for a number of objects combined
+    /// </summary>
+    public static class Hash
+    {
+        public static IHashCalculator Get() => new HashCalculator();
+    }
+}

--- a/Softeq.XToolkit.Common/Helpers/Hashing/HashCalculator.cs
+++ b/Softeq.XToolkit.Common/Helpers/Hashing/HashCalculator.cs
@@ -1,0 +1,32 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.Common.Helpers.Hashing
+{
+    internal sealed class HashCalculator : IHashCalculator
+    {
+        private const int PrimeOne = 17;
+        private const int PrimeTwo = 23;
+
+        private int _hashCode;
+
+        public HashCalculator()
+        {
+            _hashCode = PrimeOne;
+        }
+
+        public IHashCalculator Using<T>(T value)
+        {
+            unchecked
+            {
+                _hashCode = _hashCode * PrimeTwo + (value?.GetHashCode() ?? 0);
+            }
+            return this;
+        }
+
+        public int Calculate()
+        {
+            return _hashCode;
+        }
+    }
+}

--- a/Softeq.XToolkit.Common/Helpers/Hashing/IHashCalculator.cs
+++ b/Softeq.XToolkit.Common/Helpers/Hashing/IHashCalculator.cs
@@ -1,0 +1,25 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.Common.Helpers.Hashing
+{
+    /// <summary>
+    /// Common interface for Hash function implementations
+    /// </summary>
+    public interface IHashCalculator
+    {
+        /// <summary>
+        ///     Adds value to use in hash code calculations.
+        /// </summary>
+        /// <returns>IHashCalculator reference to use in chained calls</returns>
+        /// <typeparam name="T">Generic type of the value</typeparam>
+        /// <param name="value">Value to use in hash code calculations</param>
+        IHashCalculator Using<T>(T value);
+
+        /// <summary>
+        ///     Calculates hash code using specified objects.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        int Calculate();
+    }
+}


### PR DESCRIPTION
### Description

Hash helper function implementation, which use generics instead of objects. A bit more complex, but does not cause boxing for value types

### API Changes

Added:
 - static IHashCalculator Hash.Get() method
 - interface IHashCalculator
```
{
    IHashCalculator Using<T>(T value);
    int Calculate();
}
```

Changed:
 - static int HashHelper.GetHashCode() marked as obsolete with justification

### Platforms Affected

- Core (all platforms)

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
