### PR TITLE
Android: allow to go back with one item to clear backstack

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
@@ -58,6 +58,13 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
 
         public void GoBack()
         {
+            if (IsEmptyBackStack)
+            {
+                return;
+            }
+
+            var canGoBack = CanGoBack;
+
             // navigation
             var currentEntry = _backStack.CurrentWithRemove();
             var currentFrameName = ToKey(currentEntry);
@@ -65,8 +72,11 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
             // cleanup
             CurrentStore.Remove(currentFrameName);
 
-            // show
-            RestoreNavigation();
+            // show previous if needed
+            if (canGoBack)
+            {
+                RestoreNavigation();
+            }
         }
 
         public void GoBack<T>() where T : IViewModelBase

--- a/Softeq.XToolkit.WhiteLabel.Droid/Views/ToolbarFragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Views/ToolbarFragmentBase.cs
@@ -42,13 +42,18 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Views
                     _backPressedCallback.Enabled = false;
                 }
 
-                Activity.OnBackPressed();
+                InvokeActivityOnBackPressed();
 
                 if (_backPressedCallback != null)
                 {
                     _backPressedCallback.Enabled = true;
                 }
             }
+        }
+
+        protected virtual void InvokeActivityOnBackPressed()
+        {
+            Activity.OnBackPressed();
         }
     }
 }


### PR DESCRIPTION
### Description

Allow to go back with one screen in backstack of DroidFrameNavigationService to clear backstack

### API Changes
 
 None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
