### PR TITLE
New beta version 5

### DIFF
--- a/nuget/Softeq.XToolkit.Bindings.nuspec
+++ b/nuget/Softeq.XToolkit.Bindings.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Bindings</id>
-    <version>2.0.0-beta4</version>
+    <version>2.0.0-beta5</version>
     <title>Softeq.XToolkit.Bindings</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -12,17 +12,17 @@
     <description>Bindings implementation based on INotifyPropertyChanged interface.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android Bindings</tags>
-    <releaseNotes/>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
      <group targetFramework="netstandard2.1">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
       </group>
      <group targetFramework="MonoAndroid9.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
         <dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0" />
       </group>
      <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
       </group>
    </dependencies>
   </metadata>
@@ -30,8 +30,8 @@
     <!-- Core -->
     <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\netstandard2.1" />
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\MonoAndroid10" />
-    <file src="../Softeq.XToolkit.Bindings.Droid/bin/Release/Softeq.XToolkit.Bindings.Droid.dll" target="lib\MonoAndroid10" />
+    <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\MonoAndroid90" />
+    <file src="../Softeq.XToolkit.Bindings.Droid/bin/Release/Softeq.XToolkit.Bindings.Droid.dll" target="lib\MonoAndroid90" />
     <!-- iOS -->
     <file src="../Softeq.XToolkit.Bindings/bin/Release/netstandard2.1/Softeq.XToolkit.Bindings.dll" target="lib\Xamarin.iOS10" />
     <file src="../Softeq.XToolkit.Bindings.iOS/bin/Release/Softeq.XToolkit.Bindings.iOS.dll" target="lib\Xamarin.iOS10" />

--- a/nuget/Softeq.XToolkit.Common.nuspec
+++ b/nuget/Softeq.XToolkit.Common.nuspec
@@ -2,13 +2,13 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Common</id>
-    <version>1.1.0-beta4</version>
+    <version>1.1.0-beta5</version>
     <title>Softeq.XToolkit.Common</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="bdc6c7e673954012a7dd2bca6f187c547c889c85" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="8fc0941148c8fe60214d171bacf27b7c32c36218" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The most common components without dependencies that can be reused in any project.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>

--- a/nuget/Softeq.XToolkit.PushNotifications.nuspec
+++ b/nuget/Softeq.XToolkit.PushNotifications.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Softeq.XToolkit.PushNotifications</id>
-    <version>1.0.0-beta4</version>
+    <version>1.0.0-beta5</version>
     <title>Softeq.XToolkit.PushNotifications</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -12,20 +12,20 @@
     <description>Simple cross platform plugin to use push-notifications for Android and iOS.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Push Notifications Firebase FCM APNS iOS Android Xamarin</tags>
-    <releaseNotes/>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
       <group targetFramework="netstandard2.1">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
       </group>
       <group targetFramework="MonoAndroid9.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
         <dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
         <dependency id="Xamarin.AndroidX.Lifecycle.Process" version="2.2.0" />
         <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
         <dependency id="Xamarin.ShortcutBadger" version="1.1.21" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -36,8 +36,8 @@
     <!-- Core -->
     <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\netstandard2.1"/>
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\MonoAndroid9.0"/>
-    <file src="../Softeq.XToolkit.PushNotifications.Droid/bin/Release/Softeq.XToolkit.PushNotifications.Droid.dll" target="lib\MonoAndroid9.0"/>
+    <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\MonoAndroid90"/>
+    <file src="../Softeq.XToolkit.PushNotifications.Droid/bin/Release/Softeq.XToolkit.PushNotifications.Droid.dll" target="lib\MonoAndroid90"/>
     <!-- iOS -->
     <file src="../Softeq.XToolkit.PushNotifications/bin/Release/netstandard2.1/Softeq.XToolkit.PushNotifications.dll" target="lib\Xamarin.iOS10"/>
     <file src="../Softeq.XToolkit.PushNotifications.iOS/bin/Release/Softeq.XToolkit.PushNotifications.iOS.dll" target="lib\Xamarin.iOS10"/>

--- a/nuget/Softeq.XToolkit.Remote.nuspec
+++ b/nuget/Softeq.XToolkit.Remote.nuspec
@@ -2,23 +2,23 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Remote</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>Softeq.XToolkit.Remote</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="bdc6c7e673954012a7dd2bca6f187c547c889c85" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="8fc0941148c8fe60214d171bacf27b7c32c36218" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced HttpClient infrastructure for mobile applications.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android Remote Http Rest Api Auth</tags>
-    <releaseNotes>First release.</releaseNotes>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
       <dependency id="Polly" version="7.1.1" />
       <dependency id="refit" version="4.7.51" />
       <!-- XToolkit -->
-      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta4]" />
+      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
     </dependencies>
   </metadata>
   <files>

--- a/nuget/Softeq.XToolkit.WhiteLabel.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.WhiteLabel</id>
-    <version>2.0.0-beta5</version>
+    <version>2.0.0-beta6</version>
     <title>Softeq.XToolkit.WhiteLabel</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -12,15 +12,15 @@
     <description>XToolkit.WhiteLabel is a collection of "lego" components for fast create cross-platform mobile applications with Xamarin, based on XToolkit.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
     <tags>Softeq XToolkit Xamarin iOS Android</tags>
-    <releaseNotes/>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
      <group targetFramework="netstandard2.1">
         <dependency id="DryIoc.dll" version="4.0.5" />
         <dependency id="Newtonsoft.Json" version="12.0.2" />
         <!-- XToolkit -->
         <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
       </group>
      <group targetFramework="MonoAndroid9.0">
         <dependency id="DryIoc.dll" version="4.0.5" />
@@ -29,8 +29,8 @@
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
         <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
         <!-- Android specific -->
         <dependency id="Plugin.CurrentActivity" version="2.1.0.4" />
         <dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
@@ -43,8 +43,8 @@
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
         <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
       </group>
    </dependencies>
   </metadata>
@@ -52,8 +52,8 @@
     <!-- Core -->
     <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\netstandard2.1" />
     <!-- Droid -->
-    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\MonoAndroid10" />
-    <file src="../Softeq.XToolkit.WhiteLabel.Droid/bin/Release/Softeq.XToolkit.WhiteLabel.Droid.dll" target="lib\MonoAndroid10" />
+    <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\MonoAndroid90" />
+    <file src="../Softeq.XToolkit.WhiteLabel.Droid/bin/Release/Softeq.XToolkit.WhiteLabel.Droid.dll" target="lib\MonoAndroid90" />
     <!-- iOS -->
     <file src="../Softeq.XToolkit.WhiteLabel/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.dll" target="lib\Xamarin.iOS10" />
     <file src="../Softeq.XToolkit.WhiteLabel.iOS/bin/Release/Softeq.XToolkit.WhiteLabel.iOS.dll" target="lib\Xamarin.iOS10" />

--- a/samples/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/samples/Playground/Playground.Droid/Playground.Droid.csproj
@@ -22,8 +22,6 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -55,18 +53,9 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.AppCompat">
-      <Version>1.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Plugin.Permissions">
-      <Version>5.0.0-beta</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils">
-      <Version>1.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
-      <Version>2.2.0</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils" Version="1.0.0" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
 </ItemGroup>
   <ItemGroup>
     <Compile Include="Extended\DroidChooseBetterDateDialog.cs" />

--- a/samples/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/samples/Playground/Playground.iOS/Playground.iOS.csproj
@@ -13,8 +13,6 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/Playground/Playground/Playground.csproj
+++ b/samples/Playground/Playground/Playground.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

New beta release XToolkit components.

Main changes: 🚀

- AndroidX

Changes: https://github.com/Softeq/XToolkit.WhiteLabel/compare/v2.0.0-beta4...8fc0941148c8fe60214d171bacf27b7c32c36218

## Changes

### XToolkit.Common

- Implemented unified GetHashCode method with null-values support (#253)
- Added Stream.ToArray method (#278)
- Made list extensions more versatile (#279)

### XToolkit.Bindings

- Added method for set command with dispose (#269)
- Added Bindings.Tests

### XToolkit.WhiteLabel

- Added Enum key support for TabNavigation (#242)
- Refactored bootstrapper (#260)
- Reworked dialogs (#272)
- Fixed iOS 13 navigation (#214)
- Fixed OnUIThreadAsync deadlock (#273)

### Documentation

- Updated documentation (#250)

### CI/CD

- Updated pipelines versions (#262)

### Infrastructure

- Share common build properties (#266)
- Resolve nullable warnings (#262, #267, #277) 
- Update GitHub templates (#264)

## Platforms Affected

- Core (all platforms)
- iOS
- Android

## PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
- [x] Publish new NuGet packages
