### PR TITLE
Improve links detection

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Extensions/StringExtensionsTests/StringExtensionsTests.cs
+++ b/Softeq.XToolkit.Common.Tests/Extensions/StringExtensionsTests/StringExtensionsTests.cs
@@ -237,7 +237,10 @@ namespace Softeq.XToolkit.Common.Tests.Extensions.StringExtensionsTests
         [Theory]
         [InlineData("Text with http://link.link", 1)]
         [InlineData("https://google.com", 1)]
-        [InlineData("Links:http://link.link ; custom://somelink.ru ; https://link.to.link.from.link", 3)]
+        [InlineData("Links:http://link.link ; custom://softeq.com ; https://link.to.softeq.com.link", 3)]
+        [InlineData("text softeq.com la-la-la softeq.com", 2)]
+        [InlineData("softeq.com/test", 1)]
+        [InlineData("www.softeq.com", 1)]
         public void FindLinks_TextWithLinks_ReturnsCorrectAmountOfLinks(string text, int linksCount)
         {
             var result = text.FindLinks();

--- a/Softeq.XToolkit.Common.iOS.Tests/Extensions/NSStringExtensions/NSStringExtensionsTests.cs
+++ b/Softeq.XToolkit.Common.iOS.Tests/Extensions/NSStringExtensions/NSStringExtensionsTests.cs
@@ -34,8 +34,6 @@ namespace Softeq.XToolkit.Common.iOS.Tests.Extensions.NSStringExtensions
 
         [Theory]
         [InlineData("")]
-        [InlineData("localhost")]
-        [InlineData("example.com")]
         public void ToNSUrl_InvalidLink_ThrowsUriFormatException(string link)
         {
             Assert.Throws<UriFormatException>(() =>
@@ -45,6 +43,9 @@ namespace Softeq.XToolkit.Common.iOS.Tests.Extensions.NSStringExtensions
         }
 
         [Theory]
+        [InlineData("localhost", "http://localhost/")]
+        [InlineData("softeq.com", "http://softeq.com/")]
+        [InlineData("www.softeq.com", "http://www.softeq.com/")]
         [InlineData("http://softeq.com", "http://softeq.com/")]
         [InlineData("https://softeq.com", "https://softeq.com/")]
         [InlineData("https://www.softeq.com/", "https://www.softeq.com/")]
@@ -173,7 +174,7 @@ namespace Softeq.XToolkit.Common.iOS.Tests.Extensions.NSStringExtensions
 
         [Theory]
         [InlineData("link: https://softeq.com", 1)]
-        [InlineData("link: https://softeq.com, google: google.com", 1)]
+        [InlineData("link: https://softeq.com, google: google.com", 2)]
         [InlineData("test string: https://www.softeq.com/featured_projects#mobile, example: http://example.com/test/page", 2)]
         public void DetectLinks_TextWithLinks_ExecutesWithoutExceptions(string text, int linkCount)
         {

--- a/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
@@ -20,11 +20,15 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
         /// <summary>
         ///     Convert string to <see cref="T:Foundation.NSUrl"/> instance.
         /// </summary>
+        /// <remarks>
+        ///     If the pattern matches example.com, which does not have a URL scheme prefix,
+        ///     the supplied scheme will be prepended to create http://example.com when the clickable URL link is created.
+        /// </remarks>
         /// <param name="link">Link.</param>
         /// <returns><see cref="T:Foundation.NSUrl"/> instance.</returns>
         public static NSUrl ToNSUrl(this string link)
         {
-            var uri = new Uri(link);
+            var uri = new UriBuilder(link).Uri;
             var url = NSUrl.FromString(uri.AbsoluteUri);
             return url;
         }
@@ -143,6 +147,11 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
         /// <summary>
         ///    Auto-detect links.
         /// </summary>
+        /// <remarks>
+        ///     If you are matching web URLs you would supply the scheme http://.
+        ///     If the pattern matches example.com, which does not have a URL scheme prefix,
+        ///     the supplied scheme will be prepended to create http://example.com when the clickable URL link is created.
+        /// </remarks>
         /// <param name="self">Target.</param>
         /// <param name="color">Link color.</param>
         /// <param name="style">Link style.</param>

--- a/Softeq.XToolkit.Common/Extensions/StringExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/StringExtensions.cs
@@ -13,7 +13,7 @@ namespace Softeq.XToolkit.Common.Extensions
     /// </summary>
     public static class StringExtensions
     {
-        private const string LinkPattern = @"[a-z]+://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?";
+        private const string LinkPattern = @"([a-z]+://)?([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?";
 
         /// <summary>
         ///     Finds links in specified string.


### PR DESCRIPTION
### Description

- Add handle `example.com`, `www.example.com` links.

Consistently to Android: https://developer.android.com/reference/android/text/util/Linkify

### API Changes
 
None

### Platforms Affected

- Core (all platforms)
- iOS

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
