### PR TITLE
New beta version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Bindings  | [![Softeq.XToolkit.Bindings](https://buildstats.info/nuget/Softeq.XT
 Permissions | [![Softeq.XToolkit.Permissions](https://buildstats.info/nuget/Softeq.XToolkit.Permissions?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.Permissions)
 PushNotifications | [![Softeq.XToolkit.PushNotifications](https://buildstats.info/nuget/Softeq.XToolkit.PushNotifications?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.PushNotifications)
 WhiteLabel  | [![Softeq.XToolkit.WhiteLabel](https://buildstats.info/nuget/Softeq.XToolkit.WhiteLabel?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.WhiteLabel)
+WhiteLabel.Essentials  | [![Softeq.XToolkit.WhiteLabel.Essentials](https://buildstats.info/nuget/Softeq.XToolkit.WhiteLabel.Essentials?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.WhiteLabel.Essentials)
+WhiteLabel.Forms  | [![Softeq.XToolkit.WhiteLabel.Forms](https://buildstats.info/nuget/Softeq.XToolkit.WhiteLabel.Forms?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.WhiteLabel.Forms)
 Remote  | [![Softeq.XToolkit.Remote](https://buildstats.info/nuget/Softeq.XToolkit.Remote?includePreReleases=true)](https://www.nuget.org/packages/Softeq.XToolkit.Remote)
 
 ## Documentation

--- a/azure-pipelines/nuget-Softeq.XToolkit.WhiteLabel.Essentials.yml
+++ b/azure-pipelines/nuget-Softeq.XToolkit.WhiteLabel.Essentials.yml
@@ -1,0 +1,17 @@
+resources:
+- repo: self
+trigger:
+  - release/*
+pr: none
+
+queue:
+  name: Hosted macOS
+  demands: Xamarin.iOS
+
+variables:
+- template: templates/vars.yml
+
+steps:
+- template: templates/nuget-steps.yml
+  parameters:
+    ProjectName: 'Softeq.XToolkit.WhiteLabel.Essentials'

--- a/azure-pipelines/nuget-Softeq.XToolkit.WhiteLabel.Forms.yml
+++ b/azure-pipelines/nuget-Softeq.XToolkit.WhiteLabel.Forms.yml
@@ -1,0 +1,17 @@
+resources:
+- repo: self
+trigger:
+  - release/*
+pr: none
+
+queue:
+  name: Hosted macOS
+  demands: Xamarin.iOS
+
+variables:
+- template: templates/vars.yml
+
+steps:
+- template: templates/nuget-steps.yml
+  parameters:
+    ProjectName: 'Softeq.XToolkit.WhiteLabel.Forms'

--- a/documentation/articles/developer-guide.md
+++ b/documentation/articles/developer-guide.md
@@ -14,3 +14,6 @@
 4. For build iOS project:
    - Change build configuration to **Debug/iPhoneSimulator**
    - Set **Playground.iOS** as startup project
+5. For build Xamarin.Forms projects:
+   - Android: **Playground.Forms.Droid**
+   - iOS: **Playground.Forms.iOS**

--- a/documentation/articles/intro.md
+++ b/documentation/articles/intro.md
@@ -3,4 +3,4 @@
 
 In this section, we keep our articles about XTookit.
 
-If you want to help us, welcome to contribute.
+If you want to help us, welcome to [contribute](contributing.md).

--- a/nuget/Softeq.XToolkit.Bindings.nuspec
+++ b/nuget/Softeq.XToolkit.Bindings.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Bindings</id>
-    <version>2.0.0-beta5</version>
+    <version>2.0.0-beta6</version>
     <title>Softeq.XToolkit.Bindings</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -15,14 +15,14 @@
     <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
      <group targetFramework="netstandard2.1">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
       </group>
      <group targetFramework="MonoAndroid9.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
         <dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0" />
       </group>
      <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
       </group>
    </dependencies>
   </metadata>

--- a/nuget/Softeq.XToolkit.Common.nuspec
+++ b/nuget/Softeq.XToolkit.Common.nuspec
@@ -8,7 +8,7 @@
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="84e8622e9c004ffa61931999dddfd69ae6570ed3" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="aae6f948676edae2caf657f913c7d1da17191edf" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The most common components without dependencies that can be reused in any project.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>

--- a/nuget/Softeq.XToolkit.Common.nuspec
+++ b/nuget/Softeq.XToolkit.Common.nuspec
@@ -2,13 +2,13 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Common</id>
-    <version>1.1.0-beta5</version>
+    <version>1.1.0-beta6</version>
     <title>Softeq.XToolkit.Common</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="8fc0941148c8fe60214d171bacf27b7c32c36218" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="84e8622e9c004ffa61931999dddfd69ae6570ed3" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The most common components without dependencies that can be reused in any project.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>

--- a/nuget/Softeq.XToolkit.Permissions.nuspec
+++ b/nuget/Softeq.XToolkit.Permissions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Softeq.XToolkit.Permissions</id>
-    <version>2.0.0-beta3</version>
+    <version>2.0.0-beta4</version>
     <title>Softeq.XToolkit.Permissions</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -19,6 +19,7 @@
         <dependency id="Xam.Plugins.Settings" version="3.1.1"/>
       </group>
       <group targetFramework="MonoAndroid10">
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
         <dependency id="Plugin.Permissions" version="5.0.0-beta"/>
         <dependency id="Xam.Plugins.Settings" version="3.1.1"/>
       </group>

--- a/nuget/Softeq.XToolkit.PushNotifications.nuspec
+++ b/nuget/Softeq.XToolkit.PushNotifications.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Softeq.XToolkit.PushNotifications</id>
-    <version>1.0.0-beta5</version>
+    <version>1.0.0-beta6</version>
     <title>Softeq.XToolkit.PushNotifications</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -15,17 +15,17 @@
     <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
     <dependencies>
       <group targetFramework="netstandard2.1">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
       </group>
       <group targetFramework="MonoAndroid9.0">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
         <dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
         <dependency id="Xamarin.AndroidX.Lifecycle.Process" version="2.2.0" />
         <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
         <dependency id="Xamarin.ShortcutBadger" version="1.1.21" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+        <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/nuget/Softeq.XToolkit.Remote.nuspec
+++ b/nuget/Softeq.XToolkit.Remote.nuspec
@@ -8,7 +8,7 @@
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="84e8622e9c004ffa61931999dddfd69ae6570ed3" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="aae6f948676edae2caf657f913c7d1da17191edf" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced HttpClient infrastructure for mobile applications.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>

--- a/nuget/Softeq.XToolkit.Remote.nuspec
+++ b/nuget/Softeq.XToolkit.Remote.nuspec
@@ -2,13 +2,13 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.Remote</id>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <title>Softeq.XToolkit.Remote</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
     <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
-    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="8fc0941148c8fe60214d171bacf27b7c32c36218" />
+    <repository type="git" url="https://github.com/Softeq/XToolkit.WhiteLabel.git" branch="master" commit="84e8622e9c004ffa61931999dddfd69ae6570ed3" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Advanced HttpClient infrastructure for mobile applications.</description>
     <copyright>Copyright 2020 Softeq Development Corp.</copyright>
@@ -18,7 +18,7 @@
       <dependency id="Polly" version="7.1.1" />
       <dependency id="refit" version="4.7.51" />
       <!-- XToolkit -->
-      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta5]" />
+      <dependency id="Softeq.XToolkit.Common" version="[1.1.0-beta6]" />
     </dependencies>
   </metadata>
   <files>

--- a/nuget/Softeq.XToolkit.WhiteLabel.Essentials.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.Essentials.nuspec
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Softeq.XToolkit.WhiteLabel.Essentials</id>
+    <version>1.0.0-beta1</version>
+    <title>Softeq.XToolkit.WhiteLabel.Essentials</title>
+    <authors>Softeq Development Corp.</authors>
+    <owners>Softeq Development Corp.</owners>
+    <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Library over the Softeq.XToolkit.WhiteLabel that contains optional components for any application.</description>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
+    <tags>Softeq XToolkit Xamarin iOS Android ImagePicker</tags>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
+    <dependencies>
+     <group targetFramework="netstandard2.1">
+        <!-- XToolkit -->
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+      </group>
+     <group targetFramework="MonoAndroid9.0">
+        <dependency id="Plugin.Permissions" version="5.0.0-beta" />
+        <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
+        <!-- Android specific -->
+        <dependency id="Xamarin.AndroidX.Core" version="1.1.0" />
+        <!-- XToolkit -->
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+      </group>
+     <group targetFramework="Xamarin.iOS10">
+        <dependency id="Plugin.Permissions" version="5.0.0-beta" />
+        <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
+        <!-- XToolkit -->
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+      </group>
+   </dependencies>
+  </metadata>
+  <files>
+    <!-- Core -->
+    <file src="../Softeq.XToolkit.WhiteLabel.Essentials/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.Essentials.dll" target="lib\netstandard2.1" />
+    <!-- Droid -->
+    <file src="../Softeq.XToolkit.WhiteLabel.Essentials/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.Essentials.dll" target="lib\MonoAndroid90" />
+    <file src="../Softeq.XToolkit.WhiteLabel.Essentials.Droid/bin/Release/Softeq.XToolkit.WhiteLabel.Essentials.Droid.dll" target="lib\MonoAndroid90" />
+    <!-- iOS -->
+    <file src="../Softeq.XToolkit.WhiteLabel.Essentials/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.Essentials.dll" target="lib\Xamarin.iOS10" />
+    <file src="../Softeq.XToolkit.WhiteLabel.Essentials.iOS/bin/Release/Softeq.XToolkit.WhiteLabel.Essentials.iOS.dll" target="lib\Xamarin.iOS10" />
+  </files>
+</package>

--- a/nuget/Softeq.XToolkit.WhiteLabel.Essentials.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.Essentials.nuspec
@@ -16,8 +16,8 @@
     <dependencies>
      <group targetFramework="netstandard2.1">
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+        <dependency id="Softeq.XToolkit.Permissions" version="[2.0.0-beta4]" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="[2.0.0-beta7]" />
       </group>
      <group targetFramework="MonoAndroid9.0">
         <dependency id="Plugin.Permissions" version="5.0.0-beta" />
@@ -25,15 +25,15 @@
         <!-- Android specific -->
         <dependency id="Xamarin.AndroidX.Core" version="1.1.0" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+        <dependency id="Softeq.XToolkit.Permissions" version="[2.0.0-beta4]" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="[2.0.0-beta7]" />
       </group>
      <group targetFramework="Xamarin.iOS10">
         <dependency id="Plugin.Permissions" version="5.0.0-beta" />
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.WhiteLabel" version="2.0.0-beta7" />
+        <dependency id="Softeq.XToolkit.Permissions" version="[2.0.0-beta4]" />
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="[2.0.0-beta7]" />
       </group>
    </dependencies>
   </metadata>

--- a/nuget/Softeq.XToolkit.WhiteLabel.Essentials.sln
+++ b/nuget/Softeq.XToolkit.WhiteLabel.Essentials.sln
@@ -1,0 +1,281 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel", "..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj", "{797907F2-95D6-40E5-811E-3206CBF62213}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Droid", "..\Softeq.XToolkit.WhiteLabel.Droid\Softeq.XToolkit.WhiteLabel.Droid.csproj", "{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.iOS", "..\Softeq.XToolkit.WhiteLabel.iOS\Softeq.XToolkit.WhiteLabel.iOS.csproj", "{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common", "..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj", "{B6D39FB0-BD3C-477A-BDED-579D688D59DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common.Droid", "..\Softeq.XToolkit.Common.Droid\Softeq.XToolkit.Common.Droid.csproj", "{18D3FDC1-B0A1-401E-87F2-1C43034E610C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions", "..\Softeq.XToolkit.Permissions\Softeq.XToolkit.Permissions.csproj", "{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings", "..\Softeq.XToolkit.Bindings\Softeq.XToolkit.Bindings.csproj", "{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings.Droid", "..\Softeq.XToolkit.Bindings.Droid\Softeq.XToolkit.Bindings.Droid.csproj", "{2B4A678B-63B4-49DB-99B1-BFE7793110C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings.iOS", "..\Softeq.XToolkit.Bindings.iOS\Softeq.XToolkit.Bindings.iOS.csproj", "{2D399BA9-1878-43E2-AF05-6873EAE9151B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common.iOS", "..\Softeq.XToolkit.Common.iOS\Softeq.XToolkit.Common.iOS.csproj", "{6BCB2009-2E46-458C-BCAA-AFC27A631924}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications", "..\Softeq.XToolkit.PushNotifications\Softeq.XToolkit.PushNotifications.csproj", "{11BC7FFF-88E1-4043-A404-7B4907757FB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications.iOS", "..\Softeq.XToolkit.PushNotifications.iOS\Softeq.XToolkit.PushNotifications.iOS.csproj", "{0EAE7634-9497-4FB8-B62F-DDACF85985D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications.Droid", "..\Softeq.XToolkit.PushNotifications.Droid\Softeq.XToolkit.PushNotifications.Droid.csproj", "{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions.Droid", "..\Softeq.XToolkit.Permissions.Droid\Softeq.XToolkit.Permissions.Droid.csproj", "{955A4101-4989-4764-9134-E621FC4D9C86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions.iOS", "..\Softeq.XToolkit.Permissions.iOS\Softeq.XToolkit.Permissions.iOS.csproj", "{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Essentials", "..\Softeq.XToolkit.WhiteLabel.Essentials\Softeq.XToolkit.WhiteLabel.Essentials.csproj", "{AAD66B4C-ACBF-474D-95F6-340C13892134}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Essentials.Droid", "..\Softeq.XToolkit.WhiteLabel.Essentials.Droid\Softeq.XToolkit.WhiteLabel.Essentials.Droid.csproj", "{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Essentials.iOS", "..\Softeq.XToolkit.WhiteLabel.Essentials.iOS\Softeq.XToolkit.WhiteLabel.Essentials.iOS.csproj", "{23AA0E71-BF8F-47A8-A915-C8AC4841E064}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release.Stage|Any CPU = Release.Stage|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|Any CPU.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhone.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhone.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhone.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhone.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhone.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhone.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhone.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhone.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhone.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhone.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhone.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhone.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhone.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhone.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhone.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|iPhone.Build.0 = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release.Stage|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD66B4C-ACBF-474D-95F6-340C13892134}.Release.Stage|Any CPU.Build.0 = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|iPhone.Build.0 = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release.Stage|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAEA919A-5B4A-4D97-AB4C-33229484BD7A}.Release.Stage|Any CPU.Build.0 = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|iPhone.Build.0 = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release.Stage|Any CPU.ActiveCfg = Debug|Any CPU
+		{23AA0E71-BF8F-47A8-A915-C8AC4841E064}.Release.Stage|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/nuget/Softeq.XToolkit.WhiteLabel.Forms.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.Forms.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Softeq.XToolkit.WhiteLabel.Forms</id>
+    <version>1.0.0-beta1</version>
+    <title>Softeq.XToolkit.WhiteLabel.Forms</title>
+    <authors>Softeq Development Corp.</authors>
+    <owners>Softeq Development Corp.</owners>
+    <licenseUrl>https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Softeq/XToolkit.WhiteLabel</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Integration library for using Softeq.XToolkit.WhiteLabel in Xamarin.Forms projects.</description>
+    <copyright>Copyright 2020 Softeq Development Corp.</copyright>
+    <tags>Softeq XToolkit Xamarin iOS Android</tags>
+    <releaseNotes>Releases: https://github.com/Softeq/XToolkit.WhiteLabel/releases</releaseNotes>
+    <dependencies>
+     <group targetFramework="netstandard2.1">
+        <dependency id="Xamarin.Forms" version="4.5.0.530" />
+        <!-- XToolkit -->
+        <dependency id="Softeq.XToolkit.WhiteLabel" version="[2.0.0-beta7]" />
+      </group>
+   </dependencies>
+  </metadata>
+  <files>
+    <!-- Core -->
+    <file src="../Softeq.XToolkit.WhiteLabel.Forms/bin/Release/netstandard2.1/Softeq.XToolkit.WhiteLabel.Forms.dll" target="lib\netstandard2.1" />
+  </files>
+</package>

--- a/nuget/Softeq.XToolkit.WhiteLabel.Forms.sln
+++ b/nuget/Softeq.XToolkit.WhiteLabel.Forms.sln
@@ -1,0 +1,261 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel", "..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj", "{797907F2-95D6-40E5-811E-3206CBF62213}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Droid", "..\Softeq.XToolkit.WhiteLabel.Droid\Softeq.XToolkit.WhiteLabel.Droid.csproj", "{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.iOS", "..\Softeq.XToolkit.WhiteLabel.iOS\Softeq.XToolkit.WhiteLabel.iOS.csproj", "{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common", "..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj", "{B6D39FB0-BD3C-477A-BDED-579D688D59DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common.Droid", "..\Softeq.XToolkit.Common.Droid\Softeq.XToolkit.Common.Droid.csproj", "{18D3FDC1-B0A1-401E-87F2-1C43034E610C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions", "..\Softeq.XToolkit.Permissions\Softeq.XToolkit.Permissions.csproj", "{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings", "..\Softeq.XToolkit.Bindings\Softeq.XToolkit.Bindings.csproj", "{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings.Droid", "..\Softeq.XToolkit.Bindings.Droid\Softeq.XToolkit.Bindings.Droid.csproj", "{2B4A678B-63B4-49DB-99B1-BFE7793110C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Bindings.iOS", "..\Softeq.XToolkit.Bindings.iOS\Softeq.XToolkit.Bindings.iOS.csproj", "{2D399BA9-1878-43E2-AF05-6873EAE9151B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Common.iOS", "..\Softeq.XToolkit.Common.iOS\Softeq.XToolkit.Common.iOS.csproj", "{6BCB2009-2E46-458C-BCAA-AFC27A631924}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications", "..\Softeq.XToolkit.PushNotifications\Softeq.XToolkit.PushNotifications.csproj", "{11BC7FFF-88E1-4043-A404-7B4907757FB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications.iOS", "..\Softeq.XToolkit.PushNotifications.iOS\Softeq.XToolkit.PushNotifications.iOS.csproj", "{0EAE7634-9497-4FB8-B62F-DDACF85985D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.PushNotifications.Droid", "..\Softeq.XToolkit.PushNotifications.Droid\Softeq.XToolkit.PushNotifications.Droid.csproj", "{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions.Droid", "..\Softeq.XToolkit.Permissions.Droid\Softeq.XToolkit.Permissions.Droid.csproj", "{955A4101-4989-4764-9134-E621FC4D9C86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.Permissions.iOS", "..\Softeq.XToolkit.Permissions.iOS\Softeq.XToolkit.Permissions.iOS.csproj", "{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Softeq.XToolkit.WhiteLabel.Forms", "..\Softeq.XToolkit.WhiteLabel.Forms\Softeq.XToolkit.WhiteLabel.Forms.csproj", "{0F8A5F2B-4757-4AEF-96A1-626F41147D52}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release.Stage|Any CPU = Release.Stage|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|Any CPU.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhone.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{797907F2-95D6-40E5-811E-3206CBF62213}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhone.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7F44F0F6-8396-42D0-8A1B-DC40CE8C478C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhone.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CC89DBC6-E68A-4C85-91C4-E276D3BC3C2E}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|iPhone.Build.0 = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2B06D0B2-8BED-49EC-AC0B-154850F68190}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhone.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{B6D39FB0-BD3C-477A-BDED-579D688D59DA}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhone.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{18D3FDC1-B0A1-401E-87F2-1C43034E610C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhone.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7DFADBE8-C2DE-4C1E-A72C-125B40B0A416}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhone.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhone.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2B4A678B-63B4-49DB-99B1-BFE7793110C4}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhone.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2D399BA9-1878-43E2-AF05-6873EAE9151B}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhone.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6BCB2009-2E46-458C-BCAA-AFC27A631924}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhone.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{11BC7FFF-88E1-4043-A404-7B4907757FB2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhone.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0EAE7634-9497-4FB8-B62F-DDACF85985D2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhone.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FACBCCE2-C5F5-4AA8-9E19-8D61B4386EEA}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhone.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{955A4101-4989-4764-9134-E621FC4D9C86}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhone.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7EB2ADA9-C599-4644-AC6B-109F1AEED19F}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|iPhone.Build.0 = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release.Stage|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F8A5F2B-4757-4AEF-96A1-626F41147D52}.Release.Stage|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/nuget/Softeq.XToolkit.WhiteLabel.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.nuspec
@@ -18,8 +18,6 @@
         <dependency id="DryIoc.dll" version="4.0.5" />
         <dependency id="Newtonsoft.Json" version="12.0.2" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
         <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
       </group>
      <group targetFramework="MonoAndroid9.0">
@@ -27,14 +25,13 @@
         <dependency id="Newtonsoft.Json" version="12.0.2" />
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
-        <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
         <!-- Android specific -->
         <dependency id="Plugin.CurrentActivity" version="2.1.0.4" />
         <dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
         <dependency id="Xamarin.Google.Android.Material" version="1.1.0-rc3" />
+        <!-- XToolkit -->
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
       </group>
      <group targetFramework="Xamarin.iOS10">
         <dependency id="DryIoc.dll" version="4.0.5" />
@@ -42,9 +39,8 @@
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
         <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
       </group>
    </dependencies>
   </metadata>

--- a/nuget/Softeq.XToolkit.WhiteLabel.nuspec
+++ b/nuget/Softeq.XToolkit.WhiteLabel.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Softeq.XToolkit.WhiteLabel</id>
-    <version>2.0.0-beta6</version>
+    <version>2.0.0-beta7</version>
     <title>Softeq.XToolkit.WhiteLabel</title>
     <authors>Softeq Development Corp.</authors>
     <owners>Softeq Development Corp.</owners>
@@ -18,9 +18,9 @@
         <dependency id="DryIoc.dll" version="4.0.5" />
         <dependency id="Newtonsoft.Json" version="12.0.2" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
       </group>
      <group targetFramework="MonoAndroid9.0">
         <dependency id="DryIoc.dll" version="4.0.5" />
@@ -28,9 +28,9 @@
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
         <!-- Android specific -->
         <dependency id="Plugin.CurrentActivity" version="2.1.0.4" />
         <dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
@@ -42,9 +42,9 @@
         <dependency id="Xamarin.FFImageLoading" version="2.4.11.982" />
         <dependency id="Xam.Plugins.Settings" version="3.1.1" />
         <!-- XToolkit -->
-        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta3" />
-        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta5" />
-        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta5" />
+        <dependency id="Softeq.XToolkit.Permissions" version="2.0.0-beta4" />
+        <dependency id="Softeq.XToolkit.Bindings" version="2.0.0-beta6" />
+        <dependency id="Softeq.XToolkit.Common" version="1.1.0-beta6" />
       </group>
    </dependencies>
   </metadata>


### PR DESCRIPTION
## Description

New beta release XToolkit components.

Main changes: 🚀

- Xamarin.Forms

Changes: https://github.com/Softeq/XToolkit.WhiteLabel/compare/v2.0.0-beta5...aae6f948676edae2caf657f913c7d1da17191edf

## Changes

### XToolkit.Common

- Mark HashHelper as obsolete (#283)
- Weak delegates refactoring (#289)
- Refactored extensions (#290)
- Rework AsyncCommand (#293)

### XToolkit.Bindings

- Constraint of SetCommand methods for TEventArgs (#287)

### XToolkit.WhiteLabel

- ImagePicker migrated to WhiteLabel.Essentials (#258)
- Remove dependency on Permissions for WhiteLabel (#294)

### XToolkit.Permissions

- `IPermissionRequestHandler` moved to `Softeq.XToolkit.Common.Droid.Permissions.IPermissionRequestHandler` (#258)

### Xamarin.Forms

- Added support XF (#258)
- Add some converters and controls to WhiteLabel.Forms (#291)
- Generic root frame navigation (#292) 

### Documentation

- Update DocFX (286)

### Playground

- Added `samples/Playground.Forms`
- `samples.Playground.sln` moved to `XToolkit.sln`

### Process

- Added StyleCop (#285)

### Platforms Affected

- Core (all platforms)
- iOS
- Android

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
