### PR TITLE
Headers and footers are now automatically countered in ItemCount

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -224,7 +224,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public bool ShouldNotifyByAction { get; set; }
 
-        public override int ItemCount => _dataSource.Count();
+        public override int ItemCount => _flatMapping.Count;
 
         private void ReloadMapping()
         {


### PR DESCRIPTION

### Description

Headers and footers are now automatically countered in ItemCount

- Android

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
