### PR TITLE
Playground sample: iOS13 Compositional Layout

### DIFF
--- a/Softeq.XToolkit.Common/Extensions/EnumExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/EnumExtensions.cs
@@ -83,5 +83,16 @@ namespace Softeq.XToolkit.Common.Extensions
 
             return null;
         }
+
+        /// <summary>
+        ///     Get enumeration that corresponding value.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <param name="value">Enum value.</param>
+        /// <returns>Correspond enumeration.</returns>
+        public static TEnum FindByValue<TEnum>(byte value) where TEnum : Enum
+        {
+            return (TEnum) Enum.ToObject(typeof(TEnum), value);
+        }
     }
 }

--- a/Softeq.XToolkit.Common/Extensions/EnumExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/EnumExtensions.cs
@@ -8,14 +8,14 @@ namespace Softeq.XToolkit.Common.Extensions
 {
     public static class EnumExtensions
     {
-        public static T SetFlag<T>(this Enum value, T flags)
+        public static TEnum SetFlag<TEnum>(this Enum value, TEnum flags) where TEnum : Enum
         {
-            if (value.GetType() != typeof(T))
+            if (value.GetType() != typeof(TEnum))
             {
                 throw new ArgumentException("Enum value and flags types don't match.");
             }
 
-            return (T) Enum.ToObject(typeof(T), Convert.ToUInt64(value) | Convert.ToUInt64(flags));
+            return (TEnum) Enum.ToObject(typeof(TEnum), Convert.ToUInt64(value) | Convert.ToUInt64(flags));
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Softeq.XToolkit.Common.Extensions
         /// <returns>An object of type enumType whose value is represented by value.</returns>
         /// <param name="value">A string containing the name or value to convert..</param>
         /// <typeparam name="TEnum">Enum type.</typeparam>
-        public static TEnum Parse<TEnum>(string value)
+        public static TEnum Parse<TEnum>(string value) where TEnum : Enum
         {
             return (TEnum) Enum.Parse(typeof(TEnum), value);
         }
@@ -38,7 +38,7 @@ namespace Softeq.XToolkit.Common.Extensions
         /// <param name="value">A string containing the name or value to convert..</param>
         /// <param name="ignoreCase">true to ignore case; false to regard case.</param>
         /// <typeparam name="TEnum">Enum type.</typeparam>
-        public static TEnum Parse<TEnum>(string value, bool ignoreCase)
+        public static TEnum Parse<TEnum>(string value, bool ignoreCase) where TEnum : Enum
         {
             return (TEnum) Enum.Parse(typeof(TEnum), value, ignoreCase);
         }
@@ -48,7 +48,7 @@ namespace Softeq.XToolkit.Common.Extensions
         /// </summary>
         /// <param name="action">Specified action.</param>
         /// <typeparam name="TEnum">Enum type.</typeparam>
-        public static void Apply<TEnum>(Action<TEnum> action)
+        public static void Apply<TEnum>(Action<TEnum> action) where TEnum : Enum
         {
             foreach (TEnum constant in Enum.GetValues(typeof(TEnum)))
             {

--- a/samples/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/samples/Playground/Playground.iOS/Playground.iOS.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
     <Compile Include="ViewControllers\Collections\CompositionalLayout\AdaptiveSectionsViewController.cs" />
+    <Compile Include="ViewControllers\Collections\CompositionalLayout\NestedGroupsViewController.cs" />
     <Compile Include="ViewControllers\Collections\CompositionalLayout\NSUtils.cs" />
     <Compile Include="Views\MovieCollectionViewCell.cs" />
     <Compile Include="Views\MovieCollectionViewCell.designer.cs">

--- a/samples/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/samples/Playground/Playground.iOS/Playground.iOS.csproj
@@ -182,6 +182,8 @@
     <Compile Include="Extended\IosExtendedDialogsService.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="ViewControllers\Collections\CompositionalLayout\AdaptiveSectionsViewController.cs" />
+    <Compile Include="ViewControllers\Collections\CompositionalLayout\NSUtils.cs" />
     <Compile Include="Views\MovieCollectionViewCell.cs" />
     <Compile Include="Views\MovieCollectionViewCell.designer.cs">
       <DependentUpon>MovieCollectionViewCell.cs</DependentUpon>

--- a/samples/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/samples/Playground/Playground.iOS/Playground.iOS.csproj
@@ -170,6 +170,7 @@
     <InterfaceDefinition Include="ViewControllers\Controls\PhotoBrowserStoryboard.storyboard" />
     <InterfaceDefinition Include="ViewControllers\Components\ConnectivityPageStoryboard.storyboard" />
     <InterfaceDefinition Include="ViewControllers\Components\GesturesPageStoryboard.storyboard" />
+    <InterfaceDefinition Include="ViewControllers\Collections\CompositionalLayoutPageStoryboard.storyboard" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -288,6 +289,10 @@
     <Compile Include="ViewControllers\Components\GesturesPageViewController.cs" />
     <Compile Include="ViewControllers\Components\GesturesPageViewController.designer.cs">
       <DependentUpon>GesturesPageViewController.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ViewControllers\Collections\CompositionalLayoutPageViewController.cs" />
+    <Compile Include="ViewControllers\Collections\CompositionalLayoutPageViewController.designer.cs">
+      <DependentUpon>CompositionalLayoutPageViewController.cs</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/samples/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/samples/Playground/Playground.iOS/Playground.iOS.csproj
@@ -171,6 +171,7 @@
     <InterfaceDefinition Include="ViewControllers\Components\ConnectivityPageStoryboard.storyboard" />
     <InterfaceDefinition Include="ViewControllers\Components\GesturesPageStoryboard.storyboard" />
     <InterfaceDefinition Include="ViewControllers\Collections\CompositionalLayoutPageStoryboard.storyboard" />
+    <InterfaceDefinition Include="Views\Collections\DummyCell.xib" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
@@ -293,6 +294,10 @@
     <Compile Include="ViewControllers\Collections\CompositionalLayoutPageViewController.cs" />
     <Compile Include="ViewControllers\Collections\CompositionalLayoutPageViewController.designer.cs">
       <DependentUpon>CompositionalLayoutPageViewController.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Collections\DummyCell.cs" />
+    <Compile Include="Views\Collections\DummyCell.designer.cs">
+      <DependentUpon>DummyCell.cs</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/AdaptiveSectionsViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/AdaptiveSectionsViewController.cs
@@ -1,0 +1,121 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Linq;
+using Playground.iOS.Views.Collections;
+using Softeq.XToolkit.Common.Extensions;
+using UIKit;
+using static Playground.iOS.ViewControllers.Collections.CompositionalLayout.NSUtils;
+
+namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
+{
+    // Original sources on Swift:
+    // https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13/blob/master/Collection-View-Layout-iOS13/View%20Controllers/AdaptiveSectionsViewController.swift
+    //
+    // Full Apple Sample:
+    // https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/using_collection_view_compositional_layouts_and_diffable_data_sources
+    public class AdaptiveSectionsViewController : UIViewController
+    {
+        private UICollectionView? _collectionView;
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            Title = "Adaptive Sections";
+
+            ConfigureHierarchy();
+            ConfigureDataSource();
+        }
+
+        private void ConfigureHierarchy()
+        {
+            _collectionView = new UICollectionView(View.Bounds, CreateLayout());
+            _collectionView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+            _collectionView.BackgroundColor = UIColor.SystemBackgroundColor;
+            _collectionView.RegisterNibForCell(DummyCell.Nib, DummyCell.Key);
+            View.AddSubview(_collectionView);
+        }
+
+        private UICollectionViewLayout CreateLayout()
+        {
+            var layout = new UICollectionViewCompositionalLayout((sectionIndex, layoutEnvironment) =>
+            {
+                var sectionKind = EnumExtensions.FindByValue<Section>((byte) sectionIndex);
+                var columns = sectionKind.ColumnCount(layoutEnvironment.Container.EffectiveContentSize.Width);
+
+                var itemSize = NSCollectionLayoutSize.Create(
+                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                    height: NSCollectionLayoutDimension.CreateFractionalHeight(1.0f));
+                var item = NSCollectionLayoutItem.Create(itemSize);
+                item.ContentInsets = new NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2);
+
+                var groupHeight = layoutEnvironment.TraitCollection.VerticalSizeClass == UIUserInterfaceSizeClass.Compact
+                    ? NSCollectionLayoutDimension.CreateAbsolute(44)
+                    : NSCollectionLayoutDimension.CreateFractionalWidth(0.2f);
+
+                var groupSize = NSCollectionLayoutSize.Create(
+                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                    height: groupHeight);
+                var group = NSCollectionLayoutGroup.CreateHorizontal(layoutSize: groupSize, subitem: item, count: columns);
+
+                var section = NSCollectionLayoutSection.Create(group);
+                section.ContentInsets = new NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20);
+                return section;
+            });
+            return layout;
+        }
+
+        private void ConfigureDataSource()
+        {
+            var dataSource = new UICollectionViewDiffableDataSource<NS<Section>, NS<int>>(
+                collectionView: _collectionView,
+                cellProvider: (collectionView, indexPath, identifier) =>
+                {
+                    var cell = (DummyCell) collectionView.DequeueReusableCell(DummyCell.Key, indexPath);
+
+                    cell.Configure(((NS<int>) identifier).Value.ToString());
+
+                    return cell;
+                });
+
+            // initial data
+            const int ItemsPerSection = 6;
+            var snapshot = new NSDiffableDataSourceSnapshot<NS<Section>, NS<int>>();
+
+            EnumExtensions.Apply<Section>(section =>
+            {
+                var ns = new NS<Section>(section);
+                snapshot.AppendSections(new[] { ns });
+                var itemOffset = ((int) ns.Value) * ItemsPerSection;
+                var itemUpperbound = itemOffset + ItemsPerSection;
+                var items = Enumerable.Range(itemOffset, itemUpperbound).Select(x => new NS<int>(x)).ToArray();
+                snapshot.AppendItems(items);
+            });
+            dataSource.ApplySnapshot(snapshot, animatingDifferences: false);
+        }
+    }
+
+    internal enum Section
+    {
+        List = 0,
+        Grid3 = 1,
+        Grid5 = 2
+    }
+
+    internal static class SectionExtensions
+    {
+        internal static int ColumnCount(this Section self, nfloat width)
+        {
+            var wideMode = width > 800;
+            return self switch
+            {
+                Section.List => wideMode ? 2 : 1,
+                Section.Grid3 => wideMode ? 6 : 3,
+                Section.Grid5 => wideMode ? 10 : 5,
+                _ => throw new NotImplementedException()
+            };
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/AdaptiveSectionsViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/AdaptiveSectionsViewController.cs
@@ -7,14 +7,13 @@ using Playground.iOS.Views.Collections;
 using Softeq.XToolkit.Common.Extensions;
 using UIKit;
 using static Playground.iOS.ViewControllers.Collections.CompositionalLayout.NSUtils;
+using static UIKit.NSCollectionLayoutDimension;
+using Section = Playground.iOS.ViewControllers.Collections.CompositionalLayout.AdaptiveSectionsViewController.Section;
 
 namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
 {
     // Original sources on Swift:
     // https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13/blob/master/Collection-View-Layout-iOS13/View%20Controllers/AdaptiveSectionsViewController.swift
-    //
-    // Full Apple Sample:
-    // https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/using_collection_view_compositional_layouts_and_diffable_data_sources
     public class AdaptiveSectionsViewController : UIViewController
     {
         private UICollectionView? _collectionView;
@@ -22,8 +21,6 @@ namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
         public override void ViewDidLoad()
         {
             base.ViewDidLoad();
-
-            Title = "Adaptive Sections";
 
             ConfigureHierarchy();
             ConfigureDataSource();
@@ -46,17 +43,17 @@ namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
                 var columns = sectionKind.ColumnCount(layoutEnvironment.Container.EffectiveContentSize.Width);
 
                 var itemSize = NSCollectionLayoutSize.Create(
-                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
-                    height: NSCollectionLayoutDimension.CreateFractionalHeight(1.0f));
+                    width: CreateFractionalWidth(1.0f),
+                    height: CreateFractionalHeight(1.0f));
                 var item = NSCollectionLayoutItem.Create(itemSize);
                 item.ContentInsets = new NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2);
 
                 var groupHeight = layoutEnvironment.TraitCollection.VerticalSizeClass == UIUserInterfaceSizeClass.Compact
-                    ? NSCollectionLayoutDimension.CreateAbsolute(44)
-                    : NSCollectionLayoutDimension.CreateFractionalWidth(0.2f);
+                    ? CreateAbsolute(44)
+                    : CreateFractionalWidth(0.2f);
 
                 var groupSize = NSCollectionLayoutSize.Create(
-                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                    width: CreateFractionalWidth(1.0f),
                     height: groupHeight);
                 var group = NSCollectionLayoutGroup.CreateHorizontal(layoutSize: groupSize, subitem: item, count: columns);
 
@@ -95,13 +92,13 @@ namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
             });
             dataSource.ApplySnapshot(snapshot, animatingDifferences: false);
         }
-    }
 
-    internal enum Section
-    {
-        List = 0,
-        Grid3 = 1,
-        Grid5 = 2
+        internal enum Section
+        {
+            List = 0,
+            Grid3 = 1,
+            Grid5 = 2
+        }
     }
 
     internal static class SectionExtensions

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/NSUtils.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/NSUtils.cs
@@ -1,0 +1,23 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Foundation;
+
+namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
+{
+    internal static class NSUtils
+    {
+        // YP: Wrap value to use as NSObject
+        // Can be small performance degradation, only for demo.
+        // Not recommended for production.
+        internal class NS<T> : NSObject
+        {
+            public NS(T value)
+            {
+                Value = value;
+            }
+
+            public T Value { get; }
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/NestedGroupsViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayout/NestedGroupsViewController.cs
@@ -1,0 +1,135 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Linq;
+using Playground.iOS.Views.Collections;
+using UIKit;
+using static Playground.iOS.ViewControllers.Collections.CompositionalLayout.NSUtils;
+using static UIKit.NSCollectionLayoutDimension;
+
+namespace Playground.iOS.ViewControllers.Collections.CompositionalLayout
+{
+    // Original sources on Swift:
+    // https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13/blob/master/Collection-View-Layout-iOS13/View%20Controllers/NestedGroupsViewController.swift
+    public class NestedGroupsViewController : UIViewController
+    {
+        private UICollectionView? _collectionView;
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            ConfigureHierarchy();
+            ConfigureDataSource();
+        }
+
+        private void ConfigureHierarchy()
+        {
+            _collectionView = new UICollectionView(View.Bounds, CreateLayout());
+            _collectionView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+            _collectionView.BackgroundColor = UIColor.SystemBackgroundColor;
+            _collectionView.RegisterNibForCell(DummyCell.Nib, DummyCell.Key);
+            View.AddSubview(_collectionView);
+        }
+
+        //   +---------------------------------------------------+
+        //   | +-----------------------------------------------+ |
+        //   | |                                               | |
+        //   | |                                               | |
+        //   | |                       0                       | |  <- topItem
+        //   | |                                               | |
+        //   | |                                               | |
+        //   | +-----------------------------------------------+ |
+        //   | +---------------------------------+ +-----------+ |
+        //   | |                                 | |           | |
+        //   | |                                 | |           | |
+        //   | |                                 | |     2     | |  <- trailingItem
+        //   | |                                 | |           | |
+        //   | |                                 | |           | |
+        //   | |                                 | +-----------+ |
+        //   | |               1                 |               |  <- bottomNestedGroup
+        //   | |                                 | +-----------+ |
+        //   | |                                 | |           | |
+        //   | |                                 | |           | |
+        //   | |                                 | |     3     | |  <- trailingItem
+        //   | |                                 | |           | |
+        //   | |                                 | |           | |
+        //   | +---------------------------------+ +-----------+ |
+        //   +---------------------------------------------------+
+        //                leadingItem              trailingGroup
+        private UICollectionViewLayout CreateLayout()
+        {
+            var layout = new UICollectionViewCompositionalLayout((sectionIndex, layoutEnvironment) =>
+            {
+                var leadingItem = NSCollectionLayoutItem.Create(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(0.7f),
+                        height: CreateFractionalHeight(1.0f)));
+                leadingItem.ContentInsets = new NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10);
+
+                var trailingItem = NSCollectionLayoutItem.Create(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(1.0f),
+                        height: CreateFractionalHeight(0.3f)));
+                trailingItem.ContentInsets = new NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10);
+
+                var trailingGroup = NSCollectionLayoutGroup.CreateVertical(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(0.3f),
+                        height: CreateFractionalHeight(1.0f)),
+                    subitem: trailingItem,
+                    count: 2);
+
+                var bottomNestedGroup = NSCollectionLayoutGroup.CreateHorizontal(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(1.0f),
+                        height: CreateFractionalHeight(0.6f)),
+                    subitems: new[] { leadingItem, trailingGroup });
+
+                var topItem = NSCollectionLayoutItem.Create(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(1.0f),
+                        height: CreateFractionalHeight(0.3f)));
+                topItem.ContentInsets = new NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10);
+
+                var nestedGroup = NSCollectionLayoutGroup.CreateVertical(
+                    layoutSize: NSCollectionLayoutSize.Create(
+                        width: CreateFractionalWidth(1.0f),
+                        height: CreateFractionalHeight(0.4f)),
+                    subitems: new[] { topItem, bottomNestedGroup });
+
+                var section = NSCollectionLayoutSection.Create(group: nestedGroup);
+
+                section.OrthogonalScrollingBehavior = UICollectionLayoutSectionOrthogonalScrollingBehavior.Continuous;
+
+                return section;
+            });
+            return layout;
+        }
+
+        private void ConfigureDataSource()
+        {
+            var dataSource = new UICollectionViewDiffableDataSource<NS<Section>, NS<int>>(
+                collectionView: _collectionView,
+                cellProvider: (collectionView, indexPath, identifier) =>
+                {
+                    var cell = (DummyCell) collectionView.DequeueReusableCell(DummyCell.Key, indexPath);
+
+                    cell.Configure(((NS<int>) identifier).Value.ToString());
+
+                    return cell;
+                });
+
+            // initial data
+            var snapshot = new NSDiffableDataSourceSnapshot<NS<Section>, NS<int>>();
+            snapshot.AppendSections(new[] { new NS<Section>(Section.Main) });
+            snapshot.AppendItems(Enumerable.Range(0, 100).Select(x => new NS<int>(x)).ToArray());
+            dataSource.ApplySnapshot(snapshot, animatingDifferences: false);
+        }
+
+        internal enum Section
+        {
+            Main
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageStoryboard.storyboard
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageStoryboard.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Compositional Layout Page View Controller-->
+        <scene sceneID="Wte-JY-aFV">
+            <objects>
+                <viewController storyboardIdentifier="CompositionalLayoutPageViewController" id="kEM-Il-q3x" customClass="CompositionalLayoutPageViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="OnM-tY-4Hq"/>
+                        <viewControllerLayoutGuide type="bottom" id="9io-pc-mJ2"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="haZ-w3-xVx">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YTQ-aB-7WF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="220" y="44"/>
+        </scene>
+    </scenes>
+</document>

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
@@ -10,6 +10,8 @@ using UIKit;
 
 namespace Playground.iOS.ViewControllers.Collections
 {
+    // Full Apple Sample:
+    // https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/using_collection_view_compositional_layouts_and_diffable_data_sources
     public partial class CompositionalLayoutPageViewController : ViewControllerBase<CompositionalLayoutPageViewModel>
     {
         public CompositionalLayoutPageViewController(IntPtr handle)
@@ -27,7 +29,14 @@ namespace Playground.iOS.ViewControllers.Collections
             {
                 ViewControllers = new UIViewController[]
                 {
-                    new AdaptiveSectionsViewController()
+                    new AdaptiveSectionsViewController
+                    {
+                        TabBarItem = new UITabBarItem("Adaptive Sections", null, 0)
+                    },
+                    new NestedGroupsViewController
+                    {
+                        TabBarItem = new UITabBarItem("Nested Groups", null, 0)
+                    },
                 }
             };
 

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
@@ -1,0 +1,17 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Playground.ViewModels.Collections;
+using Softeq.XToolkit.WhiteLabel.iOS;
+
+namespace Playground.iOS.ViewControllers.Collections
+{
+    public partial class CompositionalLayoutPageViewController : ViewControllerBase<CompositionalLayoutPageViewModel>
+    {
+        public CompositionalLayoutPageViewController(IntPtr handle)
+            : base(handle)
+        {
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
@@ -2,16 +2,136 @@
 // http://www.softeq.com
 
 using System;
+using System.Linq;
+using Foundation;
+using Playground.iOS.Views.Collections;
 using Playground.ViewModels.Collections;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.WhiteLabel.iOS;
+using UIKit;
 
 namespace Playground.iOS.ViewControllers.Collections
 {
+    /// <summary>
+    ///     Was ported from Swift:
+    ///     https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13/blob/master/Collection-View-Layout-iOS13/View%20Controllers/AdaptiveSectionsViewController.swift
+    /// </summary>
     public partial class CompositionalLayoutPageViewController : ViewControllerBase<CompositionalLayoutPageViewModel>
     {
+        private UICollectionView _collectionView;
+
         public CompositionalLayoutPageViewController(IntPtr handle)
             : base(handle)
         {
         }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            NavigationItem.Title = "Adaptive Sections";
+
+            ConfigureHierarchy();
+            ConfigureDataSource();
+        }
+
+        private void ConfigureHierarchy()
+        {
+            _collectionView = new UICollectionView(View.Bounds, CreateLayout());
+            _collectionView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+            _collectionView.BackgroundColor = UIColor.SystemBackgroundColor;
+            _collectionView.RegisterNibForCell(DummyCell.Nib, DummyCell.Key);
+            View.AddSubview(_collectionView);
+        }
+
+        private UICollectionViewLayout CreateLayout()
+        {
+            var layout = new UICollectionViewCompositionalLayout((sectionIndex, layoutEnvironment) =>
+            {
+                var sectionKind = EnumExtensions.FindByValue<Section>((byte) sectionIndex);
+                var columns = sectionKind.ColumnCount(layoutEnvironment.Container.EffectiveContentSize.Width);
+
+                var itemSize = NSCollectionLayoutSize.Create(
+                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                    height: NSCollectionLayoutDimension.CreateFractionalHeight(1.0f));
+                var item = NSCollectionLayoutItem.Create(itemSize);
+                item.ContentInsets = new NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2);
+
+                var groupHeight = layoutEnvironment.TraitCollection.VerticalSizeClass == UIUserInterfaceSizeClass.Compact
+                    ? NSCollectionLayoutDimension.CreateAbsolute(44)
+                    : NSCollectionLayoutDimension.CreateFractionalWidth(0.2f);
+
+                var groupSize = NSCollectionLayoutSize.Create(
+                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                    height: groupHeight);
+                var group = NSCollectionLayoutGroup.CreateHorizontal(layoutSize: groupSize, subitem: item, count: columns);
+
+                var section = NSCollectionLayoutSection.Create(group);
+                section.ContentInsets = new NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20);
+                return section;
+            });
+            return layout;
+        }
+
+        private void ConfigureDataSource()
+        {
+            var dataSource = new UICollectionViewDiffableDataSource<NS<Section>, NS<int>>(
+                collectionView: _collectionView,
+                cellProvider: (collectionView, indexPath, identifier) =>
+                {
+                    var cell = (DummyCell) collectionView.DequeueReusableCell(DummyCell.Key, indexPath);
+
+                    cell.Configure(((NS<int>) identifier).Value.ToString());
+
+                    return cell;
+                });
+
+            var itemsPerSection = 6;
+            var snapshot = new NSDiffableDataSourceSnapshot<NS<Section>, NS<int>>();
+
+            EnumExtensions.Apply<Section>(section =>
+            {
+                var ns = new NS<Section>(section);
+                snapshot.AppendSections(new[] { ns });
+                var itemOffset = ((int) ns.Value) * itemsPerSection;
+                var itemUpperbound = itemOffset + itemsPerSection;
+                var items = Enumerable.Range(itemOffset, itemUpperbound).Select(x => new NS<int>(x)).ToArray();
+                snapshot.AppendItems(items);
+            });
+            dataSource.ApplySnapshot(snapshot, animatingDifferences: false);
+        }
+    }
+
+    internal enum Section
+    {
+        List = 0,
+        Grid3 = 1,
+        Grid5 = 2
+    }
+
+    internal static class SectionExtensions
+    {
+        internal static int ColumnCount(this Section self, nfloat width)
+        {
+            var wideMode = width > 800;
+            return self switch
+            {
+                Section.List => wideMode ? 2 : 1,
+                Section.Grid3 => wideMode ? 6 : 3,
+                Section.Grid5 => wideMode ? 10 : 5,
+                _ => throw new NotImplementedException()
+            };
+        }
+    }
+
+    // YP: Wrap value to use as NSObject
+    internal class NS<T> : NSObject
+    {
+        public NS(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
     }
 }

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.cs
@@ -2,24 +2,16 @@
 // http://www.softeq.com
 
 using System;
-using System.Linq;
-using Foundation;
-using Playground.iOS.Views.Collections;
+using Playground.iOS.ViewControllers.Collections.CompositionalLayout;
 using Playground.ViewModels.Collections;
-using Softeq.XToolkit.Common.Extensions;
+using Softeq.XToolkit.Common.iOS.Extensions;
 using Softeq.XToolkit.WhiteLabel.iOS;
 using UIKit;
 
 namespace Playground.iOS.ViewControllers.Collections
 {
-    /// <summary>
-    ///     Was ported from Swift:
-    ///     https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13/blob/master/Collection-View-Layout-iOS13/View%20Controllers/AdaptiveSectionsViewController.swift
-    /// </summary>
     public partial class CompositionalLayoutPageViewController : ViewControllerBase<CompositionalLayoutPageViewModel>
     {
-        private UICollectionView _collectionView;
-
         public CompositionalLayoutPageViewController(IntPtr handle)
             : base(handle)
         {
@@ -29,109 +21,17 @@ namespace Playground.iOS.ViewControllers.Collections
         {
             base.ViewDidLoad();
 
-            NavigationItem.Title = "Adaptive Sections";
+            NavigationItem.Title = "Compositional Layout";
 
-            ConfigureHierarchy();
-            ConfigureDataSource();
-        }
-
-        private void ConfigureHierarchy()
-        {
-            _collectionView = new UICollectionView(View.Bounds, CreateLayout());
-            _collectionView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
-            _collectionView.BackgroundColor = UIColor.SystemBackgroundColor;
-            _collectionView.RegisterNibForCell(DummyCell.Nib, DummyCell.Key);
-            View.AddSubview(_collectionView);
-        }
-
-        private UICollectionViewLayout CreateLayout()
-        {
-            var layout = new UICollectionViewCompositionalLayout((sectionIndex, layoutEnvironment) =>
+            var tabBarViewController = new UITabBarController
             {
-                var sectionKind = EnumExtensions.FindByValue<Section>((byte) sectionIndex);
-                var columns = sectionKind.ColumnCount(layoutEnvironment.Container.EffectiveContentSize.Width);
-
-                var itemSize = NSCollectionLayoutSize.Create(
-                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
-                    height: NSCollectionLayoutDimension.CreateFractionalHeight(1.0f));
-                var item = NSCollectionLayoutItem.Create(itemSize);
-                item.ContentInsets = new NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 2, trailing: 2);
-
-                var groupHeight = layoutEnvironment.TraitCollection.VerticalSizeClass == UIUserInterfaceSizeClass.Compact
-                    ? NSCollectionLayoutDimension.CreateAbsolute(44)
-                    : NSCollectionLayoutDimension.CreateFractionalWidth(0.2f);
-
-                var groupSize = NSCollectionLayoutSize.Create(
-                    width: NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
-                    height: groupHeight);
-                var group = NSCollectionLayoutGroup.CreateHorizontal(layoutSize: groupSize, subitem: item, count: columns);
-
-                var section = NSCollectionLayoutSection.Create(group);
-                section.ContentInsets = new NSDirectionalEdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20);
-                return section;
-            });
-            return layout;
-        }
-
-        private void ConfigureDataSource()
-        {
-            var dataSource = new UICollectionViewDiffableDataSource<NS<Section>, NS<int>>(
-                collectionView: _collectionView,
-                cellProvider: (collectionView, indexPath, identifier) =>
+                ViewControllers = new UIViewController[]
                 {
-                    var cell = (DummyCell) collectionView.DequeueReusableCell(DummyCell.Key, indexPath);
-
-                    cell.Configure(((NS<int>) identifier).Value.ToString());
-
-                    return cell;
-                });
-
-            var itemsPerSection = 6;
-            var snapshot = new NSDiffableDataSourceSnapshot<NS<Section>, NS<int>>();
-
-            EnumExtensions.Apply<Section>(section =>
-            {
-                var ns = new NS<Section>(section);
-                snapshot.AppendSections(new[] { ns });
-                var itemOffset = ((int) ns.Value) * itemsPerSection;
-                var itemUpperbound = itemOffset + itemsPerSection;
-                var items = Enumerable.Range(itemOffset, itemUpperbound).Select(x => new NS<int>(x)).ToArray();
-                snapshot.AppendItems(items);
-            });
-            dataSource.ApplySnapshot(snapshot, animatingDifferences: false);
-        }
-    }
-
-    internal enum Section
-    {
-        List = 0,
-        Grid3 = 1,
-        Grid5 = 2
-    }
-
-    internal static class SectionExtensions
-    {
-        internal static int ColumnCount(this Section self, nfloat width)
-        {
-            var wideMode = width > 800;
-            return self switch
-            {
-                Section.List => wideMode ? 2 : 1,
-                Section.Grid3 => wideMode ? 6 : 3,
-                Section.Grid5 => wideMode ? 10 : 5,
-                _ => throw new NotImplementedException()
+                    new AdaptiveSectionsViewController()
+                }
             };
-        }
-    }
 
-    // YP: Wrap value to use as NSObject
-    internal class NS<T> : NSObject
-    {
-        public NS(T value)
-        {
-            Value = value;
+            tabBarViewController.AddAsChildWithConstraints(this);
         }
-
-        public T Value { get; }
     }
 }

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.designer.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/CompositionalLayoutPageViewController.designer.cs
@@ -1,0 +1,19 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio to store outlets and
+// actions made in the UI designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+using System.CodeDom.Compiler;
+
+namespace Playground.iOS.ViewControllers.Collections
+{
+    [Register(nameof(CompositionalLayoutPageViewController))]
+    partial class CompositionalLayoutPageViewController
+    {
+        void ReleaseDesignerOutlets()
+        {
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/ViewControllers/Collections/GroupedListPageViewController.cs
+++ b/samples/Playground/Playground.iOS/ViewControllers/Collections/GroupedListPageViewController.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Foundation;
 using Playground.iOS.Views.Table;
 using Playground.ViewModels.Collections;
 using Playground.ViewModels.Collections.Products;
@@ -16,7 +15,6 @@ using UIKit;
 
 namespace Playground.iOS.ViewControllers.Collections
 {
-    [Register(nameof(GroupedListPageViewController))]
     public partial class GroupedListPageViewController : ViewControllerBase<GroupedTablePageViewModel>
     {
         public GroupedListPageViewController(IntPtr handle) : base(handle)

--- a/samples/Playground/Playground.iOS/Views/Collections/DummyCell.cs
+++ b/samples/Playground/Playground.iOS/Views/Collections/DummyCell.cs
@@ -1,0 +1,35 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Foundation;
+using UIKit;
+
+namespace Playground.iOS.Views.Collections
+{
+    public partial class DummyCell : UICollectionViewCell
+    {
+        public static readonly NSString Key = new NSString(nameof(DummyCell));
+        public static readonly UINib Nib;
+
+        static DummyCell() => Nib = UINib.FromName(Key, NSBundle.MainBundle);
+
+        protected DummyCell(IntPtr handle)
+            : base(handle)
+        {
+        }
+
+        public void Configure(string text)
+        {
+            TitleLabel.Text = text;
+        }
+
+        public override void AwakeFromNib()
+        {
+            base.AwakeFromNib();
+
+            Layer.BorderColor = UIColor.Black.CGColor;
+            Layer.BorderWidth = 1.0f;
+        }
+    }
+}

--- a/samples/Playground/Playground.iOS/Views/Collections/DummyCell.designer.cs
+++ b/samples/Playground/Playground.iOS/Views/Collections/DummyCell.designer.cs
@@ -1,0 +1,26 @@
+// WARNING
+//
+// This file has been generated automatically by Visual Studio to store outlets and
+// actions made in the UI designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+using Foundation;
+using System.CodeDom.Compiler;
+
+namespace Playground.iOS.Views.Collections
+{
+	[Register ("DummyCell")]
+	partial class DummyCell
+	{
+		[Outlet]
+		UIKit.UILabel TitleLabel { get; set; }
+		
+		void ReleaseDesignerOutlets ()
+		{
+			if (TitleLabel != null) {
+				TitleLabel.Dispose ();
+				TitleLabel = null;
+			}
+		}
+	}
+}

--- a/samples/Playground/Playground.iOS/Views/Collections/DummyCell.xib
+++ b/samples/Playground/Playground.iOS/Views/Collections/DummyCell.xib
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="cZE-iV-UFb" customClass="DummyCell">
+            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXl-Lz-Cae">
+                        <rect key="frame" x="43" y="53.5" width="42" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="wXl-Lz-Cae" firstAttribute="centerX" secondItem="cZE-iV-UFb" secondAttribute="centerX" id="RWy-Lw-aEe"/>
+                <constraint firstItem="wXl-Lz-Cae" firstAttribute="centerY" secondItem="cZE-iV-UFb" secondAttribute="centerY" id="sRu-Vf-5ct"/>
+            </constraints>
+            <size key="customSize" width="128" height="128"/>
+            <connections>
+                <outlet property="TitleLabel" destination="wXl-Lz-Cae" id="3U2-3E-te7"/>
+            </connections>
+            <point key="canvasLocation" x="89.855072463768124" y="79.6875"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/samples/Playground/Playground.iOS/Views/Table/GroupedTableHeaderView.cs
+++ b/samples/Playground/Playground.iOS/Views/Table/GroupedTableHeaderView.cs
@@ -1,7 +1,7 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-﻿using System;
+using System;
 using CoreGraphics;
 using Foundation;
 using Playground.ViewModels.Collections.Products;
@@ -11,7 +11,6 @@ using UIKit;
 
 namespace Playground.iOS.Views.Table
 {
-    [Register(nameof(GroupedTableHeaderView))]
     public partial class GroupedTableHeaderView : BindableTableViewHeaderFooterView<ProductHeaderViewModel>
     {
         #region init

--- a/samples/Playground/Playground/ViewModels/Collections/CompositionalLayoutPageViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/Collections/CompositionalLayoutPageViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Softeq.XToolkit.WhiteLabel.Mvvm;
+
+namespace Playground.ViewModels.Collections
+{
+    public class CompositionalLayoutPageViewModel : ViewModelBase
+    {
+        public CompositionalLayoutPageViewModel()
+        {
+        }
+    }
+}

--- a/samples/Playground/Playground/ViewModels/MainPageViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/MainPageViewModel.cs
@@ -139,6 +139,15 @@ namespace Playground.ViewModels
                     }),
                     "Observable grouped collection")),
 
+                (Category.Collections, new CommandAction(
+                    new RelayCommand(() =>
+                    {
+                        _pageNavigationService
+                            .For<CompositionalLayoutPageViewModel>()
+                            .Navigate();
+                    }),
+                    "Compositional Layout")),
+
                 (Category.Controls, new CommandAction(
                     new RelayCommand(() =>
                     {


### PR DESCRIPTION
### Description

Added two samples of using Compositional Layout in iOS 13.

#### Resources
- [Apple Sources](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/using_collection_view_compositional_layouts_and_diffable_data_sources)
- [Swift sample](https://github.com/TikhonovAlexander/Collection-View-Layout-iOS13)
- [Compositional Layout in iOS 13. Fundamental](https://habr.com/ru/post/495076/)

### API Changes
Added:
- `EnumExtensions.FindByValue<TEnum>(byte value)` - Get enumeration that corresponding value.
- Added `Enum` constraint to `EnumExtensions` generic methods.

### Platforms Affected

- Core (all platforms)
- iOS

### Screenshots

<img src="https://user-images.githubusercontent.com/766193/79915198-34a85d80-842f-11ea-8f6d-44f674a11fc6.gif" width="300">



### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
