### PR TITLE
Use custom FragmentManager for FrameNavigationService

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/FrameNavigationConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/FrameNavigationConfig.cs
@@ -1,0 +1,19 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using AndroidX.Fragment.App;
+
+namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
+{
+    public sealed class FrameNavigationConfig
+    {
+        public FrameNavigationConfig(FragmentManager fragmentManager, int containerId)
+        {
+            Manager = fragmentManager;
+            ContainerId = containerId;
+        }
+
+        public FragmentManager Manager { get; }
+        public int ContainerId { get; }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
@@ -65,6 +65,7 @@
     <Compile Include="MainApplicationBase.cs" />
     <Compile Include="Navigation\BundleService.cs" />
     <Compile Include="Navigation\DroidViewLocator.cs" />
+    <Compile Include="Navigation\FrameNavigationConfig.cs" />
     <Compile Include="Navigation\ViewType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\DroidPlatformProvider.cs" />

--- a/Softeq.XToolkit.WhiteLabel.Droid/ViewComponents/BottomNavigationComponentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/ViewComponents/BottomNavigationComponentBase.cs
@@ -5,9 +5,11 @@ using System;
 using Android.Content;
 using Android.Content.Res;
 using Android.Views;
+using AndroidX.Fragment.App;
 using Google.Android.Material.BottomNavigation;
 using Softeq.XToolkit.WhiteLabel.Droid.Controls;
 using Softeq.XToolkit.WhiteLabel.Droid.Extensions;
+using Softeq.XToolkit.WhiteLabel.Droid.Navigation;
 using Softeq.XToolkit.WhiteLabel.ViewModels.Tab;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.ViewComponents
@@ -17,17 +19,19 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.ViewComponents
     {
         private readonly TViewModel _viewModel;
 
-        protected BottomNavigationComponentBase(TViewModel viewModel)
+        protected BottomNavigationComponentBase(TViewModel viewModel, FragmentManager fragmentManager)
         {
             _viewModel = viewModel;
+
+            ToolbarComponent = new ToolbarComponent<TViewModel, TKey>(
+                new FrameNavigationConfig(fragmentManager, Resource.Id.activity_main_page_navigation_container));
         }
 
         public BottomNavigationView? BottomNavigationView { get; private set; }
 
         public virtual int Layout => Resource.Layout.activity_bottom_navigation;
 
-        public virtual ToolbarComponent<TViewModel, TKey> ToolbarComponent { get; } =
-            new ToolbarComponent<TViewModel, TKey>(Resource.Id.activity_main_page_navigation_container);
+        public virtual ToolbarComponent<TViewModel, TKey> ToolbarComponent { get; }
 
         protected virtual ColorStateList? BadgeBackgroundColor { get; }
 

--- a/Softeq.XToolkit.WhiteLabel.Droid/ViewComponents/ToolbarComponent.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/ViewComponents/ToolbarComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Android.OS;
+using Softeq.XToolkit.WhiteLabel.Droid.Navigation;
 using Softeq.XToolkit.WhiteLabel.ViewModels.Tab;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.ViewComponents
@@ -11,12 +12,13 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.ViewComponents
     public class ToolbarComponent<TViewModel, TKey>
         where TViewModel : ToolbarViewModelBase<TKey>
     {
-        private readonly int _navigationContainerId;
+        private readonly FrameNavigationConfig _frameNavigationConfig;
+
         private int _oldSelectedIndex;
 
-        public ToolbarComponent(int navigationContainerId)
+        public ToolbarComponent(FrameNavigationConfig frameNavigationConfig)
         {
-            _navigationContainerId = navigationContainerId;
+            _frameNavigationConfig = frameNavigationConfig;
         }
 
         public void OnCreate(TViewModel viewModel, Action<Bundle> onCreate, Bundle savedInstanceState)
@@ -32,7 +34,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.ViewComponents
 
             foreach (var tabViewModel in viewModel.TabViewModels)
             {
-                tabViewModel.InitializeNavigation(_navigationContainerId);
+                tabViewModel.InitializeNavigation(_frameNavigationConfig);
             }
 
             var selectedTabViewModel = viewModel.TabViewModels.FirstOrDefault();

--- a/samples/Playground/Playground.Droid/Views/BottomTabs/BottomTabsPageActivity.cs
+++ b/samples/Playground/Playground.Droid/Views/BottomTabs/BottomTabsPageActivity.cs
@@ -9,6 +9,7 @@ using Android.OS;
 using Playground.ViewModels.BottomTabs;
 using Softeq.XToolkit.WhiteLabel.Droid.ViewComponents;
 using Softeq.XToolkit.WhiteLabel.Droid.Views;
+using FragmentManager = AndroidX.Fragment.App.FragmentManager;
 
 namespace Playground.Droid.Views.BottomTabs
 {
@@ -24,15 +25,18 @@ namespace Playground.Droid.Views.BottomTabs
 
         protected override BottomNavigationComponentBase<BottomTabsPageViewModel, string> CreateComponent()
         {
-            return new PlaygroundBottomNavigationComponent(this, ViewModel);
+            return new PlaygroundBottomNavigationComponent(this, ViewModel, SupportFragmentManager);
         }
 
         private class PlaygroundBottomNavigationComponent : BottomNavigationComponentBase<BottomTabsPageViewModel, string>
         {
             private Context? _context;
 
-            public PlaygroundBottomNavigationComponent(Context context, BottomTabsPageViewModel viewModel)
-                : base(viewModel)
+            public PlaygroundBottomNavigationComponent(
+                Context context,
+                BottomTabsPageViewModel viewModel,
+                FragmentManager fragmentManager)
+                : base(viewModel, fragmentManager)
             {
                 _context = context;
             }


### PR DESCRIPTION
### Description

Use separate FragmentManagers for each FrameNavigationService instance

### API Changes

Added:
 - class FrameNavigationConfig(FragmentManager fragmentManager, int containerId);

Changed:
 - DroidFrameNavigationService.Initialize(object) now expect instance of FrameNavigationConfig as parameter;

### Platforms Affected

- Android

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
