### PR TITLE
Fix base async command execution

### DIFF
--- a/Softeq.XToolkit.Common/Commands/AsyncCommandBase.cs
+++ b/Softeq.XToolkit.Common/Commands/AsyncCommandBase.cs
@@ -47,9 +47,7 @@ namespace Softeq.XToolkit.Common.Commands
 
             try
             {
-                await executionProvider
-                    .Invoke()
-                    .ConfigureAwait(false);
+                await executionProvider.Invoke();
             }
             finally
             {


### PR DESCRIPTION
### Description

Case:

When AsyncCommand used with Xamarin.Forms Command binding (Button, etc), XF executes Command in UI thread and internal XF subscription on CanExecute event need that CanExecute was called from a called thread.

The previous implementation was losing the context after execution.

As a result NS exception.

### API Changes

 None

### Platforms Affected

- iOS

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
