### PR TITLE
Clearing DataContext removed from DialogFragmentBase

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
@@ -82,7 +82,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
             base.OnDismiss(dialog);
 
             Dismissed?.Invoke(this, null);
-            ViewModel?.DialogComponent.CloseCommand.Execute(null);
+
+            ViewModel.DialogComponent.CloseCommand.Execute(null);
         }
 
         public override void OnViewCreated(View view, Bundle savedInstanceState)
@@ -95,7 +96,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         public override void OnDestroyView()
         {
             ViewModel.DialogComponent.Closed -= DialogComponentOnClosed;
-            DataContext = null;
 
             base.OnDestroyView();
         }


### PR DESCRIPTION
### Description

Clearing DataContext removed from DialogFragmentBase.

This is done because `OnDismiss` method may be called both before and after `OnViewDisappeared`.
If `OnDismiss` is called after `OnViewDisappeared`, then Dismissed event is not raised.

Moving clearing DataContext to `OnDismiss` is not an option because in that case there will be another problem:
If `OnDismiss` is called before `OnViewDisappeared`(and other lifecycle methods like `OnPause`) then we can't call `OnDisappearing()` method on the ViewModel.


### API Changes
 
 None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
