### PR TITLE
Constraint of SetCommand methods for TEventArgs

### DIFF
--- a/Softeq.XToolkit.Bindings.Tests/AssertHelpers.cs
+++ b/Softeq.XToolkit.Bindings.Tests/AssertHelpers.cs
@@ -43,7 +43,7 @@ namespace Softeq.XToolkit.Bindings.Tests
 
             if (canExecute)
             {
-                command.Received(1).Execute(Arg.Is(commandParameter));
+                command.Received(1).Execute(commandParameter);
             }
             else
             {

--- a/Softeq.XToolkit.Bindings.Tests/BindingExtensionsTests/BindingExtensionsTests.cs
+++ b/Softeq.XToolkit.Bindings.Tests/BindingExtensionsTests/BindingExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Windows.Input;
 using NSubstitute;
+using Softeq.XToolkit.Common.Commands;
 using Xunit;
 
 namespace Softeq.XToolkit.Bindings.Tests.BindingExtensionsTests
@@ -11,11 +12,13 @@ namespace Softeq.XToolkit.Bindings.Tests.BindingExtensionsTests
     public class BindingExtensionsTests
     {
         private readonly ICommand _command;
+        private readonly ICommand<string> _commandGeneric;
         private readonly StubProducer _obj;
 
         public BindingExtensionsTests()
         {
             _command = Substitute.For<ICommand>();
+            _commandGeneric = Substitute.For<ICommand<string>>();
             _obj = new StubProducer();
 
             BindingExtensions.Initialize(new MockBindingFactory());
@@ -73,14 +76,15 @@ namespace Softeq.XToolkit.Bindings.Tests.BindingExtensionsTests
         public void SetCommand_GenericWithEventArgs_Executes(bool canExecute, object commandParameter)
         {
             // arrange
-            _command.CanExecute(Arg.Any<string>()).Returns(canExecute);
+            _commandGeneric.CanExecute(Arg.Any<object>()).Returns(canExecute);
 
             // act
-            _obj.SetCommand<string>(nameof(_obj.GenericStringEvent), _command);
+            // ReSharper disable once RedundantTypeArgumentsOfMethod
+            _obj.SetCommand<string>(nameof(_obj.GenericStringEvent), _commandGeneric);
 
             // assert
             _obj.RaiseGenericStringEvent((string)commandParameter);
-            AssertHelpers.ReceivedCommandInterface(_command, canExecute, commandParameter);
+            AssertHelpers.ReceivedCommandInterface(_commandGeneric, canExecute, commandParameter);
         }
 
         [Theory]

--- a/Softeq.XToolkit.Bindings/BindingExtensions.cs
+++ b/Softeq.XToolkit.Bindings/BindingExtensions.cs
@@ -444,7 +444,7 @@ namespace Softeq.XToolkit.Bindings
         public static void SetCommand<TEventArgs>(
             this object element,
             string eventName,
-            ICommand command)
+            ICommand<TEventArgs> command)
         {
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
@@ -556,12 +556,12 @@ namespace Softeq.XToolkit.Bindings
             SetCommand(element, string.Empty, command);
         }
 
-        /// <inheritdoc cref="SetCommand{TEventArgs}(object,string,ICommand)" />
+        /// <inheritdoc cref="SetCommand{TEventArgs}(object,string,ICommand{TEventArgs})" />
         public static void SetCommand<TEventArgs>(
             this object element,
-            ICommand command)
+            ICommand<TEventArgs> command)
         {
-            SetCommand<TEventArgs>(element, string.Empty, command);
+            SetCommand(element, string.Empty, command);
         }
 
         /// <inheritdoc cref="SetCommand{T}(object,string,ICommand,T)" />


### PR DESCRIPTION
### Description

Reported by @Synthezator 

Case:
```cs
view.SetCommand(nameof(view.SomeGenericEvent),
  new RelayCommand<EventArgs>(x => {})); <- runtime exception
```

Workaround:
```cs
view.SetCommand<EventArgs>(nameof(view.SomeGenericEvent),
  new RelayCommand<EventArgs>(x => {}));
```

### API Changes

- `SetCommand<TEventArgs>` only for `ICommand<TEventArgs>`


### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
