### PR TITLE
Mark HashHelper as obsolete

### DIFF
--- a/Softeq.XToolkit.Common/Helpers/HashHelper.cs
+++ b/Softeq.XToolkit.Common/Helpers/HashHelper.cs
@@ -1,13 +1,15 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Linq;
 
 namespace Softeq.XToolkit.Common.Helpers
 {
     /// <summary>
-    /// Class helps to get a hash code for a number of objects combined (2-10)
+    /// Class helps to get a hash code for a number of objects combined
     /// </summary>
+    [Obsolete("Please use System.HashCode to calculate HashCode value")]
     public static class HashHelper
     {
         private const int PrimeOne = 17;


### PR DESCRIPTION
### Description

Mark HashHelper class as obsolete in favor of using System.HashCode

### API Changes
Changed:
 - static class HashHelper marked as obsolete with justification

### Platforms Affected

- Core (all platforms)

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
