### PR TITLE
Feature/ios avatar styles - add text color

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/Helpers/AvatarImageHelpers.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Helpers/AvatarImageHelpers.cs
@@ -20,7 +20,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Helpers
             return CreateCircleImage(
                 styles.Size,
                 backgroundColor.UIColorFromHex().CGColor,
-                () => DrawText(text, styles.Size, styles.Font));
+                () => DrawText(text, styles.Size, styles.Font, styles.TextColor));
         }
 
         private static UIImage CreateCircleImage(Size size, CGColor backgroundColor, Action drawOnForegroundAction)
@@ -43,11 +43,11 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Helpers
             return image;
         }
 
-        private static void DrawText(string text, Size size, UIFont font)
+        private static void DrawText(string text, Size size, UIFont font, UIColor textColor)
         {
             var attributedText = text.BuildAttributedString()
                 .Font(font)
-                .Foreground(UIColor.White);
+                .Foreground(textColor);
 
             var textSize = attributedText.Size;
             var textPoint = new CGPoint(
@@ -63,10 +63,12 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Helpers
                 Size = size;
                 Font = font;
                 BackgroundHexColors = backgroundHexColors;
+                TextColor = UIColor.White;
             }
 
             public Size Size { get; set; }
             public UIFont Font { get; set; }
+            public UIColor TextColor { get; set; }
             public string[] BackgroundHexColors { get; set; }
         }
     }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Helpers/AvatarImageHelpers.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Helpers/AvatarImageHelpers.cs
@@ -51,8 +51,8 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Helpers
 
             var textSize = attributedText.Size;
             var textPoint = new CGPoint(
-                size.Width / 2f - textSize.Width / 2f,
-                size.Height / 2f - textSize.Height / 2f);
+                (size.Width / 2f) - (textSize.Width / 2f),
+                (size.Height / 2f) - (textSize.Height / 2f));
             attributedText.DrawString(textPoint);
         }
 


### PR DESCRIPTION
### Description

Added new property to configure TextColor for draw Avatar placeholder image.

### API Changes

Added:
 - UIColor AvatarImageHelpers.AvatarStyles.TextColor

### Platforms Affected

- iOS

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
