### PR TITLE
Feature/observable key groups collection new fix

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Handlers/DroidRecyclerObservableKeyGroupCollectionHandler.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Handlers/DroidRecyclerObservableKeyGroupCollectionHandler.cs
@@ -78,8 +78,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Handlers
 
         protected override void HandleGroupsReplace(NotifyKeyGroupCollectionChangedEventArgs<TKey, TItem> args)
         {
-            HandleGroupsAdd(args);
-            HandleGroupsRemove(args);
+            _recyclerViewAdapterRef.Target?.NotifyDataSetChanged();
         }
 
         protected override void HandleGroupsReset()

--- a/Softeq.XToolkit.Bindings.iOS/Handlers/IosCollectionObservableKeyGroupCollectionHandler.cs
+++ b/Softeq.XToolkit.Bindings.iOS/Handlers/IosCollectionObservableKeyGroupCollectionHandler.cs
@@ -55,8 +55,7 @@ namespace Softeq.XToolkit.Bindings.iOS.Handlers
 
         protected override void HandleGroupsReplace(NotifyKeyGroupCollectionChangedEventArgs<TKey, TItem> args)
         {
-            HandleGroupsAdd(args);
-            HandleGroupsRemove(args);
+            _collectionViewRef.Target?.ReloadData();
         }
 
         protected override void HandleGroupsReset()

--- a/Softeq.XToolkit.Bindings.iOS/Handlers/IosTableObservableKeyGroupCollectionHandler.cs
+++ b/Softeq.XToolkit.Bindings.iOS/Handlers/IosTableObservableKeyGroupCollectionHandler.cs
@@ -55,8 +55,7 @@ namespace Softeq.XToolkit.Bindings.iOS.Handlers
 
         protected override void HandleGroupsReplace(NotifyKeyGroupCollectionChangedEventArgs<TKey, TItem> args)
         {
-            HandleGroupsAdd(args);
-            HandleGroupsRemove(args);
+            _tableViewRef.Target?.ReloadData();
         }
 
         protected override void HandleGroupsReset()

--- a/Softeq.XToolkit.Bindings/Handlers/ObservableKeyGroupCollectionHandlerBase.cs
+++ b/Softeq.XToolkit.Bindings/Handlers/ObservableKeyGroupCollectionHandlerBase.cs
@@ -13,19 +13,25 @@ namespace Softeq.XToolkit.Bindings.Handlers
     {
         public void Handle(NotifyKeyGroupCollectionChangedEventArgs<TKey, TItem> arg)
         {
-            if (arg.Action == NotifyCollectionChangedAction.Reset)
+            switch (arg.Action)
             {
-                HandleGroupsReset();
-                return;
-            }
+                case NotifyCollectionChangedAction.Reset:
+                    HandleGroupsReset();
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    HandleGroupsReplace(arg);
+                    break;
+                default:
+                    if (BatchAction == null)
+                    {
+                        Update(arg);
+                    }
+                    else
+                    {
+                        BatchAction.Invoke(() => Update(arg));
+                    }
 
-            if (BatchAction == null)
-            {
-                Update(arg);
-            }
-            else
-            {
-                BatchAction.Invoke(() => Update(arg));
+                    break;
             }
         }
 

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollectionNew.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollectionNew.cs
@@ -316,14 +316,9 @@ namespace Softeq.XToolkit.Common.Collections
                 .Select(x => new KeyValuePair<TKey, IList<TValue>>(x, new List<TValue>()));
 
             var keysToAdd = InsertGroupsWithoutNotify(insertionIndex, groups, false)
-                .Select(x => x.Key).ToList();
+                ?.Select(x => x.Key)?.ToList() ?? new List<TKey>();
 
             var result = InsertItemsWithoutNotify(items, keySelector, valueSelector, null);
-
-            if (!result.Any())
-            {
-                return;
-            }
 
             List<(int, NotifyGroupCollectionChangedEventArgs<TValue>)>? groupEvents = result
                 .Where(x => keysToAdd.All(y => !y.Equals(x.Key)))


### PR DESCRIPTION
### Description

- Fix ReplaceItems method in ObservableKeyGroupsCollectionNew:
-- Method will not crash if you try to replace with empty enumerable
-- Method will notify changes if you replace with empty enumerable
- Replace animation will be performed as one step of data reload instead of two steps of removing and adding items (on replace all previous items are cleared)

### API Changes
 
 None

### Platforms Affected

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
