### PR TITLE
Featture/setcommand_on_ui_thread

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Softeq.XToolkit.Bindings.Droid.csproj
+++ b/Softeq.XToolkit.Bindings.Droid/Softeq.XToolkit.Bindings.Droid.csproj
@@ -71,6 +71,10 @@
       <Project>{0F1F09A8-9CDB-4933-AA1B-898AB43D394C}</Project>
       <Name>Softeq.XToolkit.Bindings</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Softeq.XToolkit.Common.Droid\Softeq.XToolkit.Common.Droid.csproj">
+      <Project>{18d3fdc1-b0a1-401e-87f2-1c43034e610c}</Project>
+      <Name>Softeq.XToolkit.Common.Droid</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj">
       <Project>{24588814-B93D-4528-8917-9C2A3C4E85CA}</Project>
       <Name>Softeq.XToolkit.Common</Name>

--- a/Softeq.XToolkit.Bindings.Tests/MockBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings.Tests/MockBindingFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Windows.Input;
 using NSubstitute;
 
 namespace Softeq.XToolkit.Bindings.Tests
@@ -10,26 +11,36 @@ namespace Softeq.XToolkit.Bindings.Tests
     internal class MockBindingFactory : BindingFactoryBase
     {
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
-            object source, Expression<Func<TSource>> sourcePropertyExpression, bool? resolveTopField,
-            object target = null, Expression<Func<TTarget>> targetPropertyExpression = null,
-            BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default, TSource targetNullValue = default)
-        {
-            return Substitute.For<Binding<TSource, TTarget>>();
-        }
-
-        public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
-            object source, Expression<Func<TSource>> sourcePropertyExpression, object target = null,
+            object source,
+            Expression<Func<TSource>> sourcePropertyExpression,
+            bool? resolveTopField,
+            object target = null,
             Expression<Func<TTarget>> targetPropertyExpression = null,
-            BindingMode mode = BindingMode.Default, TSource fallbackValue = default,
+            BindingMode mode = BindingMode.Default,
+            TSource fallbackValue = default,
             TSource targetNullValue = default)
         {
             return Substitute.For<Binding<TSource, TTarget>>();
         }
 
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
-            object source, string sourcePropertyName, object target = null,
-            string targetPropertyName = null, BindingMode mode = BindingMode.Default,
+            object source,
+            Expression<Func<TSource>> sourcePropertyExpression,
+            object target = null,
+            Expression<Func<TTarget>> targetPropertyExpression = null,
+            BindingMode mode = BindingMode.Default,
+            TSource fallbackValue = default,
+            TSource targetNullValue = default)
+        {
+            return Substitute.For<Binding<TSource, TTarget>>();
+        }
+
+        public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
+            object source,
+            string sourcePropertyName,
+            object target = null,
+            string targetPropertyName = null,
+            BindingMode mode = BindingMode.Default,
             TSource fallbackValue = default,
             TSource targetNullValue = default)
         {
@@ -39,6 +50,10 @@ namespace Softeq.XToolkit.Bindings.Tests
         public override string GetDefaultEventNameForControl(Type type)
         {
             return null;
+        }
+
+        public override void HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T> commandParameterBinding)
+        {
         }
     }
 }

--- a/Softeq.XToolkit.Bindings/BindingExtensions.cs
+++ b/Softeq.XToolkit.Bindings/BindingExtensions.cs
@@ -364,7 +364,7 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleEnabledProperty(element, t, command);
+            HandleCommandCanExecute(element, command);
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleEnabledProperty(element, t, command);
+            HandleCommandCanExecute(element, command);
         }
 
         /// <summary>
@@ -430,7 +430,7 @@ namespace Softeq.XToolkit.Bindings
                 return;
             }
 
-            HandleEnabledProperty(element, t, command, castedBinding);
+            HandleCommandCanExecute(element, command, castedBinding);
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleEnabledProperty(element, t, command);
+            HandleCommandCanExecute(element, command);
         }
 
         /// <summary>
@@ -483,7 +483,7 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleEnabledProperty(element, t, command);
+            HandleCommandCanExecute(element, command);
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace Softeq.XToolkit.Bindings
                 return;
             }
 
-            HandleEnabledProperty(element, t, command, castedBinding);
+            HandleCommandCanExecute(element, command, castedBinding);
         }
 
         /// <summary>
@@ -543,7 +543,7 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleEnabledProperty(element, t, command);
+            HandleCommandCanExecute(element, command);
 
             return Disposable.Create(() => e.RemoveEventHandler(element, handler));
         }
@@ -637,45 +637,19 @@ namespace Softeq.XToolkit.Bindings
             return info;
         }
 
-        private static void HandleEnabledProperty(
+        private static void HandleCommandCanExecute(
             object element,
-            Type elementType,
             ICommand command)
         {
-            HandleEnabledProperty<object>(element, elementType, command);
+            HandleCommandCanExecute<object>(element, command);
         }
 
-        private static void HandleEnabledProperty<T>(
+        private static void HandleCommandCanExecute<T>(
             object element,
-            Type elementType,
             ICommand command,
             Binding<T, T> commandParameterBinding = null)
         {
-            var enabledProperty = elementType.GetRuntimeProperty("Enabled");
-
-            if (enabledProperty == null)
-            {
-                return;
-            }
-
-            var commandParameter = commandParameterBinding == null ? default : commandParameterBinding.Value;
-
-            enabledProperty.SetValue(element, command.CanExecute(commandParameter));
-
-            // set by CanExecute
-            command.CanExecuteChanged += (s, args) =>
-            {
-                enabledProperty.SetValue(element, command.CanExecute(commandParameter));
-            };
-
-            // set by bindable command parameter
-            if (commandParameterBinding != null)
-            {
-                commandParameterBinding.ValueChanged += (s, args) =>
-                {
-                    enabledProperty.SetValue(element, command.CanExecute(commandParameterBinding.Value));
-                };
-            }
+            _bindingFactory.HandleCommandCanExecute(element, command, commandParameterBinding);
         }
     }
 }

--- a/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
+++ b/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
@@ -45,6 +45,12 @@ namespace Softeq.XToolkit.Bindings
         public abstract string GetDefaultEventNameForControl(Type type);
 
         /// <inheritdoc />
+        public abstract void HandleCommandCanExecute<T>(
+            object element,
+            ICommand command,
+            Binding<T, T> commandParameterBinding);
+
+        /// <inheritdoc />
         public virtual Delegate GetCommandHandler(
             EventInfo info,
             string eventName,

--- a/Softeq.XToolkit.Bindings/IBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings/IBindingFactory.cs
@@ -228,5 +228,17 @@ namespace Softeq.XToolkit.Bindings
             Binding<T, T> castedBinding);
 
         string GetDefaultEventNameForControl(Type type);
+
+        /// <summary>
+        ///     Provides the way for command to give a feedback to the element when CanExecuteChanged event is triggered.
+        /// </summary>
+        /// <param name="element">An object that assigned with a command.</param>
+        /// <param name="command">A <see cref="T:System.Windows.Input.ICommand"/> assigned to an object.</param>
+        /// <param name="commandParameterBinding">
+        ///     A <see cref="Binding{TSource, TTarget}" /> instance subscribed to the CommandParameter
+        ///     that will passed to the <see cref="T:System.Windows.Input.ICommand"/>. Used to determine new value of CanExecute.
+        /// </param>
+        /// <typeparam name="T">Type of command parameter.</typeparam>
+        void HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T> commandParameterBinding);
     }
 }

--- a/Softeq.XToolkit.Common.Droid/Extensions/ViewExtensions.cs
+++ b/Softeq.XToolkit.Common.Droid/Extensions/ViewExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
+using Android.OS;
 using Android.Views;
 
 namespace Softeq.XToolkit.Common.Droid.Extensions
@@ -17,6 +19,23 @@ namespace Softeq.XToolkit.Common.Droid.Extensions
         public static void RemoveFromParent(this View view)
         {
             ((ViewGroup) view.Parent)?.RemoveView(view);
+        }
+
+        /// <summary>
+        ///     Executes provided action on UI thread.
+        /// </summary>
+        /// <param name="view">Instance of a <see cref="T:Android.Views.View"/>.</param>
+        /// <param name="action">Action to be executed.</param>
+        public static void BeginInvokeOnMainThread(this View view, Action action)
+        {
+            if (Looper.MainLooper.IsCurrentThread)
+            {
+                action.Invoke();
+            }
+            else
+            {
+                view.Post(action);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

SetCommand() extension methods now use UI thread to update "Enabled" properties of UI elements

### Issues Resolved

- fixes #311 

### API Changes

Added:
 - void BeginInvokeOnMainThread(this Android.Views.View view, Action action);
 - void IBindingFactory.HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T> commandParameterBinding);

### Platforms Affected

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes

SetCommand() now updates "Enabled" property only for UIControl elements (on iOS) and View elements (on Android).

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
