### PR TITLE
Add tests for pagination view models

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Tests/Stubs/MainThreadExecutorBaseStub.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/Stubs/MainThreadExecutorBaseStub.cs
@@ -1,0 +1,18 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using Softeq.XToolkit.Common.Threading;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.Stubs
+{
+    internal class MainThreadExecutorBaseStub : MainThreadExecutorBase
+    {
+        public override bool IsMainThread => true;
+
+        protected override void PlatformBeginInvokeOnMainThread(Action action)
+        {
+            action();
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
@@ -2,14 +2,12 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using NSubstitute;
 using Softeq.XToolkit.Common.Threading;
 using Softeq.XToolkit.WhiteLabel.Model;
 using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
-using Softeq.XToolkit.WhiteLabel.ViewModels;
 using Xunit;
 
 namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelBaseTests
@@ -107,30 +105,6 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelB
             await _dataLoader
                 .Received()
                 .Invoke(Arg.Is(LastSearchQuery), Arg.Any<int>(), Arg.Any<int>());
-        }
-    }
-
-    internal class TestPaginationSearchViewModelBaseTests : PaginationSearchViewModelBase<string, string>
-    {
-        private readonly Func<string, int, int, Task<PagingModel<string>>> _dataLoader;
-
-        public TestPaginationSearchViewModelBaseTests(Func<string, int, int, Task<PagingModel<string>>> dataLoader)
-        {
-            _dataLoader = dataLoader;
-        }
-
-        public int TestSearchDelay => SearchDelay;
-
-        protected override int SearchDelay => 50;
-
-        protected override IList<string> MapItemsToViewModels(IList<string> models)
-        {
-            return models;
-        }
-
-        protected override Task<PagingModel<string>> LoadAsync(string query, int pageNumber, int pageSize)
-        {
-            return _dataLoader(query, pageNumber, pageSize);
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
@@ -1,10 +1,14 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using NSubstitute;
+using Softeq.XToolkit.Common.Threading;
 using Softeq.XToolkit.WhiteLabel.Model;
+using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
 using Softeq.XToolkit.WhiteLabel.ViewModels;
 using Xunit;
 
@@ -12,12 +16,22 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelB
 {
     public class PaginationSearchViewModelBaseTests
     {
+        private readonly Func<string, int, int, Task<PagingModel<string>>> _dataLoader;
         private readonly TestPaginationSearchViewModelBaseTests _viewModel;
 
         public PaginationSearchViewModelBaseTests()
         {
-            _viewModel = new TestPaginationSearchViewModelBaseTests();
+            _dataLoader = Substitute.For<Func<string, int, int, Task<PagingModel<string>>>>();
+            _dataLoader
+                .Invoke(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(new PagingModel<string>()));
+
+            _viewModel = new TestPaginationSearchViewModelBaseTests(_dataLoader);
+
+            Execute.Initialize(new MainThreadExecutorBaseStub());
         }
+
+        private int TestSearchDelay => _viewModel.TestSearchDelay + 100;
 
         [Fact]
         public void ClearCommand_Default_ReturnsICommand()
@@ -48,10 +62,67 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelB
         {
             Assert.False(_viewModel.IsBusy);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public async Task SearchQuery_NullOrWhiteSpace_DoesNotLoadData(string input)
+        {
+            _viewModel.SearchQuery = input;
+
+            await Task.Delay(TestSearchDelay);
+
+            await _dataLoader
+                .DidNotReceive()
+                .Invoke(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>());
+        }
+
+        [Theory]
+        [InlineData("test")]
+        [InlineData(" test")]
+        [InlineData("test ")]
+        public async Task SearchQuery_NotEmpty_DoesNotLoadData(string input)
+        {
+            _viewModel.SearchQuery = input;
+
+            await Task.Delay(TestSearchDelay);
+
+            await _dataLoader
+                .Received()
+                .Invoke(Arg.Is(input), Arg.Any<int>(), Arg.Any<int>());
+        }
+
+        [Fact]
+        public async Task SearchQuery_MultipleConsecutiveQueries_LoadsOnlyLastSearchQuery()
+        {
+            const string FirstSearchQuery = "test1";
+            const string LastSearchQuery = "test2";
+
+            _viewModel.SearchQuery = FirstSearchQuery;
+            _viewModel.SearchQuery = LastSearchQuery;
+
+            await Task.Delay(TestSearchDelay);
+
+            await _dataLoader
+                .Received()
+                .Invoke(Arg.Is(LastSearchQuery), Arg.Any<int>(), Arg.Any<int>());
+        }
     }
 
     internal class TestPaginationSearchViewModelBaseTests : PaginationSearchViewModelBase<string, string>
     {
+        private readonly Func<string, int, int, Task<PagingModel<string>>> _dataLoader;
+
+        public TestPaginationSearchViewModelBaseTests(Func<string, int, int, Task<PagingModel<string>>> dataLoader)
+        {
+            _dataLoader = dataLoader;
+        }
+
+        public int TestSearchDelay => SearchDelay;
+
+        protected override int SearchDelay => 50;
+
         protected override IList<string> MapItemsToViewModels(IList<string> models)
         {
             return models;
@@ -59,7 +130,7 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelB
 
         protected override Task<PagingModel<string>> LoadAsync(string query, int pageNumber, int pageSize)
         {
-            throw new System.NotImplementedException();
+            return _dataLoader(query, pageNumber, pageSize);
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/PaginationSearchViewModelBaseTests.cs
@@ -1,0 +1,65 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Softeq.XToolkit.WhiteLabel.Model;
+using Softeq.XToolkit.WhiteLabel.ViewModels;
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelBaseTests
+{
+    public class PaginationSearchViewModelBaseTests
+    {
+        private readonly TestPaginationSearchViewModelBaseTests _viewModel;
+
+        public PaginationSearchViewModelBaseTests()
+        {
+            _viewModel = new TestPaginationSearchViewModelBaseTests();
+        }
+
+        [Fact]
+        public void ClearCommand_Default_ReturnsICommand()
+        {
+            Assert.IsAssignableFrom<ICommand>(_viewModel.ClearCommand);
+        }
+
+        [Fact]
+        public void SearchCommand_Default_ReturnsICommand()
+        {
+            Assert.IsAssignableFrom<ICommand>(_viewModel.SearchCommand);
+        }
+
+        [Fact]
+        public void SearchQuery_Default_ReturnsEmptyString()
+        {
+            Assert.Equal(string.Empty, _viewModel.SearchQuery);
+        }
+
+        [Fact]
+        public void HasResults_Default_ReturnsFalse()
+        {
+            Assert.False(_viewModel.HasResults);
+        }
+
+        [Fact]
+        public void IsBusy_Default_ReturnsFalse()
+        {
+            Assert.False(_viewModel.IsBusy);
+        }
+    }
+
+    internal class TestPaginationSearchViewModelBaseTests : PaginationSearchViewModelBase<string, string>
+    {
+        protected override IList<string> MapItemsToViewModels(IList<string> models)
+        {
+            return models;
+        }
+
+        protected override Task<PagingModel<string>> LoadAsync(string query, int pageNumber, int pageSize)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/TestPaginationSearchViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/TestPaginationSearchViewModelBaseTests.cs
@@ -1,0 +1,35 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Softeq.XToolkit.WhiteLabel.Model;
+using Softeq.XToolkit.WhiteLabel.ViewModels;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelBaseTests
+{
+    internal class TestPaginationSearchViewModelBaseTests : PaginationSearchViewModelBase<string, string>
+    {
+        private readonly Func<string, int, int, Task<PagingModel<string>>> _dataLoader;
+
+        public TestPaginationSearchViewModelBaseTests(Func<string, int, int, Task<PagingModel<string>>> dataLoader)
+        {
+            _dataLoader = dataLoader;
+        }
+
+        public int TestSearchDelay => SearchDelay;
+
+        protected override int SearchDelay => 50;
+
+        protected override IList<string> MapItemsToViewModels(IList<string> models)
+        {
+            return models;
+        }
+
+        protected override Task<PagingModel<string>> LoadAsync(string query, int pageNumber, int pageSize)
+        {
+            return _dataLoader(query, pageNumber, pageSize);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/TestPaginationSearchViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationSearchViewModelBaseTests/TestPaginationSearchViewModelBaseTests.cs
@@ -27,9 +27,9 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationSearchViewModelB
             return models;
         }
 
-        protected override Task<PagingModel<string>> LoadAsync(string query, int pageNumber, int pageSize)
+        protected override Task<PagingModel<string>> LoadAsync(string query, int pageIndex, int pageSize)
         {
-            return _dataLoader(query, pageNumber, pageSize);
+            return _dataLoader(query, pageIndex, pageSize);
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
@@ -1,0 +1,119 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Threading.Tasks;
+using Softeq.XToolkit.Common.Threading;
+using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
+using Xunit;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTests
+{
+    public class PaginationViewModelBaseTests
+    {
+        private const int DefaultCurrentPage = -1;
+
+        private readonly TestPaginationViewModelBase _viewModel;
+
+        public PaginationViewModelBaseTests()
+        {
+            _viewModel = new TestPaginationViewModelBase();
+
+            Execute.Initialize(new MainThreadExecutorBaseStub());
+        }
+
+        [Fact]
+        public void Ctor_Default_ReturnsNegativeCurrentPage()
+        {
+            Assert.Equal(DefaultCurrentPage, _viewModel.CurrentPage);
+        }
+
+        [Fact]
+        public void Ctor_Default_ReturnsCanLoadMoreFalse()
+        {
+            Assert.False(_viewModel.CanLoadMore);
+        }
+
+        [Fact]
+        public void Ctor_Default_ReturnsNotNullLoadMoreCommand()
+        {
+            Assert.NotNull(_viewModel.LoadMoreCommand);
+        }
+
+        [Fact]
+        public void Ctor_Default_ReturnsEmptyItems()
+        {
+            Assert.Empty(_viewModel.Items);
+        }
+
+        [Theory]
+        [InlineData(3, 3)]
+        [InlineData(12, 100)]
+        public async Task LoadFirstPageAsync_TestData_LoadsItems(int pageSize, int totalItemsCount)
+        {
+            _viewModel.PublicPageSize = pageSize;
+            _viewModel.TotalItemsCount = totalItemsCount;
+
+            await _viewModel.PublicLoadFirstPageAsync();
+
+            Assert.Equal(0, _viewModel.CurrentPage);
+            Assert.Equal(pageSize, _viewModel.Items.Count);
+        }
+
+        [Fact]
+        public async Task ResetItems_NotEmpty_Resets()
+        {
+            _viewModel.PublicPageSize = 2;
+            _viewModel.TotalItemsCount = 2;
+            await _viewModel.PublicLoadFirstPageAsync();
+
+            _viewModel.ResetItems();
+
+            Assert.Equal(DefaultCurrentPage, _viewModel.CurrentPage);
+            Assert.Empty(_viewModel.Items);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2, 2, 1)]
+        [InlineData(3, 2, 2)]
+        public async Task LoadMoreCommand_SingleCallForNotEmptyItems_AddsItems(
+            int totalItemsCount,
+            int pageSize,
+            int totalPagesCount)
+        {
+            _viewModel.PublicPageSize = pageSize;
+            _viewModel.TotalItemsCount = totalItemsCount;
+            await _viewModel.PublicLoadFirstPageAsync();
+
+            await _viewModel.LoadMoreCommand.ExecuteAsync(null!);
+
+            Assert.Equal(totalPagesCount - 1, _viewModel.CurrentPage);
+            Assert.Equal(totalItemsCount, _viewModel.Items.Count);
+        }
+
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2, 2, 1)]
+        [InlineData(3, 2, 2)]
+        [InlineData(4, 1, 4)]
+        [InlineData(7, 2, 4)]
+        public async Task LoadMoreCommand_MultipleCallsForNotEmptyItems_AddsItems(
+            int totalItemsCount,
+            int pageSize,
+            int totalPagesCount)
+        {
+            _viewModel.PublicPageSize = pageSize;
+            _viewModel.TotalItemsCount = totalItemsCount;
+            await _viewModel.PublicLoadFirstPageAsync();
+
+            var t1 = _viewModel.LoadMoreCommand.ExecuteAsync(null!);
+            var t2 = _viewModel.LoadMoreCommand.ExecuteAsync(null!);
+            var t3 = _viewModel.LoadMoreCommand.ExecuteAsync(null!);
+
+            await Task.WhenAll(t1, t2, t3);
+
+            Assert.Equal(totalPagesCount - 1, _viewModel.CurrentPage);
+            Assert.Equal(totalItemsCount, _viewModel.Items.Count);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
@@ -51,10 +51,10 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
         [InlineData(12, 100)]
         public async Task LoadFirstPageAsync_TestData_LoadsItems(int pageSize, int totalItemsCount)
         {
-            _viewModel.PublicPageSize = pageSize;
-            _viewModel.TotalItemsCount = totalItemsCount;
+            _viewModel.TestPageSize = pageSize;
+            _viewModel.TestTotalItemsCount = totalItemsCount;
 
-            await _viewModel.PublicLoadFirstPageAsync();
+            await _viewModel.TestLoadFirstPageAsync();
 
             Assert.Equal(0, _viewModel.CurrentPage);
             Assert.Equal(pageSize, _viewModel.Items.Count);
@@ -63,9 +63,9 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
         [Fact]
         public async Task ResetItems_NotEmpty_Resets()
         {
-            _viewModel.PublicPageSize = 2;
-            _viewModel.TotalItemsCount = 2;
-            await _viewModel.PublicLoadFirstPageAsync();
+            _viewModel.TestPageSize = 2;
+            _viewModel.TestTotalItemsCount = 2;
+            await _viewModel.TestLoadFirstPageAsync();
 
             _viewModel.ResetItems();
 
@@ -82,9 +82,9 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
             int pageSize,
             int totalPagesCount)
         {
-            _viewModel.PublicPageSize = pageSize;
-            _viewModel.TotalItemsCount = totalItemsCount;
-            await _viewModel.PublicLoadFirstPageAsync();
+            _viewModel.TestPageSize = pageSize;
+            _viewModel.TestTotalItemsCount = totalItemsCount;
+            await _viewModel.TestLoadFirstPageAsync();
 
             await _viewModel.LoadMoreCommand.ExecuteAsync(null!);
 
@@ -103,9 +103,9 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
             int pageSize,
             int totalPagesCount)
         {
-            _viewModel.PublicPageSize = pageSize;
-            _viewModel.TotalItemsCount = totalItemsCount;
-            await _viewModel.PublicLoadFirstPageAsync();
+            _viewModel.TestPageSize = pageSize;
+            _viewModel.TestTotalItemsCount = totalItemsCount;
+            await _viewModel.TestLoadFirstPageAsync();
 
             var t1 = _viewModel.LoadMoreCommand.ExecuteAsync(null!);
             var t2 = _viewModel.LoadMoreCommand.ExecuteAsync(null!);

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
@@ -116,5 +116,15 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
             Assert.Equal(totalPagesCount - 1, _viewModel.CurrentPage);
             Assert.Equal(totalItemsCount, _viewModel.Items.Count);
         }
+
+        [Fact]
+        public async Task CanLoadMore_AllItemsLoaded_ReturnsFalse()
+        {
+            _viewModel.TestPageSize = 2;
+            _viewModel.TestTotalItemsCount = 2;
+            await _viewModel.TestLoadFirstPageAsync();
+
+            Assert.False(_viewModel.CanLoadMore);
+        }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/PaginationViewModelBaseTests.cs
@@ -2,6 +2,7 @@
 // http://www.softeq.com
 
 using System.Threading.Tasks;
+using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.Common.Threading;
 using Softeq.XToolkit.WhiteLabel.Tests.Stubs;
 using Xunit;
@@ -22,25 +23,25 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
         }
 
         [Fact]
-        public void Ctor_Default_ReturnsNegativeCurrentPage()
+        public void CurrentPage_Default_ReturnsNegative()
         {
             Assert.Equal(DefaultCurrentPage, _viewModel.CurrentPage);
         }
 
         [Fact]
-        public void Ctor_Default_ReturnsCanLoadMoreFalse()
+        public void CanLoadMore_Default_ReturnsFalse()
         {
             Assert.False(_viewModel.CanLoadMore);
         }
 
         [Fact]
-        public void Ctor_Default_ReturnsNotNullLoadMoreCommand()
+        public void LoadMoreCommand_Default_ReturnsIAsyncCommand()
         {
-            Assert.NotNull(_viewModel.LoadMoreCommand);
+            Assert.IsAssignableFrom<IAsyncCommand>(_viewModel.LoadMoreCommand);
         }
 
         [Fact]
-        public void Ctor_Default_ReturnsEmptyItems()
+        public void Items_Default_ReturnsEmpty()
         {
             Assert.Empty(_viewModel.Items);
         }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
@@ -13,12 +13,12 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
 {
     internal class TestPaginationViewModelBase : PaginationViewModelBase<string, string>
     {
-        public int PublicPageSize { get; set; }
-        public int TotalItemsCount { get; set; }
+        public int TestPageSize { get; set; }
+        public int TestTotalItemsCount { get; set; }
 
-        protected override int PageSize => PublicPageSize;
+        protected override int PageSize => TestPageSize;
 
-        public async Task PublicLoadFirstPageAsync(CancellationToken ct = default)
+        public async Task TestLoadFirstPageAsync(CancellationToken ct = default)
         {
             await LoadFirstPageAsync(ct);
         }
@@ -36,7 +36,7 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
         private PagingModel<string> MockLoadAsync(int pageNumber, int pageSize)
         {
             var data = Enumerable
-                .Range(0, TotalItemsCount)
+                .Range(0, TestTotalItemsCount)
                 .Skip(pageNumber * pageSize)
                 .Take(pageSize)
                 .Select(x => x.ToString()).ToList();
@@ -46,8 +46,8 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
                 Page = pageNumber,
                 PageSize = data.Count,
                 Data = data,
-                TotalNumberOfPages = (int) Math.Ceiling(TotalItemsCount / (double)pageSize),
-                TotalNumberOfRecords = TotalItemsCount
+                TotalNumberOfPages = (int) Math.Ceiling(TestTotalItemsCount / (double)pageSize),
+                TotalNumberOfRecords = TestTotalItemsCount
             };
             return model;
         }

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
@@ -1,0 +1,55 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Softeq.XToolkit.WhiteLabel.Model;
+using Softeq.XToolkit.WhiteLabel.ViewModels;
+
+namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTests
+{
+    internal class TestPaginationViewModelBase : PaginationViewModelBase<string, string>
+    {
+        public int PublicPageSize { get; set; }
+        public int TotalItemsCount { get; set; }
+
+        protected override int PageSize => PublicPageSize;
+
+        public async Task PublicLoadFirstPageAsync(CancellationToken ct = default)
+        {
+            await LoadFirstPageAsync(ct);
+        }
+
+        protected override IList<string> MapItemsToViewModels(IList<string> models)
+        {
+            return models;
+        }
+
+        protected override Task<PagingModel<string>> LoadAsync(int pageNumber, int pageSize)
+        {
+            return Task.FromResult(MockLoadAsync(pageNumber, pageSize));
+        }
+
+        private PagingModel<string> MockLoadAsync(int pageNumber, int pageSize)
+        {
+            var data = Enumerable
+                .Range(0, TotalItemsCount)
+                .Skip(pageNumber * pageSize)
+                .Take(pageSize)
+                .Select(x => x.ToString()).ToList();
+
+            var model = new PagingModel<string>
+            {
+                Page = pageNumber,
+                PageSize = data.Count,
+                Data = data,
+                TotalNumberOfPages = (int) Math.Ceiling(TotalItemsCount / (double)pageSize),
+                TotalNumberOfRecords = TotalItemsCount
+            };
+            return model;
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Tests/ViewModels/PaginationViewModelBaseTests/TestPaginationViewModelBase.cs
@@ -28,9 +28,9 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
             return models;
         }
 
-        protected override Task<PagingModel<string>> LoadAsync(int pageNumber, int pageSize)
+        protected override Task<PagingModel<string>> LoadAsync(int pageIndex, int pageSize)
         {
-            return Task.FromResult(MockLoadAsync(pageNumber, pageSize));
+            return Task.FromResult(MockLoadAsync(pageIndex, pageSize));
         }
 
         private PagingModel<string> MockLoadAsync(int pageNumber, int pageSize)
@@ -39,7 +39,8 @@ namespace Softeq.XToolkit.WhiteLabel.Tests.ViewModels.PaginationViewModelBaseTes
                 .Range(0, TestTotalItemsCount)
                 .Skip(pageNumber * pageSize)
                 .Take(pageSize)
-                .Select(x => x.ToString()).ToList();
+                .Select(x => x.ToString())
+                .ToList();
 
             var model = new PagingModel<string>
             {

--- a/Softeq.XToolkit.WhiteLabel/Model/PagingModel.cs
+++ b/Softeq.XToolkit.WhiteLabel/Model/PagingModel.cs
@@ -17,7 +17,7 @@ namespace Softeq.XToolkit.WhiteLabel.Model
         public IList<T> Data { get; set; } = default!;
 
         /// <summary>
-        ///     Gets or sets the number of the current page.
+        ///     Gets or sets the index of the current page.
         /// </summary>
         public int Page { get; set; }
 

--- a/Softeq.XToolkit.WhiteLabel/Model/PagingModel.cs
+++ b/Softeq.XToolkit.WhiteLabel/Model/PagingModel.cs
@@ -5,12 +5,35 @@ using System.Collections.Generic;
 
 namespace Softeq.XToolkit.WhiteLabel.Model
 {
+    /// <summary>
+    ///    A model for representing data pagination.
+    /// </summary>
+    /// <typeparam name="T">The type of record.</typeparam>
     public class PagingModel<T>
     {
+        /// <summary>
+        ///     Gets or sets page data (list of records).
+        /// </summary>
         public IList<T> Data { get; set; } = default!;
+
+        /// <summary>
+        ///     Gets or sets the number of the current page.
+        /// </summary>
         public int Page { get; set; }
-        public int TotalNumberOfPages { get; set; }
-        public int TotalNumberOfRecords { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the length of the current page (records count).
+        /// </summary>
         public int PageSize { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the info about the total number of pages.
+        /// </summary>
+        public int TotalNumberOfPages { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the info about the total number of records.
+        /// </summary>
+        public int TotalNumberOfRecords { get; set; }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
@@ -10,6 +10,11 @@ using Softeq.XToolkit.WhiteLabel.Model;
 
 namespace Softeq.XToolkit.WhiteLabel.ViewModels
 {
+    /// <summary>
+    ///    A base view model for searching and representing results as paginated data.
+    /// </summary>
+    /// <typeparam name="TViewModel">The type of view model.</typeparam>
+    /// <typeparam name="TModel">The type of data model.</typeparam>
     public abstract class PaginationSearchViewModelBase<TViewModel, TModel>
         : PaginationViewModelBase<TViewModel, TModel>
     {
@@ -24,10 +29,23 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             SearchCommand = new RelayCommand(DoSearch);
         }
 
+        /// <summary>
+        ///     Gets the command to clear <see cref="SearchQuery"/> property.
+        /// </summary>
         public ICommand ClearCommand { get; }
 
+        /// <summary>
+        ///     Gets the command to perform the search.
+        /// </summary>
         public ICommand SearchCommand { get; }
 
+        /// <summary>
+        ///     Gets or sets the search query.
+        /// </summary>
+        /// <remarks>
+        ///     Empty values will be ignored by default, to change this behavior
+        ///     you can override <see cref="AllowEmptySearchQuery"/> property.
+        /// </remarks>
         public string? SearchQuery
         {
             get => _searchQuery;
@@ -52,22 +70,42 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             }
         }
 
+        /// <summary>
+        ///     Gets or sets a value indicating whether any result was found.
+        /// </summary>
         public bool HasResults
         {
             get => _hasContent;
-            set => Set(ref _hasContent, value);
+            protected set => Set(ref _hasContent, value);
         }
 
+        /// <summary>
+        ///     Gets or sets a value indicating whether this ViewModel is doing some work right now.
+        /// </summary>
+        /// <remarks>
+        ///     By default during the loading of more data, this value will not be used.
+        ///     You can override <see cref="SilentLoadPagesEnabled"/> property to change this behavior.
+        /// </remarks>
         public bool IsBusy
         {
             get => _isBusy;
-            set => Set(ref _isBusy, value);
+            protected set => Set(ref _isBusy, value);
         }
 
+        /// <summary>
+        ///     Gets the delay value between searches.
+        /// </summary>
         protected virtual int SearchDelay => 300;
 
+        /// <summary>
+        ///     Gets a value indicating whether property <see cref="IsBusy"/> will be changed
+        ///     when additional pages are loaded.
+        /// </summary>
         protected virtual bool SilentLoadPagesEnabled => true;
 
+        /// <summary>
+        ///     Gets a value indicating whether empty search query validation is disabled.
+        /// </summary>
         protected virtual bool AllowEmptySearchQuery => false;
 
         protected override CancellationToken CancellationToken => _lastSearchCancelSource.Token;

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
@@ -38,10 +38,10 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
                     return;
                 }
 
-                _searchQuery = value?.Trim();
+                _searchQuery = value;
                 RaisePropertyChanged();
 
-                if (string.IsNullOrEmpty(_searchQuery) && !AllowEmptySearchQuery)
+                if (string.IsNullOrWhiteSpace(_searchQuery) && !AllowEmptySearchQuery)
                 {
                     EmptyQuery();
                 }

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
@@ -185,6 +185,10 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             {
                 // ignored
             }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
         }
 
         protected virtual void HandleException(Exception ex)

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationSearchViewModelBase.cs
@@ -110,13 +110,13 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
 
         protected override CancellationToken CancellationToken => _lastSearchCancelSource.Token;
 
-        protected abstract Task<PagingModel<TModel>> LoadAsync(string? query, int pageNumber, int pageSize);
+        protected abstract Task<PagingModel<TModel>> LoadAsync(string? query, int pageIndex, int pageSize);
 
-        protected override async Task<PagingModel<TModel>?> LoadAsync(int pageNumber, int pageSize)
+        protected override async Task<PagingModel<TModel>?> LoadAsync(int pageIndex, int pageSize)
         {
             try
             {
-                return await LoadAsync(SearchQuery, pageNumber, pageSize);
+                return await LoadAsync(SearchQuery, pageIndex, pageSize);
             }
             catch (Exception ex)
             {
@@ -142,7 +142,7 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             ResetItems();
             HasResults = false;
 
-            _lastSearchCancelSource?.Cancel();
+            _lastSearchCancelSource.Cancel();
             ShowProgress(false);
         }
 

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Softeq.XToolkit.Common;
 using Softeq.XToolkit.Common.Collections;
 using Softeq.XToolkit.Common.Commands;
@@ -17,21 +16,30 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
     public abstract class PaginationViewModelBase<TViewModel, TModel> : ObservableObject
     {
         private const int DefaultPageSize = 20;
-        private bool _canLoadMore;
 
+        private bool _canLoadMore;
         private int _currentPage = -1;
 
         protected PaginationViewModelBase()
         {
-            LoadMoreCommand = new RelayCommand(LoadMore, () => CanLoadMore);
+            PageSize = DefaultPageSize;
+            CancellationToken = CancellationToken.None;
+            Items = new ObservableRangeCollection<TViewModel>();
+            LoadMoreCommand = new AsyncCommand(LoadMoreAsync, () => CanLoadMore);
         }
 
+        /// <summary>
+        ///     Gets or sets the currently loaded page.
+        /// </summary>
         public int CurrentPage
         {
             get => _currentPage;
             protected set => Set(ref _currentPage, value);
         }
 
+        /// <summary>
+        ///     Gets or sets a value indicating whether additional data can be loaded.
+        /// </summary>
         public bool CanLoadMore
         {
             get => _canLoadMore || CanAlwaysLoadMore;
@@ -39,28 +47,52 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             {
                 if (Set(ref _canLoadMore, value))
                 {
-                    ((RelayCommand) LoadMoreCommand).RaiseCanExecuteChanged();
+                    ((AsyncCommand) LoadMoreCommand).RaiseCanExecuteChanged();
                 }
             }
         }
 
-        public ICommand LoadMoreCommand { get; }
+        /// <summary>
+        ///     Gets a command to load more data.
+        /// </summary>
+        public IAsyncCommand LoadMoreCommand { get; }
 
-        public ObservableRangeCollection<TViewModel> Items { get; } = new ObservableRangeCollection<TViewModel>();
+        /// <summary>
+        ///     Gets the list of all loaded items.
+        /// </summary>
+        public ObservableRangeCollection<TViewModel> Items { get; }
 
-        protected virtual bool CanAlwaysLoadMore { get; } = false;
+        /// <summary>
+        ///     Gets a value indicating whether additional data should be forced to be loaded.
+        /// </summary>
+        protected virtual bool CanAlwaysLoadMore { get; }
 
-        protected virtual int PageSize { get; } = DefaultPageSize;
+        /// <summary>
+        ///     Gets the size of the page that will be used to load data.
+        /// </summary>
+        protected virtual int PageSize { get; }
 
-        protected virtual CancellationToken CancellationToken { get; } = CancellationToken.None;
+        /// <summary>
+        ///     Gets the cancellation token that will be used to cancel the requests.
+        /// </summary>
+        protected virtual CancellationToken CancellationToken { get; }
 
+        /// <summary>
+        ///     Resets the list of all loaded items.
+        /// </summary>
         public void ResetItems()
         {
-            Interlocked.Exchange(ref _currentPage, 0);
+            Interlocked.Exchange(ref _currentPage, -1);
 
             Items.Clear();
         }
 
+        /// <summary>
+        ///     Loads the first page of data.
+        ///     This method must be called first to initialize the view model.
+        /// </summary>
+        /// <param name="cancellationToken">Token for canceling the request.</param>
+        /// <returns>Task.</returns>
         protected async Task LoadFirstPageAsync(CancellationToken cancellationToken)
         {
             Interlocked.Exchange(ref _currentPage, 0);
@@ -113,22 +145,19 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             });
         }
 
-        private void LoadMore()
+        private async Task LoadMoreAsync()
         {
             if (Items.Count < PageSize)
             {
                 return;
             }
 
-            Task.Run(() => LoadNextPageAsync(CancellationToken));
+            await LoadNextPageAsync(CancellationToken).ConfigureAwait(false);
         }
 
         private async Task<IList<TViewModel>> LoadPageAsync(int pageNumber)
         {
-            Execute.BeginOnUIThread(() =>
-            {
-                ItemsWillLoad();
-            });
+            Execute.BeginOnUIThread(ItemsWillLoad);
 
             var pagingModel = await LoadAsync(pageNumber, PageSize).ConfigureAwait(false);
             if (pagingModel == null)
@@ -160,10 +189,7 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             return viewModels;
         }
 
-        protected virtual Task<PagingModel<TModel>?> LoadAsync(int pageNumber, int pageSize)
-        {
-            return Task.FromResult(default(PagingModel<TModel>));
-        }
+        protected abstract Task<PagingModel<TModel>?> LoadAsync(int pageNumber, int pageSize);
 
         protected virtual void ItemsWillLoad()
         {

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
@@ -13,6 +13,11 @@ using Softeq.XToolkit.WhiteLabel.Model;
 
 namespace Softeq.XToolkit.WhiteLabel.ViewModels
 {
+    /// <summary>
+    ///     A base view model for working with paginated data.
+    /// </summary>
+    /// <typeparam name="TViewModel">The type of view model.</typeparam>
+    /// <typeparam name="TModel">The type of data model.</typeparam>
     public abstract class PaginationViewModelBase<TViewModel, TModel> : ObservableObject
     {
         private const int DefaultPageSize = 20;

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
@@ -35,7 +35,13 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
         public bool CanLoadMore
         {
             get => _canLoadMore || CanAlwaysLoadMore;
-            protected set => Set(ref _canLoadMore, value);
+            protected set
+            {
+                if (Set(ref _canLoadMore, value))
+                {
+                    ((RelayCommand) LoadMoreCommand).RaiseCanExecuteChanged();
+                }
+            }
         }
 
         public ICommand LoadMoreCommand { get; }

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
@@ -34,7 +34,7 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
         }
 
         /// <summary>
-        ///     Gets or sets the currently loaded page.
+        ///     Gets or sets the index of the currently loaded page.
         /// </summary>
         public int CurrentPage
         {
@@ -194,7 +194,7 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
             return viewModels;
         }
 
-        protected abstract Task<PagingModel<TModel>?> LoadAsync(int pageNumber, int pageSize);
+        protected abstract Task<PagingModel<TModel>?> LoadAsync(int pageIndex, int pageSize);
 
         protected virtual void ItemsWillLoad()
         {

--- a/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
+++ b/Softeq.XToolkit.WhiteLabel/ViewModels/PaginationViewModelBase.cs
@@ -177,7 +177,7 @@ namespace Softeq.XToolkit.WhiteLabel.ViewModels
 
             Execute.BeginOnUIThread(() =>
             {
-                CanLoadMore = pagingModel.Page < pagingModel.TotalNumberOfPages;
+                CanLoadMore = pagingModel.Page + 1 < pagingModel.TotalNumberOfPages;
             });
 
             var viewModels = MapItemsToViewModels(pagingModel.Data);

--- a/samples/Playground.Forms/Playground.Forms/CoreBootstrapper.cs
+++ b/samples/Playground.Forms/Playground.Forms/CoreBootstrapper.cs
@@ -54,6 +54,7 @@ namespace Playground.Forms
             builder.PerDependency<AsyncCommandsPageViewModel>();
             builder.PerDependency<PermissionsPageViewModel>();
             builder.PerDependency<ValidationPageViewModel>();
+            builder.PerDependency<PaginationSearchPageViewModel>();
 
             builder.PerDependency<ViewModelFactoryService, IViewModelFactoryService>();
 

--- a/samples/Playground.Forms/Playground.Forms/ViewModels/Components/PaginationSearchPageViewModel.cs
+++ b/samples/Playground.Forms/Playground.Forms/ViewModels/Components/PaginationSearchPageViewModel.cs
@@ -1,0 +1,70 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Softeq.XToolkit.WhiteLabel.Model;
+using Softeq.XToolkit.WhiteLabel.Mvvm;
+using Softeq.XToolkit.WhiteLabel.ViewModels;
+
+namespace Playground.Forms.ViewModels.Components
+{
+    public class PaginationSearchPageViewModel : ViewModelBase
+    {
+        public PaginationSearchPageViewModel()
+        {
+            Search = new SearchViewModel();
+        }
+
+        public SearchViewModel Search { get; }
+    }
+
+    public class SearchViewModel : PaginationSearchViewModelBase<string, string>
+    {
+        protected override int PageSize => 10;
+
+        protected override bool SilentLoadPagesEnabled => false;
+
+        protected override IList<string> MapItemsToViewModels(IList<string> models)
+        {
+            return models;
+        }
+
+        protected override IList<string> FilterItems(IList<string> viewModels)
+        {
+            return base.FilterItems(viewModels);
+        }
+
+        protected override async Task<PagingModel<string>> LoadAsync(string? query, int pageNumber, int pageSize)
+        {
+            await Task.Delay((pageNumber + 1) * 1000); // every page +1s delay
+
+            var data = await MockLoadData(query, pageNumber, pageSize);
+            return data;
+        }
+
+        private async Task<PagingModel<string>> MockLoadData(string? query, int pageNumber, int pageSize)
+        {
+            const int DefaultItemsCount = 100;
+
+            var startIndex = (pageNumber + 1) * pageSize;
+            var isEndOfList = startIndex >= DefaultItemsCount;
+            var items = isEndOfList
+                ? new List<string>()
+                : Enumerable
+                    .Range(startIndex, pageSize)
+                    .Select(x => $"Page: {pageNumber} Item: {x} — {query}")
+                    .ToList();
+
+            return new PagingModel<string>
+            {
+                Data = items,
+                Page = pageNumber,
+                PageSize = items.Count,
+                TotalNumberOfPages = DefaultItemsCount / pageSize,
+                TotalNumberOfRecords = DefaultItemsCount
+            };
+        }
+    }
+}

--- a/samples/Playground.Forms/Playground.Forms/ViewModels/Components/PaginationSearchPageViewModel.cs
+++ b/samples/Playground.Forms/Playground.Forms/ViewModels/Components/PaginationSearchPageViewModel.cs
@@ -36,32 +36,30 @@ namespace Playground.Forms.ViewModels.Components
             return base.FilterItems(viewModels);
         }
 
-        protected override async Task<PagingModel<string>> LoadAsync(string? query, int pageNumber, int pageSize)
+        protected override async Task<PagingModel<string>> LoadAsync(string? query, int pageIndex, int pageSize)
         {
-            await Task.Delay((pageNumber + 1) * 1000); // every page +1s delay
+            await Task.Delay((pageIndex + 1) * 1000); // every page +1s delay
 
-            var data = await MockLoadData(query, pageNumber, pageSize);
+            var data = MockLoadData(query, pageIndex, pageSize);
             return data;
         }
 
-        private async Task<PagingModel<string>> MockLoadData(string? query, int pageNumber, int pageSize)
+        private PagingModel<string> MockLoadData(string? query, int pageIndex, int pageSize)
         {
-            const int DefaultItemsCount = 100;
+            const int DefaultItemsCount = 30;
 
-            var startIndex = (pageNumber + 1) * pageSize;
-            var isEndOfList = startIndex >= DefaultItemsCount;
-            var items = isEndOfList
-                ? new List<string>()
-                : Enumerable
-                    .Range(startIndex, pageSize)
-                    .Select(x => $"Page: {pageNumber} Item: {x} — {query}")
-                    .ToList();
+            var data = Enumerable
+                .Range(0, DefaultItemsCount)
+                .Skip(pageIndex * pageSize)
+                .Take(pageSize)
+                .Select(x => $"Page: {pageIndex} Item: {x} — {query}")
+                .ToList();
 
             return new PagingModel<string>
             {
-                Data = items,
-                Page = pageNumber,
-                PageSize = items.Count,
+                Data = data,
+                Page = pageIndex,
+                PageSize = data.Count,
                 TotalNumberOfPages = DefaultItemsCount / pageSize,
                 TotalNumberOfRecords = DefaultItemsCount
             };

--- a/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
+++ b/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
@@ -1,11 +1,12 @@
 // Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Windows.Input;
+using System.Collections.Generic;
 using Playground.Forms.ViewModels.Components;
 using Playground.Forms.ViewModels.Dialogs;
 using Playground.Forms.ViewModels.MasterDetailNavigation;
 using Playground.Forms.ViewModels.SimpleNavigation;
+using Softeq.XToolkit.Common.Collections;
 using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.WhiteLabel.Mvvm;
 using Softeq.XToolkit.WhiteLabel.Navigation;
@@ -22,25 +23,19 @@ namespace Playground.Forms.ViewModels
         {
             _pageNavigationService = pageNavigationService;
 
-            SimpleNavigationCommand = new RelayCommand(PerformSimpleNavigation);
-            MasterDetailNavigationCommand = new RelayCommand(PerformMasterDetailNavigation);
-            DialogsCommand = new RelayCommand(Dialogs);
-            AsyncCommandsCommand = new RelayCommand(AsyncCommands);
-            PermissionsCommand = new RelayCommand(Permissions);
-            ValidationCommand = new RelayCommand(Validation);
+            Items = new ObservableRangeCollection<CommandAction>(
+                new List<CommandAction>
+                {
+                    new CommandAction(new RelayCommand(PerformSimpleNavigation), "Simple Navigation"),
+                    new CommandAction(new RelayCommand(PerformMasterDetailNavigation), "Master Detail Navigation"),
+                    new CommandAction(new RelayCommand(Dialogs), "Dialogs"),
+                    new CommandAction(new RelayCommand(AsyncCommands), "Async Commands"),
+                    new CommandAction(new RelayCommand(Permissions), "Permissions"),
+                    new CommandAction(new RelayCommand(Validation), "Validation"),
+                });
         }
 
-        public ICommand SimpleNavigationCommand { get; }
-
-        public ICommand MasterDetailNavigationCommand { get; }
-
-        public ICommand DialogsCommand { get; }
-
-        public ICommand AsyncCommandsCommand { get; }
-
-        public ICommand PermissionsCommand { get; }
-
-        public ICommand ValidationCommand { get; }
+        public ObservableRangeCollection<CommandAction> Items { get; }
 
         public string Title
         {

--- a/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
+++ b/samples/Playground.Forms/Playground.Forms/ViewModels/MainPageViewModel.cs
@@ -32,6 +32,7 @@ namespace Playground.Forms.ViewModels
                     new CommandAction(new RelayCommand(AsyncCommands), "Async Commands"),
                     new CommandAction(new RelayCommand(Permissions), "Permissions"),
                     new CommandAction(new RelayCommand(Validation), "Validation"),
+                    new CommandAction(new RelayCommand(PaginationSearch), "Pagination Search"),
                 });
         }
 
@@ -82,6 +83,13 @@ namespace Playground.Forms.ViewModels
         {
             _pageNavigationService
                 .For<ValidationPageViewModel>()
+                .Navigate();
+        }
+
+        private void PaginationSearch()
+        {
+            _pageNavigationService
+                .For<PaginationSearchPageViewModel>()
                 .Navigate();
         }
     }

--- a/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml
+++ b/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml
@@ -31,7 +31,7 @@
                 <DataTemplate>
                     <TextCell
                         Text="{Binding Path=.}"
-                        TextColor="Black" />
+                        TextColor="Purple" />
                 </DataTemplate>
             </ListView.ItemTemplate>
             <ListView.Footer>
@@ -50,6 +50,7 @@
         <Label
             Text="Empty list"
             HorizontalOptions="Center"
+            VerticalOptions="CenterAndExpand"
             IsVisible="{Binding Search.HasResults, Converter={StaticResource InverseConverter}}" />
     </StackLayout>
 </ContentPage>

--- a/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml
+++ b/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:vm="clr-namespace:Playground.Forms.ViewModels.Components;assembly=Playground.Forms"
+    xmlns:converters="clr-namespace:Softeq.XToolkit.WhiteLabel.Forms.Converters;assembly=Softeq.XToolkit.WhiteLabel.Forms"
+    x:Class="Playground.Forms.Views.Components.PaginationSearchPage"
+    x:DataType="vm:PaginationSearchPageViewModel"
+    Title="Search with pagination"
+    BackgroundColor="White">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:BooleanInverseConverter x:Key="InverseConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <StackLayout>
+        <Entry
+            Margin="20"
+            Placeholder="Write something to search..."
+            Text="{Binding Search.SearchQuery}"
+            ClearButtonVisibility="WhileEditing" />
+        <ListView
+            IsVisible="{Binding Search.HasResults}"
+            ItemsSource="{Binding Search.Items}"
+            BackgroundColor="White"
+            SelectionMode="None"
+            SeparatorVisibility="None">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TextCell
+                        Text="{Binding Path=.}"
+                        TextColor="Black" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.Footer>
+                <StackLayout>
+                    <ActivityIndicator
+                        Color="OrangeRed"
+                        IsVisible="{Binding Search.IsBusy}"
+                        IsRunning="True" />
+                    <Button
+                        Text="Load more"
+                        Command="{Binding Search.LoadMoreCommand}"
+                        IsVisible="{Binding Search.IsBusy, Converter={StaticResource InverseConverter}}"/>
+                </StackLayout>
+            </ListView.Footer>
+        </ListView>
+        <Label
+            Text="Empty list"
+            HorizontalOptions="Center"
+            IsVisible="{Binding Search.HasResults, Converter={StaticResource InverseConverter}}" />
+    </StackLayout>
+</ContentPage>

--- a/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml.cs
+++ b/samples/Playground.Forms/Playground.Forms/Views/Components/PaginationSearchPage.xaml.cs
@@ -1,0 +1,14 @@
+// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Playground.Forms.Views.Components
+{
+    public partial class PaginationSearchPage
+    {
+        public PaginationSearchPage()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/samples/Playground.Forms/Playground.Forms/Views/MainPage.xaml
+++ b/samples/Playground.Forms/Playground.Forms/Views/MainPage.xaml
@@ -3,33 +3,32 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:vm="clr-namespace:Playground.Forms.ViewModels;assembly=Playground.Forms"
+    xmlns:mvvm="clr-namespace:Softeq.XToolkit.WhiteLabel.Mvvm;assembly=Softeq.XToolkit.WhiteLabel"
     x:Class="Playground.Forms.Views.MainPage"
     x:DataType="vm:MainPageViewModel"
     Title="{Binding Title}">
 
     <StackLayout>
-        <Button
-            Command="{Binding SimpleNavigationCommand}"
-            Text="Simple Navigation" />
-        <Button
-            Command="{Binding MasterDetailNavigationCommand}"
-            Text="Master Detail Navigation" />
-        <Button
-            Command="{Binding DialogsCommand}"
-            Text="Dialogs" />
-
-        <Button
-            Command="{Binding AsyncCommandsCommand}"
-            Text="Async Commands" />
-
-        <Button
-            Command="{Binding PermissionsCommand}"
-            Text="Permissions" />
-
-        <Button
-            Command="{Binding ValidationCommand}"
-            Text="Validation" />
-
+        <ListView
+            ItemsSource="{Binding Items}"
+            SelectionMode="None"
+            SeparatorColor="DodgerBlue"
+            Footer="">
+            <ListView.Header>
+                <Label
+                    Text="Select sample:"
+                    TextColor="DarkGray"
+                    Padding="20"/>
+            </ListView.Header>
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="mvvm:CommandAction">
+                    <TextCell
+                        Text="{Binding Title}"
+                        Command="{Binding Command}"
+                        TextColor="DodgerBlue" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </StackLayout>
 
 </ContentPage>

--- a/samples/Playground/Playground/ViewModels/MainPageViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/MainPageViewModel.cs
@@ -13,7 +13,6 @@ using Playground.ViewModels.Frames;
 using Playground.ViewModels.Pages;
 using Softeq.XToolkit.Common.Collections;
 using Softeq.XToolkit.Common.Commands;
-using Softeq.XToolkit.WhiteLabel.Essentials.FullScreenImage;
 using Softeq.XToolkit.WhiteLabel.Interfaces;
 using Softeq.XToolkit.WhiteLabel.Model;
 using Softeq.XToolkit.WhiteLabel.Mvvm;


### PR DESCRIPTION
### Description

Add tests
Add docs
Add Playground.Forms sample
Rework Playground.Forms MainPage

### Fixed issues

- `PaginationSearchViewModelBase.SearchQuery` behavior for an empty value

### API changes

Changed:
- `PaginationViewModelBase.LoadAsync(int pageNumber, int pageSize)` -> abstract
- `ICommand LoadMoreCommand` -> `IAsyncCommand LoadMoreCommand`

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
