### PR TITLE
Tests for ObservableItemContentRangeCollection

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionDataProvider.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionDataProvider.cs
@@ -8,12 +8,19 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
 {
     internal static class ObservableItemContentRangeCollectionDataProvider
     {
-        public static TheoryData<IEnumerable<ObservableObject>> Data
+        public static TheoryData<IEnumerable<ObservableObject>> EmptyCollectionData
            => new TheoryData<IEnumerable<ObservableObject>>
            {
                 { null },
-                { new List<ObservableObject>() },
-                { new List<ObservableObject>() { new ObservableObject(), new ObservableObject(), new ObservableObject() } },
+                { new List<ObservableObject>() }
+           };
+
+        public static TheoryData<IEnumerable<ObservableObject>> CollectionData
+           => new TheoryData<IEnumerable<ObservableObject>>
+           {
+               { new List<ObservableObject>() { new ObservableObject() } },
+               { new List<ObservableObject>() { new ObservableObject(), new ObservableObject() } },
+               { new List<ObservableObject>() { new ObservableObject(), new ObservableObject(), new ObservableObject() } },
            };
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionDataProvider.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionDataProvider.cs
@@ -1,0 +1,19 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCollectionTests
+{
+    internal static class ObservableItemContentRangeCollectionDataProvider
+    {
+        public static TheoryData<IEnumerable<ObservableObject>> Data
+           => new TheoryData<IEnumerable<ObservableObject>>
+           {
+                { null },
+                { new List<ObservableObject>() },
+                { new List<ObservableObject>() { new ObservableObject(), new ObservableObject(), new ObservableObject() } },
+           };
+    }
+}

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
@@ -29,8 +29,11 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
 
             Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
             Assert.Equal(count, collection.Count);
-            Assert.All(collection, (item) => items.Contains(item));
-            Assert.All(items, (item) => collection.Contains(item));
+            if (count > 0)
+            {
+                Assert.All(collection, (item) => items.Contains(item));
+                Assert.All(items, (item) => collection.Contains(item));
+            }
         }
 
         [Fact]

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
@@ -19,21 +19,38 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
 
         [Theory]
         [MemberData(
-            nameof(ObservableItemContentRangeCollectionDataProvider.Data),
+            nameof(ObservableItemContentRangeCollectionDataProvider.CollectionData),
             MemberType = typeof(ObservableItemContentRangeCollectionDataProvider))]
         public void ObservableItemContentRangeCollection_WhenCreatedWithItems_AddsAllItems(
             IEnumerable<ObservableObject> items)
         {
-            var count = items?.Count() ?? 0;
             var collection = new ObservableItemContentRangeCollection<ObservableObject>(items);
 
             Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
-            Assert.Equal(count, collection.Count);
-            if (count > 0)
-            {
-                Assert.All(collection, (item) => items.Contains(item));
-                Assert.All(items, (item) => collection.Contains(item));
-            }
+            Assert.Equal(items.Count(), collection.Count);
+            Assert.Equal(collection, items);
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(ObservableItemContentRangeCollectionDataProvider.EmptyCollectionData),
+            MemberType = typeof(ObservableItemContentRangeCollectionDataProvider))]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithEmptyItems_CreatesEmptyCollection(
+            IEnumerable<ObservableObject> items)
+        {
+            var collection = new ObservableItemContentRangeCollection<ObservableObject>(items);
+
+            Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
+            Assert.Empty(collection);
+        }
+
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithoutItems_CreatesEmptyCollection()
+        {
+            var collection = new ObservableItemContentRangeCollection<ObservableObject>();
+
+            Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
+            Assert.Empty(collection);
         }
 
         [Fact]
@@ -53,13 +70,6 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
             Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
             Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
             Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
-
-            collection.Remove(item);
-
-            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
-                   handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
-                   handler => { },
-                   () => item.TestProperty = TestPropertyValue2);
         }
 
         [Fact]
@@ -82,13 +92,6 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
             Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
             Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
             Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
-
-            collection.Remove(addedItem);
-
-            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
-                   handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
-                   handler => { },
-                   () => addedItem.TestProperty = TestPropertyValue2);
         }
 
         [Fact]
@@ -108,7 +111,35 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
             Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
             Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
             Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
+        }
 
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithItems_DoesNotNotifyForRemovedItems()
+        {
+            var item = new TestObservableObject();
+            var items = new List<TestObservableObject>() { item, new TestObservableObject(), new TestObservableObject() };
+            var collection = new ObservableItemContentRangeCollection<TestObservableObject>(items);
+
+            collection.Remove(item);
+
+            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
+                   handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                   handler => { },
+                   () => item.TestProperty = TestPropertyValue2);
+        }
+
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithoutItems_DoesNotNotifyForRemovedItems()
+        {
+            var item = new TestObservableObject();
+            var collection = new ObservableItemContentRangeCollection<TestObservableObject>();
+
+            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
+                    handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                    handler => { },
+                    () => item.TestProperty = TestPropertyValue);
+
+            collection.Add(item);
             collection.Remove(item);
 
             CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
@@ -1,0 +1,116 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using Softeq.XToolkit.Common.Collections;
+using Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils;
+using Xunit;
+
+namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCollectionTests
+{
+    public class ObservableItemContentRangeCollectionTests
+    {
+        private const string TestPropertyValue = "Property value";
+        private const string TestPropertyValue2 = "Property value 2";
+
+        [Theory]
+        [MemberData(
+            nameof(ObservableItemContentRangeCollectionDataProvider.Data),
+            MemberType = typeof(ObservableItemContentRangeCollectionDataProvider))]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithItems_AddsAllItems(
+            IEnumerable<ObservableObject> items)
+        {
+            var count = items?.Count() ?? 0;
+            var collection = new ObservableItemContentRangeCollection<ObservableObject>(items);
+
+            Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
+            Assert.Equal(count, collection.Count);
+            Assert.All(collection, (item) => items.Contains(item));
+        }
+
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithItems_NotifiesForInitialItems()
+        {
+            var item = new TestObservableObject();
+            var items = new List<TestObservableObject>() { item, new TestObservableObject(), new TestObservableObject() };
+            var collection = new ObservableItemContentRangeCollection<TestObservableObject>(items);
+            var itemIndex = collection.IndexOf(item);
+
+            var raisedEvent = Assert.Raises<NotifyCollectionChangedEventArgs>(
+                    handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                    handler => { },
+                    () => item.TestProperty = TestPropertyValue);
+
+            Assert.NotNull(raisedEvent);
+            Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
+
+            collection.Remove(item);
+
+            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
+                   handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                   handler => { },
+                   () => item.TestProperty = TestPropertyValue2);
+        }
+
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithItems_NotifiesForAddedItems()
+        {
+            var item = new TestObservableObject();
+            var items = new List<TestObservableObject>() { item, new TestObservableObject(), new TestObservableObject() };
+            var collection = new ObservableItemContentRangeCollection<TestObservableObject>(items);
+            var addedItem = new TestObservableObject();
+            collection.Add(addedItem);
+
+            var itemIndex = collection.IndexOf(addedItem);
+
+            var raisedEvent = Assert.Raises<NotifyCollectionChangedEventArgs>(
+                    handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                    handler => { },
+                    () => addedItem.TestProperty = TestPropertyValue);
+
+            Assert.NotNull(raisedEvent);
+            Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
+
+            collection.Remove(addedItem);
+
+            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
+                   handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                   handler => { },
+                   () => addedItem.TestProperty = TestPropertyValue2);
+        }
+
+        [Fact]
+        public void ObservableItemContentRangeCollection_WhenCreatedWithoutItems_NotifiesForAddedItems()
+        {
+            var item = new TestObservableObject();
+            var collection = new ObservableItemContentRangeCollection<TestObservableObject>();
+            collection.Add(item);
+            var itemIndex = collection.IndexOf(item);
+
+            var raisedEvent = Assert.Raises<NotifyCollectionChangedEventArgs>(
+                    handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                    handler => { },
+                    () => item.TestProperty = TestPropertyValue);
+
+            Assert.NotNull(raisedEvent);
+            Assert.Equal(NotifyCollectionChangedAction.Replace, raisedEvent.Arguments.Action);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.NewStartingIndex);
+            Assert.Equal(itemIndex, raisedEvent.Arguments.OldStartingIndex);
+
+            collection.Remove(item);
+
+            CustomAsserts.Assert_NotRaises<NotifyCollectionChangedEventArgs>(
+                    handler => collection.CollectionChanged += (s, e) => handler.Invoke(s, e),
+                    handler => { },
+                    () => item.TestProperty = TestPropertyValue2);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableItemContentRangeCollectionTests/ObservableItemContentRangeCollectionTests.cs
@@ -30,6 +30,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableItemContentRangeCol
             Assert.IsAssignableFrom<ObservableCollection<ObservableObject>>(collection);
             Assert.Equal(count, collection.Count);
             Assert.All(collection, (item) => items.Contains(item));
+            Assert.All(items, (item) => collection.Contains(item));
         }
 
         [Fact]

--- a/Softeq.XToolkit.Common.Tests/ObservableObjectTests/ObservableObjectTests.cs
+++ b/Softeq.XToolkit.Common.Tests/ObservableObjectTests/ObservableObjectTests.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 using Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils;
 using Xunit;
 using Xunit.Sdk;
-using static Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils.CustomPropertyChangedAsserts;
+using static Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils.CustomAsserts;
 
 namespace Softeq.XToolkit.Common.Tests.ObservableObjectTests
 {

--- a/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
+++ b/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
@@ -22,12 +22,12 @@ namespace Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils
         {
             bool propertyChangeHappened = false;
             var changedEventHandler = (PropertyChangedEventHandler) ((sender, args) =>
-             {
+            {
                 // YP: removed string.IsNullOrEmpty check from original Xunit Assert.PropertyChanged
                 propertyChangeHappened = ((propertyChangeHappened ? 1 : 0) | (args.PropertyName == null
-                     ? 0
-                     : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
-             });
+                        ? 0
+                        : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
+            });
             @object.PropertyChanged += changedEventHandler;
             try
             {

--- a/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
+++ b/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
@@ -25,8 +25,8 @@ namespace Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils
             {
                 // YP: removed string.IsNullOrEmpty check from original Xunit Assert.PropertyChanged
                 propertyChangeHappened = ((propertyChangeHappened ? 1 : 0) | (args.PropertyName == null
-                        ? 0
-                        : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
+                    ? 0
+                    : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
             });
             @object.PropertyChanged += changedEventHandler;
             try

--- a/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
+++ b/Softeq.XToolkit.Common.Tests/ObservableObjectTests/Utils/CustomAsserts.cs
@@ -3,25 +3,31 @@
 
 using System;
 using System.ComponentModel;
+using Xunit;
 using Xunit.Sdk;
 
 namespace Softeq.XToolkit.Common.Tests.ObservableObjectTests.Utils
 {
-    internal static class CustomPropertyChangedAsserts
+    internal static class CustomAsserts
     {
+        public static void Assert_NotRaises<T>(Action<EventHandler<T>> attach, Action<EventHandler<T>> detach, Action testCode) where T : EventArgs
+        {
+            Assert.Throws<RaisesException>(() => Assert.Raises(attach, detach, testCode));
+        }
+
         public static void Assert_PropertyChanged(
             INotifyPropertyChanged @object,
             string propertyName,
             Action testCode)
         {
             bool propertyChangeHappened = false;
-            var changedEventHandler = (PropertyChangedEventHandler)((sender, args) =>
-            {
+            var changedEventHandler = (PropertyChangedEventHandler) ((sender, args) =>
+             {
                 // YP: removed string.IsNullOrEmpty check from original Xunit Assert.PropertyChanged
                 propertyChangeHappened = ((propertyChangeHappened ? 1 : 0) | (args.PropertyName == null
-                    ? 0
-                    : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
-            });
+                     ? 0
+                     : propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase) ? 1 : 0)) != 0;
+             });
             @object.PropertyChanged += changedEventHandler;
             try
             {

--- a/Softeq.XToolkit.Common/Collections/ObservableItemContentRangeCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableItemContentRangeCollection.cs
@@ -17,7 +17,10 @@ namespace Softeq.XToolkit.Common.Collections
         public ObservableItemContentRangeCollection(IEnumerable<T> items)
             : this()
         {
-            AddRange(items);
+            if (items != null)
+            {
+                AddRange(items);
+            }
         }
 
         private void ObservableItemContentRangeCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
### Description

Tests for ObservableItemContentRangeCollection

### API Changes
 
 None

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
