### PR TITLE
DialogConfigs and DryIocContainerAdapter tests

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DroidFragmentDialogService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DroidFragmentDialogService.cs
@@ -23,8 +23,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
             IViewLocator viewLocator,
             IContainer container)
         {
-            _viewLocator = viewLocator;
             _container = container;
+            _viewLocator = viewLocator;
         }
 
         [Obsolete("Use ShowDialogAsync(new ConfirmDialogConfig()) instead.")]
@@ -35,13 +35,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
             string? cancelButtonText = null,
             OpenDialogOptions? openDialogOptions = null)
         {
-            return ShowDialogAsync(new ConfirmDialogConfig
-            {
-                Title = title,
-                Message = message,
-                AcceptButtonText = okButtonText,
-                CancelButtonText = cancelButtonText
-            });
+            return ShowDialogAsync(new ConfirmDialogConfig(
+                title, message, okButtonText, cancelButtonText));
         }
 
         public Task ShowDialogAsync(AlertDialogConfig config)
@@ -104,7 +99,12 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
             where TViewModel : IDialogViewModel
         {
             var viewModel = _container.Resolve<TViewModel>();
-            viewModel.ApplyParameters(parameters);
+
+            if (parameters != null)
+            {
+                viewModel.ApplyParameters(parameters);
+            }
+
             return viewModel;
         }
 

--- a/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerAdapterTests/DryIocContainerAdapterTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerAdapterTests/DryIocContainerAdapterTests.cs
@@ -1,0 +1,62 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using NSubstitute;
+using Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers;
+using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
+using Xunit;
+using IDryContainer = DryIoc.IContainer;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Bootstrapper.Containers.DryIocContainerAdapterTests
+{
+    public class DryIocContainerAdapterTests
+    {
+        private readonly IDryContainer _container;
+        private readonly DryIocContainerAdapter _dryIocContainerAdapter;
+
+        public DryIocContainerAdapterTests()
+        {
+            _container = Substitute.For<IDryContainer>();
+            _dryIocContainerAdapter = new DryIocContainerAdapter();
+        }
+
+        [Fact]
+        public void Initialize_Null_ThrowsCorrectException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _dryIocContainerAdapter.Initialize(null));
+        }
+
+        [Fact]
+        public void Initialize_NotNull_DoesNotThrowException()
+        {
+            _dryIocContainerAdapter.Initialize(_container);
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(DryIocContainerAdapterTestsDataProvider.ParamsData),
+            MemberType = typeof(DryIocContainerAdapterTestsDataProvider))]
+        public void Resolve_BeforeInitialization_ThrowsCorrectException(object[] parameters)
+        {
+            Assert.Throws<InvalidOperationException>(() => _dryIocContainerAdapter.Resolve<ViewModelStub>(parameters));
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(DryIocContainerAdapterTestsDataProvider.ParamsData),
+            MemberType = typeof(DryIocContainerAdapterTestsDataProvider))]
+        public void Resolve_AfterInitialization_DoesNotThrow(object[] parameters)
+        {
+            _dryIocContainerAdapter.Initialize(_container);
+            _dryIocContainerAdapter.Resolve<ViewModelStub>(parameters);
+
+            //TODO: PS: Find out why the following does not work:
+            //_container.Received(1).Resolve<ViewModelStub>(
+            //    Arg.Is(parameters),
+            //    IfUnresolved.Throw,
+            //    (Type) null,
+            //    (object) null);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerAdapterTests/DryIocContainerAdapterTestsDataProvider.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerAdapterTests/DryIocContainerAdapterTestsDataProvider.cs
@@ -1,0 +1,18 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Bootstrapper.Containers.DryIocContainerAdapterTests
+{
+    internal static class DryIocContainerAdapterTestsDataProvider
+    {
+        public static TheoryData<object[]> ParamsData
+           => new TheoryData<object[]>
+           {
+               { new object[] { } },
+               { new object[] { new object() } },
+               { new object[] { new object(), new object(), new object() } },
+           };
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerBuilderTests/DryIocContainerBuilderTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/Containers/DryIocContainerBuilderTests/DryIocContainerBuilderTests.cs
@@ -1,0 +1,14 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Bootstrapper.Containers.DryIocContainerBuilderTests
+{
+    public class DryIocContainerBuilderTests
+    {
+        public DryIocContainerBuilderTests()
+        {
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/DefaultViewModelFinderTests/DefaultViewModelFinderTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Bootstrapper/DefaultViewModelFinderTests/DefaultViewModelFinderTests.cs
@@ -5,9 +5,10 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
+using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
 using Xunit;
 
-namespace Softeq.XToolkit.Whitelabel.Tests.Bootstrapper.DefaultViewModelFinderTests
+namespace Softeq.XToolkit.WhiteLabel.Tests.Bootstrapper.DefaultViewModelFinderTests
 {
     public class DefaultViewModelFinderTests
     {

--- a/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/ActionSheetDialogConfigTests/ActionSheetDialogConfigTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/ActionSheetDialogConfigTests/ActionSheetDialogConfigTests.cs
@@ -1,0 +1,68 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using Softeq.XToolkit.WhiteLabel.Dialogs;
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Dialogs.ActionSheetDialogConfigTests
+{
+    public class ActionSheetDialogConfigTests
+    {
+        private const string EmptyString = "";
+        private const string NonEmptyTitle = "Abc Title";
+        private const string NonEmptyCancelButtonText = "Abc Cancel Button";
+        private const string NonEmptyDestructButtonText = "Abc Destruct Button";
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_WithNullOptions_CreatesEmptyOptionsAndFillsOtherProperties(
+            [CombinatorialValues(null, EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyDestructButtonText)] string destructButtonText)
+        {
+            var actionSheetDialogConfig =
+                new ActionSheetDialogConfig(null, title, cancelButtonText, destructButtonText);
+
+            Assert.NotNull(actionSheetDialogConfig.OptionButtons);
+            Assert.Empty(actionSheetDialogConfig.OptionButtons);
+
+            Assert.Equal(title, actionSheetDialogConfig.Title);
+            Assert.Equal(cancelButtonText, actionSheetDialogConfig.CancelButtonText);
+            Assert.Equal(destructButtonText, actionSheetDialogConfig.DestructButtonText);
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_WithEmptyOptions_FillsProperties(
+            [CombinatorialValues(null, EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyDestructButtonText)] string destructButtonText)
+        {
+            var options = new string[] { };
+            var actionSheetDialogConfig =
+                new ActionSheetDialogConfig(options, title, cancelButtonText, destructButtonText);
+
+            Assert.Equal(options, actionSheetDialogConfig.OptionButtons);
+            Assert.Equal(title, actionSheetDialogConfig.Title);
+            Assert.Equal(cancelButtonText, actionSheetDialogConfig.CancelButtonText);
+            Assert.Equal(destructButtonText, actionSheetDialogConfig.DestructButtonText);
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_WithNonEmptyOptions_FillsProperties(
+            [CombinatorialValues(null, EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyDestructButtonText)] string destructButtonText)
+        {
+            var options = new string[] { "Option1", "Option2", "Option3" };
+            var actionSheetDialogConfig =
+                new ActionSheetDialogConfig(options, title, cancelButtonText, destructButtonText);
+
+            Assert.Equal(options, actionSheetDialogConfig.OptionButtons);
+            Assert.Equal(title, actionSheetDialogConfig.Title);
+            Assert.Equal(cancelButtonText, actionSheetDialogConfig.CancelButtonText);
+            Assert.Equal(destructButtonText, actionSheetDialogConfig.DestructButtonText);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/AlertDialogConfigTests/AlertDialogConfigTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/AlertDialogConfigTests/AlertDialogConfigTests.cs
@@ -1,0 +1,62 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Softeq.XToolkit.WhiteLabel.Dialogs;
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Dialogs.AlertDialogConfigTests
+{
+    public class AlertDialogConfigTests
+    {
+        private const string EmptyString = "";
+        private const string NonEmptyTitle = "Abc Title";
+        private const string NonEmptyMessage = "Abc Message";
+        private const string NonEmptyCloseButtonText = "Abc Cancel Button";
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NullTitle_ThrowsCorrectException(
+            [CombinatorialValues(null, EmptyString, NonEmptyMessage)] string message,
+            [CombinatorialValues(null, EmptyString, NonEmptyCloseButtonText)] string closeButtonText)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new AlertDialogConfig(null, message, closeButtonText));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NullMessage_ThrowsCorrectException(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(null, EmptyString, NonEmptyCloseButtonText)] string closeButtonText)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new AlertDialogConfig(title, null, closeButtonText));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NonNullMessage_NullCloseButtonText_ThrowsCorrectException(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(EmptyString, NonEmptyMessage)] string message)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new AlertDialogConfig(title, message, null));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NonNullMessage_NonNullCloseButtonText_FillsProperties(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(EmptyString, NonEmptyMessage)] string message,
+            [CombinatorialValues(EmptyString, NonEmptyCloseButtonText)] string closeButtonText)
+        {
+            var alertDialogConfig =
+                new AlertDialogConfig(title, message, closeButtonText);
+
+            Assert.Equal(title, alertDialogConfig.Title);
+            Assert.Equal(message, alertDialogConfig.Message);
+            Assert.Equal(closeButtonText, alertDialogConfig.CloseButtonText);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/ConfirmDialogConfigTests/ConfirmDialogConfigTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Dialogs/ConfirmDialogConfigTests/ConfirmDialogConfigTests.cs
@@ -1,0 +1,73 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Softeq.XToolkit.WhiteLabel.Dialogs;
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Dialogs.ConfirmDialogConfigTests
+{
+    public class ConfirmDialogConfigTests
+    {
+        private const string EmptyString = "";
+        private const string NonEmptyTitle = "Abc Title";
+        private const string NonEmptyMessage = "Abc Message";
+        private const string NonEmptyAcceptButtonText = "Abc Accept Button";
+        private const string NonEmptyCancelButtonText = "Abc Cancel Button";
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NullTitle_ThrowsCorrectException(
+            [CombinatorialValues(null, EmptyString, NonEmptyMessage)] string message,
+            [CombinatorialValues(null, EmptyString, NonEmptyAcceptButtonText)] string acceptButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(true, false)] bool isDestructive)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new ConfirmDialogConfig(null, message, acceptButtonText, cancelButtonText, isDestructive));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NullMessage_ThrowsCorrectException(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(null, EmptyString, NonEmptyAcceptButtonText)] string acceptButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(true, false)] bool isDestructive)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new ConfirmDialogConfig(title, null, acceptButtonText, cancelButtonText, isDestructive));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NonNullMessage_NullAcceptButtonText_ThrowsCorrectException(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(EmptyString, NonEmptyMessage)] string message,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(true, false)] bool isDestructive)
+        {
+            Assert.Throws<ArgumentNullException>(()
+                => new ConfirmDialogConfig(title, message, null, cancelButtonText, isDestructive));
+        }
+
+        [Theory]
+        [PairwiseData]
+        public void Ctor_NonNullTitle_NonNullMessage_NonNullAcceptButtonText_FillsProperties(
+            [CombinatorialValues(EmptyString, NonEmptyTitle)] string title,
+            [CombinatorialValues(EmptyString, NonEmptyMessage)] string message,
+            [CombinatorialValues(EmptyString, NonEmptyAcceptButtonText)] string acceptButtonText,
+            [CombinatorialValues(null, EmptyString, NonEmptyCancelButtonText)] string cancelButtonText,
+            [CombinatorialValues(true, false)] bool isDestructive)
+        {
+            var confirmDialogConfig =
+                new ConfirmDialogConfig(title, message, acceptButtonText, cancelButtonText, isDestructive);
+
+            Assert.Equal(title, confirmDialogConfig.Title);
+            Assert.Equal(message, confirmDialogConfig.Message);
+            Assert.Equal(acceptButtonText, confirmDialogConfig.AcceptButtonText);
+            Assert.Equal(cancelButtonText, confirmDialogConfig.CancelButtonText);
+            Assert.Equal(isDestructive, confirmDialogConfig.IsDestructive);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/Stubs/TypeStubs.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Stubs/TypeStubs.cs
@@ -3,7 +3,7 @@
 
 using Softeq.XToolkit.WhiteLabel.Mvvm;
 
-namespace Softeq.XToolkit.Whitelabel.Tests.Bootstrapper.DefaultViewModelFinderTests
+namespace Softeq.XToolkit.WhiteLabel.Tests.Stubs
 {
     internal interface IDroidViewStub { }
 

--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
@@ -42,14 +42,12 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             string? cancelButtonText = null,
             OpenDialogOptions? options = null)
         {
-            return ShowDialogAsync(new ConfirmDialogConfig
-            {
-                Title = title,
-                Message = message,
-                AcceptButtonText = okButtonText,
-                CancelButtonText = cancelButtonText,
-                IsDestructive = options?.DialogType == DialogType.Destructive
-            });
+            return ShowDialogAsync(new ConfirmDialogConfig(
+                title,
+                message,
+                okButtonText,
+                cancelButtonText,
+                options?.DialogType == DialogType.Destructive));
         }
 
         public virtual Task ShowDialogAsync(AlertDialogConfig config)
@@ -97,6 +95,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             {
                 _logger.Error(e);
             }
+
             return default!;
         }
 
@@ -120,6 +119,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             {
                 _logger.Error(e);
             }
+
             return default!;
         }
 
@@ -128,7 +128,12 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             where TViewModel : IDialogViewModel
         {
             var viewModel = _container.Resolve<TViewModel>();
-            viewModel.ApplyParameters(parameters);
+
+            if (parameters != null)
+            {
+                viewModel.ApplyParameters(parameters);
+            }
+
             var presentedViewController = await PresentModalViewControllerAsync(viewModel).ConfigureAwait(false);
             try
             {
@@ -140,6 +145,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             {
                 _logger.Warn(e);
             }
+
             return new PresentationResult(presentedViewController, null);
         }
 

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
@@ -6,7 +6,8 @@ using System;
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
 {
     /// <summary>
-    ///    An interface that decouples from any implementation of DI container that used for registering dependencies.
+    ///    An interface that decouples from any implementation of IoC container
+    ///    that is used for registering dependencies.
     /// </summary>
     public interface IContainerBuilder
     {

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/BootstrapperBase.cs
@@ -32,15 +32,19 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
             return BuildContainer(containerBuilder);
         }
 
+        /// <summary>
+        ///     Creates IoC container builder. It will be used to build IoC container later.
+        /// </summary>
+        /// <returns>IoC container builder.</returns>
         protected virtual IContainerBuilder CreateContainerBuilder()
         {
             return new DryIocContainerBuilder();
         }
 
         /// <summary>
-        ///     Registers internal services in DI container.
+        ///     Registers internal services in IoC container builder.
         /// </summary>
-        /// <param name="builder">Implementation of DI container.</param>
+        /// <param name="builder">IoC container builder.</param>
         protected virtual void RegisterInternalServices(IContainerBuilder builder)
         {
             // logs
@@ -55,10 +59,11 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         }
 
         /// <summary>
-        ///     Registers additional types from the specified assemblies to DI container.
+        ///     Registers additional types from the specified assemblies in the specified
+        ///     IoC container builder.
         ///     Assemblies should be specified as the return value of the <see cref="SelectAssemblies"/> method.
         /// </summary>
-        /// <param name="builder">Implementation of DI container.</param>
+        /// <param name="builder">IoC container builder.</param>
         protected virtual void RegisterFromAssemblies(IContainerBuilder builder)
         {
             var assemblies = SelectAssemblies();
@@ -69,13 +74,13 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         /// <summary>
         ///     Override to tell the framework where to find assemblies to inspect for views, etc.
         /// </summary>
-        /// <returns>A list of assemblies to inspect.</returns>
+        /// <returns>The list of assemblies to inspect.</returns>
         protected abstract IList<Assembly> SelectAssemblies();
 
         /// <summary>
         ///    Initializes <see cref="AssemblySourceCache"/>.
         /// </summary>
-        /// <param name="assemblies">List of Assemblies to cache.</param>
+        /// <param name="assemblies">List of assemblies to cache.</param>
         protected virtual void InitializeAssemblySource(IEnumerable<Assembly> assemblies)
         {
             AssemblySourceCache.Install();
@@ -93,14 +98,15 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         ///     The predicate of extracting type for storing in the cache.
         /// </summary>
         /// <param name="type"><see cref="T:System.Type"/> of the object.</param>
-        /// <returns><c>true</c> when type should be extracted.</returns>
+        /// <returns><see langword="true"/> when the type should be extracted.</returns>
         protected abstract bool IsExtractToAssembliesCache(Type type);
 
         /// <summary>
-        ///     Registers types from the specified assemblies.
+        ///     Registers types from the specified assemblies
+        ///     in the specified IoC container builder.
         /// </summary>
-        /// <param name="builder">Implementation of DI container.</param>
-        /// <param name="assemblies">List of source Assemblies to register.</param>
+        /// <param name="builder">IoC container builder.</param>
+        /// <param name="assemblies">List of source assemblies to register.</param>
         protected virtual void RegisterTypesFromAssemblies(IContainerBuilder builder, IList<Assembly> assemblies)
         {
         }
@@ -108,14 +114,14 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper
         /// <summary>
         ///     Override to configure the framework and setup your IoC container.
         /// </summary>
-        /// <param name="builder">Implementation of DI container.</param>
+        /// <param name="builder">IoC container builder.</param>
         protected abstract void ConfigureIoc(IContainerBuilder builder);
 
         /// <summary>
-        ///    Builds DI container.
+        ///    Builds IoC container.
         /// </summary>
-        /// <param name="builder">Implementation of DI container.</param>
-        /// <returns>DI container.</returns>
+        /// <param name="builder">IoC container builder.</param>
+        /// <returns>IoC container.</returns>
         protected virtual IContainer BuildContainer(IContainerBuilder builder)
         {
             return builder.Build();

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
@@ -2,27 +2,44 @@
 // http://www.softeq.com
 
 using System;
+using System.Runtime.CompilerServices;
 using DryIoc;
 using IContainer = Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract.IContainer;
 using IDryContainer = DryIoc.IContainer;
 
+[assembly: InternalsVisibleTo("Softeq.XToolkit.WhiteLabel.Tests")]
+
 namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
 {
+    /// <summary>
+    ///     An implementation of <see cref="IContainer"/> interface that resolves dependencies using
+    ///     <see cref="T:DryIoc.IContainer"/> from <see href="https://github.com/dadhi/DryIoc">DryIoc</see> library.
+    /// </summary>
     internal class DryIocContainerAdapter : IContainer
     {
         private IDryContainer _container = default!;
 
+        /// <summary>
+        ///     Initializes current service with the specified instance of <see cref="T:DryIoc.IContainer"/>.
+        /// </summary>
+        /// <param name="container">Instance of <see cref="T:DryIoc.IContainer"/>.</param>
         internal void Initialize(IDryContainer container)
         {
-            _container = container;
+            _container = container ?? throw new ArgumentNullException(nameof(container));
         }
 
         /// <inheritdoc/>
         public TService Resolve<TService>(params object[] parameters) where TService : notnull
         {
+            if (_container == null)
+            {
+                throw new InvalidOperationException("DryIocContainerAdapter is not initialized");
+            }
+
             return _container.Resolve<TService>(parameters);
         }
 
+        /// <inheritdoc/>
         public Lazy<TService> ResolveLazy<TService>() where TService : notnull
         {
             return new Lazy<TService>(() => _container.Resolve<TService>());

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/ActionSheetDialogConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/ActionSheetDialogConfig.cs
@@ -4,31 +4,51 @@
 namespace Softeq.XToolkit.WhiteLabel.Dialogs
 {
     /// <summary>
-    ///     Displays a native platform action sheet,
-    ///     allowing the application user to choose from several buttons.
+    ///     Configuration of an action sheet dialog
+    ///     that allows user to choose from several options.
     /// </summary>
     public class ActionSheetDialogConfig
     {
         /// <summary>
-        ///     Title of the displayed action sheet.
+        ///     Initializes a new instance of the <see cref="ActionSheetDialogConfig"/> class.
         /// </summary>
-        public string? Title { get; set; }
+        /// <param name="optionButtons">The text to be displayed on the option buttons.</param>
+        /// <param name="title">Dialog title.</param>
+        /// <param name="cancelButtonText">The text to be displayed on the 'Cancel' button.</param>
+        /// <param name="destructButtonText">The text to be displayed on the 'Destruct' button.</param>
+        public ActionSheetDialogConfig(
+            string[]? optionButtons,
+            string? title = null,
+            string? cancelButtonText = null,
+            string? destructButtonText = null)
+        {
+            OptionButtons = optionButtons ?? new string[] { };
+            Title = title;
+            CancelButtonText = cancelButtonText;
+            DestructButtonText = destructButtonText;
+        }
 
         /// <summary>
-        ///     Text to be displayed in the 'Cancel' button.
-        ///     Can be null to hide the cancel action.
+        ///     Gets the dialog title.
+        ///     Can be <see langword="null"/> to hide the title.
         /// </summary>
-        public string? CancelButtonText { get; set; }
+        public string? Title { get; }
 
         /// <summary>
-        ///     Text to be displayed in the 'Destruct' button.
-        ///     Can be null to hide the destructive option.
+        ///     Gets the text to be displayed on the 'Cancel' button.
+        ///     Can be <see langword="null"/> to hide the 'Cancel' button.
         /// </summary>
-        public string? DestructButtonText { get; set; }
+        public string? CancelButtonText { get; }
 
         /// <summary>
-        ///     Text labels for additional buttons.
+        ///     Gets the text to be displayed on the 'Destruct' button.
+        ///     Can be <see langword="null"/> to hide the 'Destruct' button.
         /// </summary>
-        public string[] OptionButtons { get; set; } = new string[] {};
+        public string? DestructButtonText { get; }
+
+        /// <summary>
+        ///    Gets the text to be displayed on the option buttons.
+        /// </summary>
+        public string[] OptionButtons { get; }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/AlertDialogConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/AlertDialogConfig.cs
@@ -1,33 +1,41 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
+
 namespace Softeq.XToolkit.WhiteLabel.Dialogs
 {
     /// <summary>
-    ///     Presents an alert dialog to the application user with a single cancel button.
+    ///     Configuration of an alert dialog with a single 'Close' button.
     /// </summary>
     public class AlertDialogConfig
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AlertDialogConfig"/> class.
+        /// </summary>
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog message.</param>
+        /// <param name="closeButtonText">The text to be displayed on the 'Close' button.</param>
         public AlertDialogConfig(string title, string message, string closeButtonText)
         {
-            Title = title;
-            Message = message;
-            CloseButtonText = closeButtonText;
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            CloseButtonText = closeButtonText ?? throw new ArgumentNullException(nameof(closeButtonText));
         }
 
         /// <summary>
-        ///     The title of the alert dialog.
+        ///    Gets the dialog title.
         /// </summary>
-        public string Title { get; set; }
+        public string Title { get; }
 
         /// <summary>
-        ///     The body text of the alert dialog.
+        ///     Gets the dialog message.
         /// </summary>
-        public string Message { get; set; }
+        public string Message { get; }
 
         /// <summary>
-        ///     Text to be displayed on the close button.
+        ///     Gets the text to be displayed on the 'Close' button.
         /// </summary>
-        public string CloseButtonText { get; set; }
+        public string CloseButtonText { get; }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/ConfirmDialogConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/ConfirmDialogConfig.cs
@@ -2,55 +2,70 @@
 // http://www.softeq.com
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
+using System;
+
 namespace Softeq.XToolkit.WhiteLabel.Dialogs
 {
     /// <summary>
-    ///     Presents an alert dialog to the application user with an accept and a cancel button.
+    ///     Configuration of an alert dialog with 'Confirm' and 'Cancel' buttons.
     /// </summary>
     public class ConfirmDialogConfig
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ConfirmDialogConfig"/> class.
+        /// </summary>
+        /// <param name="title">Dialog title.</param>
+        /// <param name="message">Dialog message.</param>
+        /// <param name="acceptButtonText">The text to be displayed on the 'Accept' button.</param>
+        /// <param name="cancelButtonText">The text to be displayed on the 'Cancel' button.</param>
+        /// <param name="isDestructive">
+        ///     Value indicating whether the 'Accept' button should look destructive on UI.
+        /// </param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="title"/>
+        ///     and <paramref name="message"/>
+        ///     and <paramref name="acceptButtonText"/>
+        ///     cannot be null.
+        /// </exception>
         public ConfirmDialogConfig(
             string title,
             string message,
             string acceptButtonText,
-            string cancelButtonText)
+            string? cancelButtonText = null,
+            bool isDestructive = false)
         {
-            Title = title;
-            Message = message;
-            AcceptButtonText = acceptButtonText;
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            AcceptButtonText = acceptButtonText ?? throw new ArgumentNullException(nameof(acceptButtonText));
             CancelButtonText = cancelButtonText;
-        }
-
-        public ConfirmDialogConfig()
-        {
-            Title = string.Empty;
-            Message = string.Empty;
-            AcceptButtonText = string.Empty;
+            IsDestructive = isDestructive;
         }
 
         /// <summary>
-        ///     The title of the alert dialog.
+        ///     Gets the dialog title.
         /// </summary>
-        public string Title { get; set; }
+        public string Title { get; }
 
         /// <summary>
-        ///     The body text of the alert dialog.
+        ///     Gets the dialog message.
         /// </summary>
-        public string Message { get; set; }
+        public string Message { get; }
 
         /// <summary>
-        ///     Text to be displayed on the 'Accept' button.
+        ///     Gets the text to be displayed on the 'Accept' button.
         /// </summary>
-        public string AcceptButtonText { get; set; }
+        public string AcceptButtonText { get; }
 
         /// <summary>
-        ///     Text to be displayed on the 'Cancel' button.
+        ///     Gets the text to be displayed on the 'Cancel' button.
+        ///     Can be <see langword="null"/> to hide the 'Cancel' button.
         /// </summary>
-        public string? CancelButtonText { get; set; }
+        public string? CancelButtonText { get; }
 
         /// <summary>
-        ///     Declares that 'Accept' button should look destructive on UI.
+        ///     Gets a value indicating whether
+        ///     the 'Accept' button should look destructive on UI.
         /// </summary>
-        public bool IsDestructive { get; set; }
+        public bool IsDestructive { get; }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/IDialog.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/IDialog.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 namespace Softeq.XToolkit.WhiteLabel.Dialogs
 {
     /// <summary>
-    ///     The main contract of dialogue implementation.
+    ///     The main contract of dialog implementation.
     /// </summary>
     /// <typeparam name="T">Type of dialog result.</typeparam>
     public interface IDialog<T>
     {
         /// <summary>
-        ///    Shows dialog asynchronously with a return result of work.
+        ///    Shows dialog asynchronously.
         /// </summary>
         /// <returns>Dialog result.</returns>
         Task<T> ShowAsync();

--- a/samples/Playground/Playground/ViewModels/Dialogs/DialogsPageViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/Dialogs/DialogsPageViewModel.cs
@@ -106,10 +106,7 @@ namespace Playground.ViewModels.Dialogs
 
         private async Task OpenConfirm()
         {
-            var config = new ConfirmDialogConfig("~title - remove?", "~message", "~yes", "~no")
-            {
-                IsDestructive = true
-            };
+            var config = new ConfirmDialogConfig("~title - remove?", "~message", "~yes", "~no", true);
             var result = await _dialogsService.ShowDialogAsync(config);
 
             ConfirmResult = result ? "Removed" : "Declined";
@@ -117,18 +114,16 @@ namespace Playground.ViewModels.Dialogs
 
         private async Task OpenActionSheet()
         {
-            var config = new ActionSheetDialogConfig
-            {
-                Title = "~title",
-                OptionButtons = new[]
+            var config = new ActionSheetDialogConfig(
+                new[]
                 {
                     "~option 1",
                     "~option 2",
                     "~option 3"
                 },
-                CancelButtonText = "~cancel",
-                DestructButtonText = "~destruct"
-            };
+                "~title",
+                "~cancel",
+                "~destruct");
             var result = await _dialogsService.ShowDialogAsync(config);
 
             ActionSheetResult = result;


### PR DESCRIPTION
### Description

- Tests and documentation added for dialog configs;
- Tests and documentation added for DryIocContainerAdapter;
- Documentation for BootstrapperBase and ContainerBuilder reworked;

### API Changes
DialogConfig classes are now immutable and throw exceptions when initialized with incorrect values.

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
