### PR TITLE
Android: Add ability to override showing dialog

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
@@ -16,10 +16,12 @@ using Dialog = Android.App.Dialog;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
 {
-    public abstract class DialogFragmentBase<TViewModel> : DialogFragment, IBindable
+    public abstract class DialogFragmentBase<TViewModel> : DialogFragment, IBindable, IDialogFragment
         where TViewModel : IDialogViewModel
     {
         private readonly Lazy<IContextProvider> _contextProviderLazy = Dependencies.Container.Resolve<Lazy<IContextProvider>>();
+
+        public event EventHandler? Dismissed;
 
         protected TViewModel ViewModel => (TViewModel) DataContext;
 
@@ -79,6 +81,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         {
             base.OnDismiss(dialog);
 
+            Dismissed?.Invoke(this, null);
             ViewModel?.DialogComponent.CloseCommand.Execute(null);
         }
 

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DroidFragmentDialogService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DroidFragmentDialogService.cs
@@ -108,7 +108,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
             return viewModel;
         }
 
-        private Task<object> ShowDialogAsync<TViewModel>(TViewModel viewModel)
+        protected virtual Task<object> ShowDialogAsync<TViewModel>(TViewModel viewModel)
             where TViewModel : IDialogViewModel
         {
             var dialogFragment = (DialogFragmentBase<TViewModel>) _viewLocator.GetView(viewModel, ViewType.DialogFragment);

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/IDialogFragment.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/IDialogFragment.cs
@@ -1,0 +1,20 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+
+namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
+{
+    public interface IDialogFragment
+    {
+        /// <summary>
+        ///     Event called when Dialog fragment is dismissed.
+        /// </summary>
+        public event EventHandler? Dismissed;
+
+        /// <summary>
+        ///     Show Dialog fragment.
+        /// </summary>
+        void Show();
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Internal\IViewModelStore.cs" />
     <Compile Include="Views\ToolbarFragmentBase.cs" />
     <Compile Include="Navigation\BackPressedCallback.cs" />
+    <Compile Include="Dialogs\IDialogFragment.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj">


### PR DESCRIPTION
### Description

Add ability to override showing dialog on Android

### API Changes
`DialogFragmentBase` now implements an interface `IDialogFragment`

Added:
 - event EventHandler? IDialogFragment.Dismissed;
 - void IDialogFragment.Show ();

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
