### PR TITLE
Refactor common dictionary extensions

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Extensions/DictionaryExtensionsTests/DictionaryExtensionsTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Extensions/DictionaryExtensionsTests/DictionaryExtensionsTests.cs
@@ -1,0 +1,53 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using Softeq.XToolkit.Common.Extensions;
+using Xunit;
+
+namespace Softeq.XToolkit.Common.Tests.Extensions.DictionaryExtensionsTests
+{
+    public class DictionaryExtensionsTests
+    {
+        [Fact]
+        public void AddOrReplace_NullDictionary_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() =>
+            {
+                DictionaryExtensions.AddOrReplace(null!, "test_key", 1);
+            });
+        }
+
+        [Fact]
+        public void AddOrReplace_NewValueInEmptyDictionary_Adds()
+        {
+            var dictionary = new Dictionary<string, int>();
+
+            dictionary.AddOrReplace("test_key", 1);
+
+            Assert.NotEmpty(dictionary);
+        }
+
+        [Fact]
+        public void AddOrReplace_NewValueInNonEmptyDictionary_Adds()
+        {
+            var dictionary = new Dictionary<string, int> { { "test_key1", 1 } };
+
+            dictionary.AddOrReplace("test_key2", 2);
+
+            Assert.Equal(2, dictionary.Count);
+        }
+
+        [Fact]
+        public void AddOrReplace_ExistValueInNonEmptyDictionary_Replaces()
+        {
+            const string Key = "test_key";
+            var dictionary = new Dictionary<string, int> { { Key, 1 } };
+
+            dictionary.AddOrReplace(Key, 2);
+
+            Assert.Equal(2, dictionary[Key]);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common/Extensions/DictionaryExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/DictionaryExtensions.cs
@@ -2,26 +2,11 @@
 // http://www.softeq.com
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Softeq.XToolkit.Common.Extensions
 {
     public static class DictionaryExtensions
     {
-        /// <summary>
-        ///     Gets the value for a key. If the key does not exist, return default(TValue).
-        /// </summary>
-        /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
-        /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
-        /// <param name="dictionary">The dictionary to call this method on.</param>
-        /// <param name="key">The key to look up.</param>
-        /// <returns>The key value. default(TValue) if this key is not in the dictionary.</returns>
-        [return: MaybeNull]
-        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
-        {
-            return dictionary.TryGetValue(key, out var result) ? result : default;
-        }
-
         /// <summary>
         ///     Adds value with a specified key to the dictionary.
         ///     If the key already exists in the dictionary, replaces the value for this key.

--- a/Softeq.XToolkit.Common/Extensions/DictionaryExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/DictionaryExtensions.cs
@@ -14,7 +14,7 @@ namespace Softeq.XToolkit.Common.Extensions
         /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
         /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary to call this method on.</param>
-        /// <param name="key">The key to look up.</param>
+        /// <param name="key">The key to be added or whose value should be updated.</param>
         /// <param name="value">The value to add to the dictionary.</param>
         public static void AddOrReplace<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {

--- a/Softeq.XToolkit.WhiteLabel/AssemblySource.cs
+++ b/Softeq.XToolkit.WhiteLabel/AssemblySource.cs
@@ -45,8 +45,8 @@ namespace Softeq.XToolkit.WhiteLabel
     /// </summary>
     public static class AssemblySourceCache
     {
+        private static readonly Dictionary<string, Type> _typeNameCache = new Dictionary<string, Type>();
         private static bool _isInstalled;
-        private static readonly IDictionary<string, Type> TypeNameCache = new Dictionary<string, Type>();
 
         /// <summary>
         ///     Extracts the types from the specified assembly for storing in the cache.
@@ -74,15 +74,15 @@ namespace Softeq.XToolkit.WhiteLabel
                     case NotifyCollectionChangedAction.Add:
                         e.NewItems.OfType<Assembly>()
                             .SelectMany(a => ExtractTypes(a))
-                            .Apply(t => TypeNameCache.Add(t.FullName, t));
+                            .Apply(t => _typeNameCache.Add(t.FullName, t));
                         break;
                     case NotifyCollectionChangedAction.Remove:
                     case NotifyCollectionChangedAction.Replace:
                     case NotifyCollectionChangedAction.Reset:
-                        TypeNameCache.Clear();
+                        _typeNameCache.Clear();
                         AssemblySource.Instance
                             .SelectMany(a => ExtractTypes(a))
-                            .Apply(t => TypeNameCache.Add(t.FullName, t));
+                            .Apply(t => _typeNameCache.Add(t.FullName, t));
                         break;
                 }
             };
@@ -94,7 +94,7 @@ namespace Softeq.XToolkit.WhiteLabel
                     return null;
                 }
 
-                var type = names.Select(n => TypeNameCache.GetValueOrDefault(n)).FirstOrDefault(t => t != null);
+                var type = names.Select(n => _typeNameCache.GetValueOrDefault(n)).FirstOrDefault(t => t != null);
                 return type;
             };
         }


### PR DESCRIPTION
### Description

Removed `GetValueOrDefault`. Please use [System.Collections.Generic.CollectionExtensions.GetValueOrDefault](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.collectionextensions.getvalueordefault)

Added tests.

### API Changes

Removed:

DictionaryExtensions:
- TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)

### Platforms Affected

- Core (all platforms)

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
