### PR TITLE
Add tests for resolving async command ctors

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandGenericTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandGenericTests.cs
@@ -14,6 +14,22 @@ namespace Softeq.XToolkit.Common.Tests.Commands.AsyncCommandTests
     public class AsyncCommandGenericTests
     {
         [Fact]
+        public void Constructors_Resolved_Correctly()
+        {
+            var func = CreateFuncWithArg<string>();
+
+            new AsyncCommand<string>(func);
+
+            new AsyncCommand<string>(func, ex => { });
+
+            new AsyncCommand<string>(func, () => true);
+            new AsyncCommand<string>(func, () => true, ex => { });
+
+            new AsyncCommand<string>(func, x => true);
+            new AsyncCommand<string>(func, x => true, ex => { });
+        }
+
+        [Fact]
         public void Constructor_ExecuteIsNull_CreatesCorrectly()
         {
             CreateAsyncCommandGeneric<string>(null);

--- a/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandGenericTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandGenericTests.cs
@@ -1,6 +1,7 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using Softeq.XToolkit.Common.Commands;
@@ -24,9 +25,11 @@ namespace Softeq.XToolkit.Common.Tests.Commands.AsyncCommandTests
 
             new AsyncCommand<string>(func, () => true);
             new AsyncCommand<string>(func, () => true, ex => { });
+            new AsyncCommand<string>(func, null as Func<bool>, ex => { });
 
             new AsyncCommand<string>(func, x => true);
             new AsyncCommand<string>(func, x => true, ex => { });
+            new AsyncCommand<string>(func, null as Func<object, bool>, ex => { });
         }
 
         [Fact]

--- a/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandTests.cs
@@ -1,6 +1,7 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows.Input;
 using Softeq.XToolkit.Common.Commands;
@@ -24,11 +25,13 @@ namespace Softeq.XToolkit.Common.Tests.Commands.AsyncCommandTests
 
             new AsyncCommand(func, () => true);
             new AsyncCommand(func, () => true, ex => { });
+            new AsyncCommand(func, null, ex => { });
 
             var funcGeneric = CreateFuncWithArg<object>();
 
             new AsyncCommand(funcGeneric, x => true);
             new AsyncCommand(funcGeneric, x => true, ex => { });
+            new AsyncCommand(funcGeneric, null, ex => { });
         }
 
         [Fact]

--- a/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Commands/AsyncCommandTests/AsyncCommandTests.cs
@@ -14,6 +14,24 @@ namespace Softeq.XToolkit.Common.Tests.Commands.AsyncCommandTests
     public class AsyncCommandTests
     {
         [Fact]
+        public void Constructors_Resolved_Correctly()
+        {
+            var func = CreateFunc();
+
+            new AsyncCommand(func);
+
+            new AsyncCommand(func, ex => { });
+
+            new AsyncCommand(func, () => true);
+            new AsyncCommand(func, () => true, ex => { });
+
+            var funcGeneric = CreateFuncWithArg<object>();
+
+            new AsyncCommand(funcGeneric, x => true);
+            new AsyncCommand(funcGeneric, x => true, ex => { });
+        }
+
+        [Fact]
         public void Constructor_ExecuteIsNull_CreatesCorrectly()
         {
             CreateAsyncCommand(null);

--- a/Softeq.XToolkit.Common/Commands/AsyncCommand.cs
+++ b/Softeq.XToolkit.Common/Commands/AsyncCommand.cs
@@ -66,7 +66,7 @@ namespace Softeq.XToolkit.Common.Commands
         /// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute.</param>
         public AsyncCommand(
             Func<object, Task> execute,
-            Func<object?, bool>? canExecute = null,
+            Func<object?, bool>? canExecute,
             Action<Exception>? onException = null)
             : base(canExecute)
         {

--- a/Softeq.XToolkit.Common/Commands/AsyncCommandGeneric.cs
+++ b/Softeq.XToolkit.Common/Commands/AsyncCommandGeneric.cs
@@ -70,7 +70,7 @@ namespace Softeq.XToolkit.Common.Commands
         /// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute.</param>
         public AsyncCommand(
             Func<T, Task> execute,
-            Func<object?, bool>? canExecute = null,
+            Func<object?, bool>? canExecute,
             Action<Exception>? onException = null)
             : base(canExecute)
         {


### PR DESCRIPTION
### Description

Added tests for explicit check resolving constructors for AsyncCommands.

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
