### PR TITLE
Hide details of iOS init navigation

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
@@ -6,7 +6,6 @@ using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.iOS;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
-using Softeq.XToolkit.WhiteLabel.Navigation;
 using Softeq.XToolkit.WhiteLabel.Threading;
 using UIKit;
 
@@ -17,32 +16,32 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
     /// </summary>
     public abstract class AppDelegateBase : UIApplicationDelegate
     {
-        private UIViewController _rootNavigationController = default!;
+        private UIViewController _rootViewController = default!;
 
         public override UIWindow Window { get; set; } = default!;
 
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             // YP: Hard reference kept because StoryboardNavigation service uses weak references.
-            _rootNavigationController = CreateRootNavigationController();
+            _rootViewController = CreateRootViewController();
 
-            InitializeMainWindow();
+            InitializeMainWindow(_rootViewController);
             InitializeWhiteLabelRuntime();
 
             return true;
         }
 
-        protected virtual UINavigationController CreateRootNavigationController()
+        protected virtual UIViewController CreateRootViewController()
         {
             return new UINavigationController();
         }
 
-        protected virtual void InitializeMainWindow()
+        protected virtual void InitializeMainWindow(UIViewController rootViewController)
         {
             Window = new UIWindow(UIScreen.MainScreen.Bounds)
             {
                 BackgroundColor = UIColor.SystemBackgroundColor,
-                RootViewController = _rootNavigationController
+                RootViewController = rootViewController
             };
             Window.MakeKeyAndVisible();
         }
@@ -71,13 +70,6 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             InitializeNavigation(container);
         }
 
-        protected virtual void InitializeNavigation(IContainer container)
-        {
-            var navigationService = container.Resolve<IPageNavigationService>();
-            navigationService.Initialize(Window.RootViewController);
-            ConfigureEntryPointNavigation(navigationService);
-        }
-
-        protected abstract void ConfigureEntryPointNavigation(IPageNavigationService navigationService);
+        protected abstract void InitializeNavigation(IContainer container);
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/AppDelegateBase.cs
@@ -23,7 +23,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
-            // YP: Hard reference kept because StoryboardNavigation service used weak references.
+            // YP: Hard reference kept because StoryboardNavigation service uses weak references.
             _rootNavigationController = CreateRootNavigationController();
 
             InitializeMainWindow();

--- a/XToolkit.ruleset
+++ b/XToolkit.ruleset
@@ -125,6 +125,7 @@
     <Rule Id="SA1509" Action="Error" />
     <Rule Id="SA1510" Action="Error" />
     <Rule Id="SA1511" Action="Error" /> -->
+    <Rule Id="SA1512" Action="None" /> 
     <Rule Id="SA1516" Action="None" /> <!-- @ Warning --> 
     <!-- <Rule Id="SA1517" Action="Error" />
     <Rule Id="SA1519" Action="Error" />

--- a/documentation/articles/configure-android.md
+++ b/documentation/articles/configure-android.md
@@ -31,7 +31,10 @@ public class MainApplication : MainApplicationBase
     {
     }
 
-    protected override IBootstrapper Bootstrapper => new CustomBootstrapper();
+    protected override IBootstrapper CreateBootstrapper()
+    {
+        return new CustomBootstrapper();
+    }
 }
 ```
 

--- a/documentation/articles/configure-ios.md
+++ b/documentation/articles/configure-ios.md
@@ -10,35 +10,28 @@
 
 Copy and replace AppDelegate:
 
-```csharp
+```cs
 [Register(nameof(AppDelegate))]
 public class AppDelegate : AppDelegateBase
 {
-    private UINavigationController _rootNavigationController;
-
-    public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
-        var _ = base.FinishedLaunching(app, options);
+        var result = base.FinishedLaunching(application, launchOptions);
 
-        // Init navigation
-        _rootNavigationController = new UINavigationController();
+        // Override point for customization after application launch.
 
-        Window = new UIWindow(UIScreen.MainScreen.Bounds)
-        {
-            RootViewController = _rootNavigationController
-        };
-        Window.MakeKeyAndVisible();
-
-        var navigationService = Dependencies.PageNavigationService;
-        navigationService.Initialize(Window.RootViewController);
-
-        // Entry point
-        navigationService.For<MainPageViewModel>().Navigate();
-
-        return true;
+        return result;
     }
 
-    protected override IBootstrapper Bootstrapper => new CustomBootstrapper();
+    protected override IBootstrapper CreateBootstrapper()
+    {
+        return new CustomIosBootstrapper();
+    }
+
+    protected override void ConfigureEntryPointNavigation(IPageNavigationService navigationService)
+    {
+        navigationService.For<StartPageViewModel>().Navigate();
+    }
 }
 ```
 

--- a/documentation/articles/configure-ios.md
+++ b/documentation/articles/configure-ios.md
@@ -28,8 +28,10 @@ public class AppDelegate : AppDelegateBase
         return new CustomIosBootstrapper();
     }
 
-    protected override void ConfigureEntryPointNavigation(IPageNavigationService navigationService)
+    protected override void InitializeNavigation(IContainer container)
     {
+        var navigationService = container.Resolve<IPageNavigationService>();
+        navigationService.Initialize(Window.RootViewController);
         navigationService.For<StartPageViewModel>().Navigate();
     }
 }

--- a/samples/Playground/Playground.iOS/AppDelegate.cs
+++ b/samples/Playground/Playground.iOS/AppDelegate.cs
@@ -3,9 +3,9 @@
 
 using Foundation;
 using Playground.ViewModels;
-using Softeq.XToolkit.WhiteLabel;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.iOS;
+using Softeq.XToolkit.WhiteLabel.Navigation;
 using UIKit;
 
 namespace Playground.iOS
@@ -13,23 +13,13 @@ namespace Playground.iOS
     [Register(nameof(AppDelegate))]
     public class AppDelegate : AppDelegateBase
     {
-        private readonly UINavigationController _rootNavigationController = new UINavigationController();
-
-        public override UIWindow Window { get; set; } = default!;
-
         public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
-            var _ = base.FinishedLaunching(application, launchOptions);
+            var result = base.FinishedLaunching(application, launchOptions);
 
-            Window = new UIWindow(UIScreen.MainScreen.Bounds)
-            {
-                RootViewController = _rootNavigationController
-            };
-            Window.MakeKeyAndVisible();
+            // Override point for customization after application launch.
 
-            InitNavigation();
-
-            return true;
+            return result;
         }
 
         protected override IBootstrapper CreateBootstrapper()
@@ -37,12 +27,8 @@ namespace Playground.iOS
             return new CustomIosBootstrapper();
         }
 
-        private void InitNavigation()
+        protected override void ConfigureEntryPointNavigation(IPageNavigationService navigationService)
         {
-            var navigationService = Dependencies.PageNavigationService;
-            navigationService.Initialize(Window.RootViewController);
-
-            // Entry point
             navigationService.For<StartPageViewModel>().Navigate();
         }
     }

--- a/samples/Playground/Playground.iOS/AppDelegate.cs
+++ b/samples/Playground/Playground.iOS/AppDelegate.cs
@@ -4,6 +4,7 @@
 using Foundation;
 using Playground.ViewModels;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.iOS;
 using Softeq.XToolkit.WhiteLabel.Navigation;
 using UIKit;
@@ -27,8 +28,10 @@ namespace Playground.iOS
             return new CustomIosBootstrapper();
         }
 
-        protected override void ConfigureEntryPointNavigation(IPageNavigationService navigationService)
+        protected override void InitializeNavigation(IContainer container)
         {
+            var navigationService = container.Resolve<IPageNavigationService>();
+            navigationService.Initialize(Window.RootViewController!);
             navigationService.For<StartPageViewModel>().Navigate();
         }
     }


### PR DESCRIPTION
### Description

Added several methods to hide details of navigation init implementation and avoid boilerplate in each project.

### API Changes

Added protected methods to AppDelegateBase:
 - UINavigationController CreateRootViewController()
 - void InitializeMainWindow(UIViewController rootViewController)
 - void InitializeNavigation(IContainer container)

### Platforms Affected

- iOS

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
