### PR TITLE
Rework Bootstrapper responsibility and application initialization lifecycle

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/MainApplicationBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/MainApplicationBase.cs
@@ -9,6 +9,7 @@ using Plugin.CurrentActivity;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.Droid;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Droid.Providers;
 using Softeq.XToolkit.WhiteLabel.Threading;
 
@@ -24,8 +25,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             : base(handle, transfer)
         {
         }
-
-        protected abstract IBootstrapper Bootstrapper { get; }
 
         public override void OnCreate()
         {
@@ -66,6 +65,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             CrossCurrentActivity.Current.Init(this);
         }
 
+        protected abstract IBootstrapper CreateBootstrapper();
+
         protected virtual void InitializeWhiteLabelRuntime()
         {
             // Init Bindings
@@ -75,7 +76,16 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             PlatformProvider.Current = new DroidPlatformProvider();
 
             // Init dependencies
-            Bootstrapper.Initialize();
+            var bootstrapper = CreateBootstrapper();
+            var container = bootstrapper.Initialize();
+            Dependencies.Initialize(container);
+
+            // Notify dependencies ready to be used
+            OnContainerInitialized(container);
+        }
+
+        protected virtual void OnContainerInitialized(IContainer container)
+        {
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Forms/FormsApp.cs
+++ b/Softeq.XToolkit.WhiteLabel.Forms/FormsApp.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Threading;
 using Xamarin.Forms;
 
@@ -34,7 +35,10 @@ namespace Softeq.XToolkit.WhiteLabel.Forms
         /// <summary>
         ///     Application developers override this method to perform actions when the application start was completed.
         /// </summary>
-        protected virtual void OnStarted()
+        /// <param name="container">
+        ///     IoC container, configured by bootstrapper
+        /// </param>
+        protected virtual void OnStarted(IContainer container)
         {
         }
 
@@ -44,10 +48,11 @@ namespace Softeq.XToolkit.WhiteLabel.Forms
             {
                 if (_bootstrapper != null)
                 {
-                    _bootstrapper.Initialize();
+                    var container = _bootstrapper.Initialize();
                     _bootstrapper = null;
 
-                    Execute.BeginOnUIThread(OnStarted);
+                    Dependencies.Initialize(container);
+                    Execute.BeginOnUIThread(() => OnStarted(container));
                 }
             }).FireAndForget();
         }

--- a/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
@@ -5,6 +5,7 @@ using Foundation;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.iOS;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Threading;
 using UIKit;
 
@@ -17,14 +18,14 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
     {
         public override UIWindow Window { get; set; } = default!;
 
-        protected abstract IBootstrapper Bootstrapper { get; }
-
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             InitializeWhiteLabelRuntime();
 
             return true;
         }
+
+        protected abstract IBootstrapper CreateBootstrapper();
 
         protected virtual void InitializeWhiteLabelRuntime()
         {
@@ -35,7 +36,16 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             PlatformProvider.Current = new IosPlatformProvider();
 
             // Init dependencies
-            Bootstrapper.Initialize();
+            var bootstrapper = CreateBootstrapper();
+            var container = bootstrapper.Initialize();
+            Dependencies.Initialize(container);
+
+            // Notify dependencies ready to be used
+            OnContainerInitialized(container);
+        }
+
+        protected virtual void OnContainerInitialized(IContainer container)
+        {
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/AssemblySource.cs
+++ b/Softeq.XToolkit.WhiteLabel/AssemblySource.cs
@@ -49,7 +49,7 @@ namespace Softeq.XToolkit.WhiteLabel
         private static readonly IDictionary<string, Type> TypeNameCache = new Dictionary<string, Type>();
 
         /// <summary>
-        ///     Extracts the types from the spezified assembly for storing in the cache.
+        ///     Extracts the types from the specified assembly for storing in the cache.
         /// </summary>
         public static Func<Assembly, IEnumerable<Type>> ExtractTypes = assembly =>
             assembly.GetExportedTypes()

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
@@ -28,6 +28,7 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
 
         void Singleton<TService>(Func<IContainer, TService> func, IfRegistered ifRegistered = IfRegistered.AppendNew);
 
+        [Obsolete("Please use app lifecycle callbacks to access configured container")]
         void RegisterBuildCallback(Action<IContainer> action);
 
         void Decorator<TImplementation, TService>()

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -18,17 +18,8 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
     /// </summary>
     public abstract class BootstrapperBase : IBootstrapper
     {
-        private bool _isInitialized;
-
-        public void Initialize()
+        public IContainer Initialize()
         {
-            if (_isInitialized)
-            {
-                return;
-            }
-
-            _isInitialized = true;
-
             var containerBuilder = CreateContainerBuilder();
 
             // framework level
@@ -38,9 +29,7 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             // application level
             ConfigureIoc(containerBuilder);
 
-            var container = BuildContainer(containerBuilder);
-
-            Dependencies.Initialize(container);
+            return BuildContainer(containerBuilder);
         }
 
         protected virtual IContainerBuilder CreateContainerBuilder()

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using DryIoc;
 using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
-using IDryContainer = DryIoc.IContainer;
 using IContainer = Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract.IContainer;
+using IDryContainer = DryIoc.IContainer;
 
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
 {
@@ -44,7 +44,8 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         }
 
 #pragma warning disable RECS0096 // Type parameter is never used
-        public void PerDependency<TService>(Func<IContainer, object> func,
+        public void PerDependency<TService>(
+            Func<IContainer, object> func,
 #pragma warning restore RECS0096 // Type parameter is never used
             IfRegistered ifRegistered = IfRegistered.AppendNew)
         {
@@ -110,10 +111,15 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
             _dryContainer.Register(type, reuse, null, null, MapIfAlreadyRegistered(ifRegistered));
         }
 
-        private void RegisterInternal<TService>(Func<IContainer, TService> func, IReuse reuse,
+        private void RegisterInternal<TService>(
+            Func<IContainer, TService> func,
+            IReuse reuse,
             IfRegistered ifRegistered = IfRegistered.AppendNew)
         {
-            _dryContainer.RegisterDelegate(c => func.Invoke(c.Resolve<IContainer>()), reuse, null,
+            _dryContainer.RegisterDelegate(
+                c => func.Invoke(c.Resolve<IContainer>()),
+                reuse,
+                null,
                 MapIfAlreadyRegistered(ifRegistered));
         }
 

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/IBootstrapper.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/IBootstrapper.cs
@@ -1,10 +1,12 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
+
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
 {
     public interface IBootstrapper
     {
-        void Initialize();
+        IContainer Initialize();
     }
 }

--- a/samples/Playground.Forms/Playground.Forms/App.xaml.cs
+++ b/samples/Playground.Forms/Playground.Forms/App.xaml.cs
@@ -3,8 +3,8 @@
 
 using Playground.Forms.ViewModels;
 using Playground.Forms.Views;
-using Softeq.XToolkit.WhiteLabel;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Navigation;
 using Xamarin.Forms;
 
@@ -19,11 +19,11 @@ namespace Playground.Forms
             MainPage = new NavigationPage(new StartPage());
         }
 
-        protected override void OnStarted()
+        protected override void OnStarted(IContainer container)
         {
-            base.OnStarted();
+            base.OnStarted(container);
 
-            var navigationService = Dependencies.Container.Resolve<IPageNavigationService>();
+            var navigationService = container.Resolve<IPageNavigationService>();
             navigationService.Initialize(Current.MainPage.Navigation);
             navigationService
                 .For<MainPageViewModel>()

--- a/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
+++ b/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
@@ -62,7 +62,8 @@ namespace Playground.Forms.ViewModels
         private void Dialogs()
         {
             _pageNavigationService
-                .For<DialogsRootPageViewModel>();
+                .For<DialogsRootPageViewModel>()
+                .Navigate();
         }
 
         private void AsyncCommands()

--- a/samples/Playground/Playground.Droid/MainApplication.cs
+++ b/samples/Playground/Playground.Droid/MainApplication.cs
@@ -21,6 +21,9 @@ namespace Playground.Droid
         {
         }
 
-        protected override IBootstrapper Bootstrapper => new CustomDroidBootstrapper();
+        protected override IBootstrapper CreateBootstrapper()
+        {
+            return new CustomDroidBootstrapper();
+        }
     }
 }

--- a/samples/Playground/Playground.iOS/AppDelegate.cs
+++ b/samples/Playground/Playground.iOS/AppDelegate.cs
@@ -17,8 +17,6 @@ namespace Playground.iOS
 
         public override UIWindow Window { get; set; } = default!;
 
-        protected override IBootstrapper Bootstrapper => new CustomIosBootstrapper();
-
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             var _ = base.FinishedLaunching(application, launchOptions);
@@ -32,6 +30,11 @@ namespace Playground.iOS
             InitNavigation();
 
             return true;
+        }
+
+        protected override IBootstrapper CreateBootstrapper()
+        {
+            return new CustomIosBootstrapper();
         }
 
         private void InitNavigation()


### PR DESCRIPTION
### Description

Make IBootstrapper stateless IoC container builder. Add callback with initialized container for AppDelegate and MainApplication

### API Changes

Added:
 - `void virtual MainApplicationBase.OnContainerInitialized(IContainer)`;
 - `void virtual AppDelegateBase.OnContainerInitialized(IContainer)`;

Changed:
 - `void IBootstrapper.Initialize()` => `IContainer IBootstrapper.Initialize()`;
 - `IBootstrapper MainApplicationBase.Bootstrapper {get;}` => `IBootstrapper MainApplicationBase.CreateBootstrapper()`;
 - `IBootstrapper AppDelegateBase.Bootstrapper {get;}` => `IBootstrapper AppDelegateBase.CreateBootstrapper()`;

### Platforms Affected

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
