### PR TITLE
Update ColoredClickableSpan

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Controls/ColoredClickableSpan.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Controls/ColoredClickableSpan.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Android.Content;
+using Android.Graphics;
 using Android.Text;
 using Android.Text.Style;
 using Android.Views;
@@ -18,9 +19,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Controls
     {
         private readonly Context _context;
         private readonly Action _clickAction;
-        private readonly int _colorResourceId;
+        private readonly int? _colorResourceId;
 
-        public ColoredClickableSpan(Context context, Action clickAction, int colorResourceId)
+        public ColoredClickableSpan(Context context, Action clickAction, int? colorResourceId = null)
         {
             _context = context;
             _clickAction = clickAction;
@@ -36,7 +37,10 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Controls
         {
             base.UpdateDrawState(ds);
             ds.UnderlineText = false;
-            ds.BgColor = ContextCompat.GetColor(_context, _colorResourceId);
+            if (_colorResourceId.HasValue)
+            {
+                ds.Color = new Color(ContextCompat.GetColor(_context, _colorResourceId.Value));
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

Updated ColoredClickableSpan

### Issues Resolved

- fixes usage of `colorResourceId` parameter for text color

### API Changes

Changed:
 - public ColoredClickableSpan(Context context, Action clickAction, int colorResourceId) => 
    public ColoredClickableSpan(Context context, Action clickAction, int? colorResourceId = null)

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
