### PR TITLE
Android: fix crash when trying to perform navigation in incorrect sta…

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/FrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/FrameNavigationService.cs
@@ -170,5 +170,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
         {
             return _backStack.Any(item => ReferenceEquals(item.ViewModel, viewModelBase));
         }
+
+        public void RestoreUnfinishedNavigation()
+        {
+        }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Forms/Navigation/FormsFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Forms/Navigation/FormsFrameNavigationService.cs
@@ -61,5 +61,10 @@ namespace Softeq.XToolkit.WhiteLabel.Forms.Navigation
         {
             throw new NotImplementedException();
         }
+
+        public void RestoreUnfinishedNavigation()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
@@ -71,6 +71,10 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
         {
         }
 
+        void IFrameNavigationService.RestoreUnfinishedNavigation()
+        {
+        }
+
         void IFrameNavigationService.NavigateToFirstPage()
         {
         }

--- a/Softeq.XToolkit.WhiteLabel/Navigation/IFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel/Navigation/IFrameNavigationService.cs
@@ -62,5 +62,10 @@ namespace Softeq.XToolkit.WhiteLabel.Navigation
         ///     Restores the last fragment after a switch between tabs or back navigation.
         /// </summary>
         void RestoreNavigation();
+
+        /// <summary>
+        ///     Restores the last fragment only if there was an unfinished navigation transaction.
+        /// </summary>
+        void RestoreUnfinishedNavigation();
     }
 }


### PR DESCRIPTION
### Description

- Fix Android crash when trying to perform navigation in incorrect state (for instance, after application was minimized)
- Add method to restore unfinished navigation if any after such situation

### API Changes

Added:
 - void IFrameNavigationService.RestoreUnfinishedNavigation();

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
