### PR TITLE
Add custom borders with support AutoLayout

### DIFF
--- a/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
@@ -47,47 +47,45 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
 
             if (edge.HasFlag(UIRectEdge.Top))
             {
-                AddBorder(view, borderWidth, borderColor, UIRectEdge.Top);
+                AddBorder(
+                    view,
+                    borderColor,
+                    UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleBottomMargin,
+                    new CGRect(0, 0, view.Frame.Size.Width, borderWidth));
             }
 
             if (edge.HasFlag(UIRectEdge.Bottom))
             {
-                AddBorder(view, borderWidth, borderColor, UIRectEdge.Bottom);
+                AddBorder(
+                    view,
+                    borderColor,
+                    UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleTopMargin,
+                    new CGRect(0, view.Frame.Size.Height - borderWidth, view.Frame.Size.Width, borderWidth));
             }
 
             if (edge.HasFlag(UIRectEdge.Left))
             {
-                AddBorder(view, borderWidth, borderColor, UIRectEdge.Left);
+                AddBorder(
+                    view,
+                    borderColor,
+                    UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleRightMargin,
+                    new CGRect(0, 0, borderWidth, view.Frame.Size.Height));
             }
 
             if (edge.HasFlag(UIRectEdge.Right))
             {
-                AddBorder(view, borderWidth, borderColor, UIRectEdge.Right);
+                AddBorder(
+                    view,
+                    borderColor,
+                    UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleLeftMargin,
+                    new CGRect(view.Frame.Size.Width - borderWidth, 0, borderWidth, view.Frame.Size.Height));
             }
 
             return view;
         }
 
-        private static UIView AddBorder(UIView view, nfloat borderWidth, CGColor borderColor, UIRectEdge edge)
+        private static UIView AddBorder(UIView view, CGColor borderColor, UIViewAutoresizing autoresizingMask, CGRect frame)
         {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
-            var autoresizingMask = edge switch
-            {
-                UIRectEdge.Top => UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleBottomMargin,
-                UIRectEdge.Bottom => UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleTopMargin,
-                UIRectEdge.Left => UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleRightMargin,
-                UIRectEdge.Right => UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleLeftMargin,
-            };
-
-            var frame = edge switch
-            {
-                UIRectEdge.Top => new CGRect(0, 0, view.Frame.Size.Width, borderWidth),
-                UIRectEdge.Bottom => new CGRect(0, view.Frame.Size.Height - borderWidth, view.Frame.Size.Width, borderWidth),
-                UIRectEdge.Left => new CGRect(0, 0, borderWidth, view.Frame.Size.Height),
-                UIRectEdge.Right => new CGRect(view.Frame.Size.Width - borderWidth, 0, borderWidth, view.Frame.Size.Height),
-            };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
-
             var border = new UIView
             {
                 BackgroundColor = UIColor.FromCGColor(borderColor),

--- a/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
@@ -11,10 +11,10 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
     public static class UIViewExtensions
     {
         /// <summary>
-        ///     UIView with the coloured border.
+        ///     UIView with the colored border.
         /// </summary>
-        /// <returns>UIView with border</returns>
-        /// <param name="view">View.</param>
+        /// <returns>UIView with border.</returns>
+        /// <param name="view">Target view.</param>
         /// <param name="borderWidth">Border width.</param>
         /// <param name="borderColor">Border color. UIColor.White is default color.</param>
         public static UIView WithBorder(this UIView view, nfloat borderWidth, CGColor? borderColor = null)
@@ -29,7 +29,7 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
         ///     UIView with the colored border for target edges.
         /// </summary>
         /// <returns>UIView with border.</returns>
-        /// <param name="view">View.</param>
+        /// <param name="view">Target view.</param>
         /// <param name="borderWidth">Border width.</param>
         /// <param name="borderColor">Border color.</param>
         /// <param name="edge">Border edge.</param>
@@ -100,6 +100,12 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
             return view;
         }
 
+        /// <summary>
+        ///     Make view corners rounded.
+        /// </summary>
+        /// <param name="view">Target view.</param>
+        /// <param name="cornerRadius">Rounding size.</param>
+        /// <returns>Rounded view.</returns>
         public static UIView WithCornerRadius(this UIView view, nfloat cornerRadius)
         {
             view.ClipsToBounds = true;
@@ -110,15 +116,19 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
             return view;
         }
 
+        /// <summary>
+        ///     Make view rounded.
+        /// </summary>
+        /// <param name="view">Target view.</param>
         public static void AsCircle(this UIView view)
         {
             WithCornerRadius(view, view.Frame.Width / 2f);
         }
 
         /// <summary>
-        ///     Use it in LayoutSubviews method
+        ///     Use it in LayoutSubviews method.
         /// </summary>
-        /// <param name="view">View.</param>
+        /// <param name="view">Target view.</param>
         /// <param name="corners">Corners.</param>
         /// <param name="radius">Radius.</param>
         public static void WithCornerRadius(this UIView view, UIRectCorner corners, float radius)
@@ -132,7 +142,21 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
             view.Layer.Mask = maskLayer;
         }
 
-        public static void WithShadow(this UIView view, CGSize offset, UIColor color, double opacity, double radius,
+        /// <summary>
+        ///     Add shadow to the view.
+        /// </summary>
+        /// <param name="view">Target view.</param>
+        /// <param name="offset">Shadow offset.</param>
+        /// <param name="color">Shadow color.</param>
+        /// <param name="opacity">Shadow opacity.</param>
+        /// <param name="radius">Shadow radius.</param>
+        /// <param name="shadowPath">Shadow shape.</param>
+        public static void WithShadow(
+            this UIView view,
+            CGSize offset,
+            UIColor color,
+            double opacity,
+            double radius,
             UIBezierPath? shadowPath = null)
         {
             view.Layer.MasksToBounds = false;

--- a/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/UIViewExtensions.cs
@@ -25,6 +25,81 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
             return view;
         }
 
+        /// <summary>
+        ///     UIView with the colored border for target edges.
+        /// </summary>
+        /// <returns>UIView with border.</returns>
+        /// <param name="view">View.</param>
+        /// <param name="borderWidth">Border width.</param>
+        /// <param name="borderColor">Border color.</param>
+        /// <param name="edge">Border edge.</param>
+        public static UIView WithBorder(this UIView view, nfloat borderWidth, CGColor borderColor, UIRectEdge edge)
+        {
+            if (edge == UIRectEdge.None)
+            {
+                return view;
+            }
+
+            if (edge.HasFlag(UIRectEdge.All))
+            {
+                return WithBorder(view, borderWidth, borderColor);
+            }
+
+            if (edge.HasFlag(UIRectEdge.Top))
+            {
+                AddBorder(view, borderWidth, borderColor, UIRectEdge.Top);
+            }
+
+            if (edge.HasFlag(UIRectEdge.Bottom))
+            {
+                AddBorder(view, borderWidth, borderColor, UIRectEdge.Bottom);
+            }
+
+            if (edge.HasFlag(UIRectEdge.Left))
+            {
+                AddBorder(view, borderWidth, borderColor, UIRectEdge.Left);
+            }
+
+            if (edge.HasFlag(UIRectEdge.Right))
+            {
+                AddBorder(view, borderWidth, borderColor, UIRectEdge.Right);
+            }
+
+            return view;
+        }
+
+        private static UIView AddBorder(UIView view, nfloat borderWidth, CGColor borderColor, UIRectEdge edge)
+        {
+#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+            var autoresizingMask = edge switch
+            {
+                UIRectEdge.Top => UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleBottomMargin,
+                UIRectEdge.Bottom => UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleTopMargin,
+                UIRectEdge.Left => UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleRightMargin,
+                UIRectEdge.Right => UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleLeftMargin,
+            };
+
+            var frame = edge switch
+            {
+                UIRectEdge.Top => new CGRect(0, 0, view.Frame.Size.Width, borderWidth),
+                UIRectEdge.Bottom => new CGRect(0, view.Frame.Size.Height - borderWidth, view.Frame.Size.Width, borderWidth),
+                UIRectEdge.Left => new CGRect(0, 0, borderWidth, view.Frame.Size.Height),
+                UIRectEdge.Right => new CGRect(view.Frame.Size.Width - borderWidth, 0, borderWidth, view.Frame.Size.Height),
+            };
+#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+
+            var border = new UIView
+            {
+                BackgroundColor = UIColor.FromCGColor(borderColor),
+                AutoresizingMask = autoresizingMask,
+                Frame = frame
+            };
+
+            view.AddSubview(border);
+
+            return view;
+        }
+
         public static UIView WithCornerRadius(this UIView view, nfloat cornerRadius)
         {
             view.ClipsToBounds = true;


### PR DESCRIPTION
### Description

Ability to add a border to the custom edges:

```cs
testView
    .WithBorder(8, UIColor.Red.CGColor, UIRectEdge.Left)
    .WithBorder(8, UIColor.Blue.CGColor, UIRectEdge.Top | UIRectEdge.Bottom);
```


### API Changes

Added:
 - UIView UIView.WithBorder(this UIView view, nfloat borderWidth, CGColor borderColor, UIRectEdge edge)

### Platforms Affected

- iOS

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
