### PR TITLE
Improves/observable key groups collection tests

### DIFF
--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ItemsEventsCatcher.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ItemsEventsCatcher.cs
@@ -47,11 +47,15 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
                 switch (action)
                 {
                     case NotifyCollectionChangedAction.Add:
-                        actualValues = _events[0].GroupEvents.SelectMany(x => x.Arg.NewItemRanges.SelectMany(y => y.NewItems)).ToList();
+                        actualValues = _events[0].GroupEvents
+                            .SelectMany(x => x.Arg.NewItemRanges.SelectMany(y => y.NewItems))
+                            .ToList();
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
-                        actualValues = _events[0].GroupEvents.SelectMany(x => x.Arg.OldItemRanges.SelectMany(y => y.OldItems)).ToList();
+                        actualValues = _events[0].GroupEvents
+                            .SelectMany(x => x.Arg.OldItemRanges.SelectMany(y => y.OldItems))
+                            .ToList();
                         break;
 
                     case NotifyCollectionChangedAction.Reset:

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionHelper.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionHelper.cs
@@ -35,67 +35,67 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         public static IList<KeyValuePair<string, IList<int>>> PairsNull;
         public static IList<KeyValuePair<string, IList<int>>> PairsEmpty = new List<KeyValuePair<string, IList<int>>>();
-        public static IList<KeyValuePair<string, IList<int>>> PairsWithKeysWithItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairsWithKeysWithItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyFirst, ItemsFirst),
             new KeyValuePair<string, IList<int>>(GroupKeySecond, ItemsSecond)
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairsWithKeysWithItemsWithEmpty = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairsWithKeysWithItemsWithEmpty = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyFirst, ItemsFirst),
             new KeyValuePair<string, IList<int>>(GroupKeyEmpty, ItemsEmpty)
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairWithKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairWithKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyNull, ItemsNull),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairWithKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairWithKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyEmpty, ItemsEmpty),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsThird),
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsThird),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsThird),
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsNull),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairDuplicateKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsThird),
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsEmpty),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(null, ItemsFirst),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithNullItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(null, null),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithEmptyItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairNullKeyWithEmptyItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(null, new List<int>()),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairNotContainedKeyWithItems = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairNotContainedKeyWithItems = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsThird),
         };
 
-        public static IList<KeyValuePair<string, IList<int>>> PairNotContainedKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>()
+        public static IList<KeyValuePair<string, IList<int>>> PairNotContainedKeyWithEmptyItem = new List<KeyValuePair<string, IList<int>>>
         {
             new KeyValuePair<string, IList<int>>(GroupKeyThird, ItemsEmpty),
         };
@@ -503,8 +503,8 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var collection = new ObservableKeyGroupsCollection<string, int>(false);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
-                 new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int>() { 4 }),
-                 new KeyValuePair<string, IList<int>>(GroupKeyThird, new List<int>() { 1, 3 }),
+                 new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 4 }),
+                 new KeyValuePair<string, IList<int>>(GroupKeyThird, new List<int> { 1, 3 }),
             };
 
             collection.AddGroups(items);

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionHelper.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionHelper.cs
@@ -102,24 +102,24 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         public static ObservableKeyGroupsCollection<string, int> CreateWithEmptyGroups()
         {
-            return new ObservableKeyGroupsCollection<string, int>(false);
+            return new ObservableKeyGroupsCollection<string, int>(true);
         }
 
         public static ObservableKeyGroupsCollection<string, int> CreateWithoutEmptyGroups()
         {
-            return new ObservableKeyGroupsCollection<string, int>(true);
+            return new ObservableKeyGroupsCollection<string, int>(false);
         }
 
         public static ObservableKeyGroupsCollection<string, int> CreateFilledGroupsWithEmpty()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(false);
+            var collection = new ObservableKeyGroupsCollection<string, int>(true);
             collection.AddGroups(CreateGroupsWithEmpty());
             return collection;
         }
 
         public static ObservableKeyGroupsCollection<string, int> CreateFilledGroupsWithoutEmpty()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(true);
+            var collection = new ObservableKeyGroupsCollection<string, int>(false);
             collection.AddGroups(CreateGroupWithoutEmpty());
             return collection;
         }
@@ -380,7 +380,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> InsertItemsListItemsWithExistKeysWithEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(false);
+            var collection = new ObservableKeyGroupsCollection<string, int>(true);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 1, 2, 11, 13, 3, 4 }),
@@ -395,7 +395,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> InsertItemsListItemsWithExistKeysWithoutEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(true);
+            var collection = new ObservableKeyGroupsCollection<string, int>(false);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 1, 2, 11, 13, 3, 4 }),
@@ -420,7 +420,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> RemoveItemsExistKeysWithEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(false);
+            var collection = new ObservableKeyGroupsCollection<string, int>(true);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 2, 4 }),
@@ -435,7 +435,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> RemoveItemsExistKeysWithoutEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(true);
+            var collection = new ObservableKeyGroupsCollection<string, int>(false);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 2, 4 }),
@@ -462,7 +462,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> RemoveItemsAllItemsForExistKeyAllowEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(false);
+            var collection = new ObservableKeyGroupsCollection<string, int>(true);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int>()),
@@ -477,7 +477,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> RemoveItemsAllItemsForExistKeyForbidEmptyResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(true);
+            var collection = new ObservableKeyGroupsCollection<string, int>(false);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeySecond, new List<int> { 4, 6, 7 }),
@@ -500,7 +500,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
         private static ObservableKeyGroupsCollection<string, int> ReplaceItemsListItemsResult()
         {
-            var collection = new ObservableKeyGroupsCollection<string, int>(false);
+            var collection = new ObservableKeyGroupsCollection<string, int>(true);
             var items = new List<KeyValuePair<string, IList<int>>>
             {
                  new KeyValuePair<string, IList<int>>(GroupKeyFirst, new List<int> { 4 }),

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsAddItems.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsAddItems.cs
@@ -18,7 +18,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void AddItems_NullListItems_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.AddItems(CollectionHelper.CreateNullItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+                () => collection.AddItems(CollectionHelper.CreateNullItemsList(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         {
             var size = collection.Select(x => (x.Key, x.Count()));
 
-            collection.AddItems(CollectionHelper.CreateEmptyItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(CollectionHelper.CreateEmptyItemsList(), x => x.SelectKey(), x => x.SelectValue());
 
             foreach (var item in collection)
             {
@@ -40,7 +40,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void AddItems_NullItem_NullReferenceException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<NullReferenceException>(
-               () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNull(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+               () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNull(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var referenceValues = collection.ToDictionary(x => x.Key, x => x.ToList());
             var items = CollectionHelper.CreateFillItemsListWithNewKeys();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             foreach (var item in items)
             {
@@ -75,7 +75,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void AddItems_NullKeySelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), null, (x) => x.SelectValue()));
+                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), null!, x => x.SelectValue()));
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void AddItems_NullValueSelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), (x) => x.SelectKey(), null));
+                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), x => x.SelectKey(), null!));
         }
 
         [Theory]
@@ -91,7 +91,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void AddItems_SelectNullKey_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), (x) => null, (x) => x.SelectValue()));
+                () => collection.AddItems(CollectionHelper.CreateFillItemsListWithNewKeys(), x => null, x => x.SelectValue()));
         }
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsCollectionChanged.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsCollectionChanged.cs
@@ -282,7 +282,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -297,7 +297,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -312,7 +312,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -327,7 +327,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.InsertItems(items, (x) => x.SelectKey(), (x) => x.SelectValue(), (x) => x.SelectIndex());
+            collection.InsertItems(items, x => x.SelectKey(), x => x.SelectValue(), x => x.SelectIndex());
 
             catcher.Unsubscribe();
 
@@ -344,7 +344,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -356,12 +356,12 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void CollectionChanged_RemoveItemsForbidEmptyGroupRemoveAllGroupItems_NotifyOneTime(
             ObservableKeyGroupsCollection<string, int> collection,
             List<TestItem<string, int>> items,
-            List<string> removedKeys)
+            List<string> _)
         {
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -377,7 +377,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -393,7 +393,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -409,7 +409,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.ReplaceAllItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.ReplaceAllItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -425,7 +425,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateCollectionEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.ReplaceAllItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.ReplaceAllItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsInsertItems.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsInsertItems.cs
@@ -20,9 +20,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<ArgumentNullException>(
                 () => collection.InsertItems(
                     CollectionHelper.CreateNullItemsList(),
-                    (x) => x.SelectKey(),
-                    (x) => x.SelectValue(),
-                    (x) => x.SelectIndex()));
+                    x => x.SelectKey(),
+                    x => x.SelectValue(),
+                    x => x.SelectIndex()));
         }
 
         [Theory]
@@ -33,9 +33,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
 
             collection.InsertItems(
                      CollectionHelper.CreateEmptyItemsList(),
-                     (x) => x.SelectKey(),
-                     (x) => x.SelectValue(),
-                     (x) => x.SelectIndex());
+                     x => x.SelectKey(),
+                     x => x.SelectValue(),
+                     x => x.SelectIndex());
 
             foreach (var item in collection)
             {
@@ -50,9 +50,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<NullReferenceException>(
                () => collection.InsertItems(
                    CollectionHelper.CreateFillItemsListWithNull(),
-                   (x) => x.SelectKey(),
-                   (x) => x.SelectValue(),
-                   (x) => x.SelectIndex()));
+                   x => x.SelectKey(),
+                   x => x.SelectValue(),
+                   x => x.SelectIndex()));
         }
 
         [Theory]
@@ -62,7 +62,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             List<TestItem<string, int>> items,
             ObservableKeyGroupsCollection<string, int> resultCollection)
         {
-            collection.InsertItems(items, (x) => x.SelectKey(), (x) => x.SelectValue(), (x) => x.SelectIndex());
+            collection.InsertItems(items, x => x.SelectKey(), x => x.SelectValue(), x => x.SelectIndex());
 
             Assert.Equal(resultCollection.Keys.Count, collection.Keys.Count);
 
@@ -78,9 +78,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         {
             Assert.Throws<KeyNotFoundException>(() => collection.InsertItems(
                      CollectionHelper.CreateFillItemsListWithNewKeys(),
-                     (x) => x.SelectKey(),
-                     (x) => x.SelectValue(),
-                     (x) => x.SelectIndex()));
+                     x => x.SelectKey(),
+                     x => x.SelectValue(),
+                     x => x.SelectIndex()));
         }
 
         [Theory]
@@ -90,9 +90,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<ArgumentNullException>(
                 () => collection.InsertItems(
                     CollectionHelper.CreateFillItemsListWithNewKeys(),
-                    null,
-                    (x) => x.SelectValue(),
-                    (x) => x.SelectIndex()));
+                    null!,
+                    x => x.SelectValue(),
+                    x => x.SelectIndex()));
         }
 
         [Theory]
@@ -102,9 +102,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<ArgumentNullException>(
                 () => collection.InsertItems(
                     CollectionHelper.CreateFillItemsListWithNewKeys(),
-                    (x) => x.SelectKey(),
-                    null,
-                    (x) => x.SelectIndex()));
+                    x => x.SelectKey(),
+                    null!,
+                    x => x.SelectIndex()));
         }
 
         [Theory]
@@ -114,9 +114,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<ArgumentNullException>(
                 () => collection.InsertItems(
                     CollectionHelper.CreateFillItemsListWithNewKeys(),
-                    (x) => x.SelectKey(),
-                    (x) => x.SelectValue(),
-                    null));
+                    x => x.SelectKey(),
+                    x => x.SelectValue(),
+                    null!));
         }
 
         [Theory]
@@ -126,9 +126,9 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             Assert.Throws<ArgumentNullException>(
                 () => collection.InsertItems(
                     CollectionHelper.CreateFillItemsListWithExistKeys(),
-                    (x) => null,
-                    (x) => x.SelectValue(),
-                    (x) => x.SelectIndex()));
+                    x => null,
+                    x => x.SelectValue(),
+                    x => x.SelectIndex()));
         }
 
         [Theory]
@@ -139,7 +139,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             int index)
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => collection.InsertItems(items, (x) => x.SelectKey(), (x) => x.SelectValue(), (x) => index));
+                () => collection.InsertItems(items, x => x.SelectKey(), x => x.SelectValue(), x => index));
         }
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsItemsChanged.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsItemsChanged.cs
@@ -164,7 +164,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -179,7 +179,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -194,7 +194,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.AddItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.AddItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -209,7 +209,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.InsertItems(items, (x) => x.SelectKey(), (x) => x.SelectValue(), (x) => x.SelectIndex());
+            collection.InsertItems(items, x => x.SelectKey(), x => x.SelectValue(), x => x.SelectIndex());
 
             catcher.Unsubscribe();
 
@@ -224,7 +224,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.InsertItems(items, (x) => x.SelectKey(), (x) => x.SelectValue(), (x) => x.SelectIndex());
+            collection.InsertItems(items, x => x.SelectKey(), x => x.SelectValue(), x => x.SelectIndex());
 
             catcher.Unsubscribe();
 
@@ -239,7 +239,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -254,7 +254,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -269,7 +269,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -285,7 +285,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -301,7 +301,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 
@@ -317,7 +317,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             var catcher = CollectionHelper.CreateItemsEventCatcher(collection);
             catcher.Subscribe();
 
-            collection.ReplaceAllItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.ReplaceAllItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             catcher.Unsubscribe();
 

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsRemoveItems.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsRemoveItems.cs
@@ -18,7 +18,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_NullListItems_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.RemoveItems(CollectionHelper.CreateNullItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+                () => collection.RemoveItems(CollectionHelper.CreateNullItemsList(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         {
             var size = collection.Select(x => (x.Key, x.Count()));
 
-            collection.RemoveItems(CollectionHelper.CreateEmptyItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(CollectionHelper.CreateEmptyItemsList(), x => x.SelectKey(), x => x.SelectValue());
 
             foreach (var item in collection)
             {
@@ -40,7 +40,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_NullItem_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-               () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithNull(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+               () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithNull(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             List<TestItem<string, int>> items,
             ObservableKeyGroupsCollection<string, int> resultCollection)
         {
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             Assert.Equal(resultCollection.Keys.Count, collection.Keys.Count);
 
@@ -65,7 +65,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_ItemsWithNotExistKeys_KeyNotFoundException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<KeyNotFoundException>(
-                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithNewKeys(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithNewKeys(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -73,7 +73,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_ItemsWithNotExistValue_KeyNotFoundException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<KeyNotFoundException>(
-                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), (x) => x.SelectKey(), (x) => int.MaxValue));
+                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), x => x.SelectKey(), x => int.MaxValue));
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             List<TestItem<string, int>> items,
             ObservableKeyGroupsCollection<string, int> resultCollection)
         {
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             Assert.Equal(resultCollection.Keys.Count, collection.Keys.Count);
 
@@ -100,7 +100,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             List<TestItem<string, int>> items,
             ObservableKeyGroupsCollection<string, int> resultCollection)
         {
-            collection.RemoveItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.RemoveItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             Assert.Equal(resultCollection.Keys.Count, collection.Keys.Count);
 
@@ -115,7 +115,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_NullKeySelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), null, (x) => x.SelectValue()));
+                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), null!, x => x.SelectValue()));
         }
 
         [Theory]
@@ -123,7 +123,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_NullValueSelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), (x) => x.SelectKey(), null));
+                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), x => x.SelectKey(), null!));
         }
 
         [Theory]
@@ -131,7 +131,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void RemoveItems_SelectNullKey_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), (x) => null, (x) => x.SelectValue()));
+                () => collection.RemoveItems(CollectionHelper.CreateFillItemsListWithExistKeys(), x => null, x => x.SelectValue()));
         }
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsReplaceAllItems.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/ObservableKeyGroupsCollectionTestsReplaceAllItems.cs
@@ -18,7 +18,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void ReplaceAllItems_NullListItems_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.ReplaceAllItems(CollectionHelper.CreateNullItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+                () => collection.ReplaceAllItems(CollectionHelper.CreateNullItemsList(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         {
             var size = collection.Select(x => (x.Key, x.Count()));
 
-            collection.ReplaceAllItems(CollectionHelper.CreateEmptyItemsList(), (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.ReplaceAllItems(CollectionHelper.CreateEmptyItemsList(), x => x.SelectKey(), x => x.SelectValue());
 
             foreach (var item in collection)
             {
@@ -40,7 +40,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void ReplaceAllItems_NullItem_NullReferenceException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<NullReferenceException>(
-               () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNull(), (x) => x.SelectKey(), (x) => x.SelectValue()));
+               () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNull(), x => x.SelectKey(), x => x.SelectValue()));
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
             List<TestItem<string, int>> items,
             ObservableKeyGroupsCollection<string, int> resultCollection)
         {
-            collection.ReplaceAllItems(items, (x) => x.SelectKey(), (x) => x.SelectValue());
+            collection.ReplaceAllItems(items, x => x.SelectKey(), x => x.SelectValue());
 
             Assert.Equal(resultCollection.Keys.Count, collection.Keys.Count);
 
@@ -65,7 +65,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void ReplaceAllItems_NullKeySelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNewKeys(), null, (x) => x.SelectValue()));
+                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNewKeys(), null!, x => x.SelectValue()));
         }
 
         [Theory]
@@ -73,7 +73,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void ReplaceAllItems_NullValueSelector_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNewKeys(), (x) => x.SelectKey(), null));
+                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithNewKeys(), x => x.SelectKey(), null!));
         }
 
         [Theory]
@@ -81,7 +81,7 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public void ReplaceAllItems_SelectNullKey_ArgumentNullException(ObservableKeyGroupsCollection<string, int> collection)
         {
             Assert.Throws<ArgumentNullException>(
-                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithExistKeys(), (x) => null, (x) => x.SelectValue()));
+                () => collection.ReplaceAllItems(CollectionHelper.CreateFillItemsListWithExistKeys(), x => null, x => x.SelectValue()));
         }
     }
 }

--- a/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/TestItem.cs
+++ b/Softeq.XToolkit.Common.Tests/Collections/ObservableKeyGroupsCollectionTest/TestItem.cs
@@ -7,6 +7,13 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         where TKey : notnull
         where TValue : notnull
     {
+        public TestItem(TKey key, TValue value, int index = 0)
+        {
+            Key = key;
+            Value = value;
+            Index = index;
+        }
+
         public TKey Key { get; }
         public TValue Value { get; }
         public int Index { get; }
@@ -14,13 +21,6 @@ namespace Softeq.XToolkit.Common.Tests.Collections.ObservableKeyGroupsCollection
         public bool IsKeySelectedFire { get; private set; }
         public bool IsValueSelectedFire { get; private set; }
         public bool IsIndexSelectedFire { get; private set; }
-
-        public TestItem(TKey key, TValue value, int index = 0)
-        {
-            Key = key;
-            Value = value;
-            Index = index;
-        }
 
         public TKey SelectKey()
         {

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
@@ -28,15 +28,15 @@ namespace Softeq.XToolkit.Common.Collections
         private const string UnsupportEmptyGroupExceptionMessage = "Empty group isn't supported";
 
         private readonly IList<Group> _items;
-        private readonly bool _withoutEmptyGroups;
+        private readonly bool _emptyGroupsDisabled;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ObservableKeyGroupsCollection{TKey, TValue}"/> class.
         /// </summary>
-        /// <param name="withoutEmptyGroups">If true empty groups will be removed.</param>
-        public ObservableKeyGroupsCollection(bool withoutEmptyGroups = true)
+        /// <param name="allowEmptyGroups">If <see langword="false"/> empty groups will be removed.</param>
+        public ObservableKeyGroupsCollection(bool allowEmptyGroups = true)
         {
-            _withoutEmptyGroups = withoutEmptyGroups;
+            _emptyGroupsDisabled = !allowEmptyGroups;
             _items = new List<Group>();
         }
 
@@ -68,7 +68,7 @@ namespace Softeq.XToolkit.Common.Collections
         /// <inheritdoc />
         public void InsertGroups(int index, IEnumerable<TKey> keys)
         {
-            if (_withoutEmptyGroups)
+            if (_emptyGroupsDisabled)
             {
                 throw new InvalidOperationException(UnsupportEmptyGroupExceptionMessage);
             }
@@ -94,12 +94,12 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException(nameof(items), "One of the keys is null.");
             }
 
-            if (_withoutEmptyGroups && items.Any(x => x.Value?.Count == 0))
+            if (_emptyGroupsDisabled && items.Any(x => x.Value?.Count == 0))
             {
                 throw new InvalidOperationException(UnsupportEmptyGroupExceptionMessage);
             }
 
-            var insertedGroups = InsertGroupsWithoutNotify(index, items, _withoutEmptyGroups);
+            var insertedGroups = InsertGroupsWithoutNotify(index, items, _emptyGroupsDisabled);
             if (insertedGroups == null)
             {
                 return;
@@ -127,7 +127,7 @@ namespace Softeq.XToolkit.Common.Collections
         /// <inheritdoc />
         public void ReplaceAllGroups(IEnumerable<TKey> keys)
         {
-            if (_withoutEmptyGroups)
+            if (_emptyGroupsDisabled)
             {
                 throw new InvalidOperationException(UnsupportEmptyGroupExceptionMessage);
             }
@@ -148,7 +148,7 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException(nameof(items));
             }
 
-            if (_withoutEmptyGroups && items.Any(x => x.Value?.Count == 0))
+            if (_emptyGroupsDisabled && items.Any(x => x.Value?.Count == 0))
             {
                 throw new InvalidOperationException(UnsupportEmptyGroupExceptionMessage);
             }
@@ -160,7 +160,7 @@ namespace Softeq.XToolkit.Common.Collections
 
             _items.Clear();
 
-            var insertedGroups = InsertGroupsWithoutNotify(0, items, _withoutEmptyGroups);
+            var insertedGroups = InsertGroupsWithoutNotify(0, items, _emptyGroupsDisabled);
             if (insertedGroups == null)
             {
                 return;
@@ -224,7 +224,7 @@ namespace Softeq.XToolkit.Common.Collections
         /// <inheritdoc />
         public void ClearGroup(TKey key)
         {
-            if (_withoutEmptyGroups)
+            if (_emptyGroupsDisabled)
             {
                 throw new InvalidOperationException($"{UnsupportEmptyGroupExceptionMessage}. Group with key '{key}' can't be clear.");
             }
@@ -451,7 +451,7 @@ namespace Softeq.XToolkit.Common.Collections
                 }
             }
 
-            if (_withoutEmptyGroups)
+            if (_emptyGroupsDisabled)
             {
                 var keysToRemove = _items.Where(x => x.Count == 0).Select(x => x.Key);
                 groupsToRemove = RemoveGroupsWithoutNotify(keysToRemove);

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
@@ -43,7 +43,7 @@ namespace Softeq.XToolkit.Common.Collections
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
         public event EventHandler<NotifyKeyGroupCollectionChangedEventArgs<TKey, TValue>>? ItemsChanged;
 
-        public IList<TKey> Keys => _items.Select(item => item.Key).ToList() ?? new List<TKey>();
+        public IList<TKey> Keys => _items.Select(item => item.Key).ToList();
 
         public int Count => _items.Count;
 
@@ -267,7 +267,7 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException();
             }
 
-            if (items.Count() == 0)
+            if (!items.Any())
             {
                 return;
             }
@@ -474,8 +474,9 @@ namespace Softeq.XToolkit.Common.Collections
 
             removedItemsEvents = removedItemsEvents.Count > 0 ? removedItemsEvents : default;
 
-            var oldItems = groupsToRemove?.Count > 0 ?
-                new Collection<(int, IReadOnlyList<TKey>)> { (0, groupsToRemove[0].Keys) } : null;
+            var oldItems = groupsToRemove?.Count > 0
+                ? new Collection<(int, IReadOnlyList<TKey>)> { (0, groupsToRemove[0].Keys) }
+                : null;
 
             OnChanged(
                 groupsToRemove?.Count > 0 ? NotifyCollectionChangedAction.Remove : (NotifyCollectionChangedAction?) null,
@@ -499,7 +500,7 @@ namespace Softeq.XToolkit.Common.Collections
 
         private void RaiseEvents(NotifyKeyGroupCollectionChangedEventArgs<TKey, TValue> args)
         {
-            if (args?.Action != null)
+            if (args.Action != null)
             {
                 NotifyCollectionChangedEventArgs notifyArgs;
 

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
@@ -27,7 +27,7 @@ namespace Softeq.XToolkit.Common.Collections
     {
         private const string UnsupportEmptyGroupExceptionMessage = "Empty group isn't supported";
 
-        private readonly IList<Group> _items;
+        private readonly IList<Group> _groups;
         private readonly bool _emptyGroupsDisabled;
 
         /// <summary>
@@ -37,32 +37,32 @@ namespace Softeq.XToolkit.Common.Collections
         public ObservableKeyGroupsCollection(bool allowEmptyGroups = true)
         {
             _emptyGroupsDisabled = !allowEmptyGroups;
-            _items = new List<Group>();
+            _groups = new List<Group>();
         }
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
         public event EventHandler<NotifyKeyGroupCollectionChangedEventArgs<TKey, TValue>>? ItemsChanged;
 
-        public IList<TKey> Keys => _items.Select(item => item.Key).ToList();
+        public IList<TKey> Keys => _groups.Select(item => item.Key).ToList();
 
-        public int Count => _items.Count;
-
-        /// <inheritdoc />
-        public IEnumerator<IGrouping<TKey, TValue>> GetEnumerator() => _items.GetEnumerator();
+        public int Count => _groups.Count;
 
         /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+        public IEnumerator<IGrouping<TKey, TValue>> GetEnumerator() => _groups.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => _groups.GetEnumerator();
 
         /// <inheritdoc />
         public void AddGroups(IEnumerable<TKey> keys)
         {
-            InsertGroups(_items.Count, keys);
+            InsertGroups(_groups.Count, keys);
         }
 
         /// <inheritdoc />
         public void AddGroups(IEnumerable<KeyValuePair<TKey, IList<TValue>>> items)
         {
-            InsertGroups(_items.Count, items);
+            InsertGroups(_groups.Count, items);
         }
 
         /// <inheritdoc />
@@ -112,7 +112,7 @@ namespace Softeq.XToolkit.Common.Collections
 
             var itemsEvents = insertedGroups
                 .Select(x => (
-                    _items.IndexOf(x),
+                    _groups.IndexOf(x),
                     new NotifyGroupCollectionChangedEventArgs<TValue>(
                         NotifyCollectionChangedAction.Add, new Collection<(int, IReadOnlyList<TValue>)>(), default)))
              .ToList();
@@ -155,10 +155,10 @@ namespace Softeq.XToolkit.Common.Collections
 
             var oldItems = new Collection<(int, IReadOnlyList<TKey>)>
             {
-                (0, _items.Select(x => x.Key).ToList())
+                (0, _groups.Select(x => x.Key).ToList())
             };
 
-            _items.Clear();
+            _groups.Clear();
 
             var insertedGroups = InsertGroupsWithoutNotify(0, items, _emptyGroupsDisabled);
             if (insertedGroups == null)
@@ -207,12 +207,12 @@ namespace Softeq.XToolkit.Common.Collections
         /// <inheritdoc />
         public void Clear()
         {
-            if (_items.Count == 0)
+            if (_groups.Count == 0)
             {
                 return;
             }
 
-            _items.Clear();
+            _groups.Clear();
 
             OnChanged(
                 NotifyCollectionChangedAction.Reset,
@@ -234,7 +234,7 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var item = _items.FirstOrDefault(x => x.Key.Equals(key));
+            var item = _groups.FirstOrDefault(x => x.Key.Equals(key));
             if (item == null)
             {
                 throw new KeyNotFoundException();
@@ -245,7 +245,7 @@ namespace Softeq.XToolkit.Common.Collections
             var clearGroupEvent =
                 new Collection<(int, NotifyGroupCollectionChangedEventArgs<TValue>)>
                 {
-                    (_items.IndexOf(item),
+                    (_groups.IndexOf(item),
                         new NotifyGroupCollectionChangedEventArgs<TValue>(NotifyCollectionChangedAction.Reset, default, default))
                 };
 
@@ -272,12 +272,12 @@ namespace Softeq.XToolkit.Common.Collections
                 return;
             }
 
-            int insertionIndex = _items.Count;
+            int insertionIndex = _groups.Count;
 
             var groups = items
                 .Select(keySelector.Invoke)
                 .Distinct()
-                .Where(x => _items.All(y => !y.Key.Equals(x)))
+                .Where(x => _groups.All(y => !y.Key.Equals(x)))
                 .Select(x => new KeyValuePair<TKey, IList<TValue>>(x, new List<TValue>()));
 
             var keysOfAddedGroups = InsertGroupsWithoutNotify(insertionIndex, groups, false)?.Select(x => x.Key).ToList();
@@ -291,7 +291,7 @@ namespace Softeq.XToolkit.Common.Collections
             var addedItemsEvents = insertedItems
                 .Where(x => keysOfAddedGroups == null || keysOfAddedGroups.All(y => !y.Equals(x.Key)))
                 .Select(x => (
-                    _items.IndexOf(_items.First(y => y.Key.Equals(x.Key))),
+                    _groups.IndexOf(_groups.First(y => y.Key.Equals(x.Key))),
                     new NotifyGroupCollectionChangedEventArgs<TValue>(
                             NotifyCollectionChangedAction.Add,
                             new Collection<(int, IReadOnlyList<TValue>)>(x.ValuesGroups.ToList()),
@@ -328,7 +328,7 @@ namespace Softeq.XToolkit.Common.Collections
 
             var insertedItemsEvents = insertedItems
                 .Select(x => (
-                    _items.IndexOf(_items.First(y => y.Key.Equals(x.Key))),
+                    _groups.IndexOf(_groups.First(y => y.Key.Equals(x.Key))),
                     new NotifyGroupCollectionChangedEventArgs<TValue>(
                         NotifyCollectionChangedAction.Add,
                         new Collection<(int, IReadOnlyList<TValue>)>(x.ValuesGroups.ToList()),
@@ -353,14 +353,14 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException();
             }
 
-            var keysToRemove = _items.Select(x => x.Key).ToList();
+            var keysToRemove = _groups.Select(x => x.Key).ToList();
 
-            _items.Clear();
+            _groups.Clear();
 
             var groups = items
                 .Select(keySelector.Invoke)
                 .Distinct()
-                .Where(x => _items.All(y => !y.Key.Equals(x)))
+                .Where(x => _groups.All(y => !y.Key.Equals(x)))
                 .Select(x => new KeyValuePair<TKey, IList<TValue>>(x, new List<TValue>()));
 
             var keysOfAddedGroup = InsertGroupsWithoutNotify(0, groups, false)?.Select(x => x.Key)?.ToList() ?? new List<TKey>();
@@ -408,16 +408,16 @@ namespace Softeq.XToolkit.Common.Collections
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                if (!_items.Any(x => x.Key.Equals(key)))
+                if (!_groups.Any(x => x.Key.Equals(key)))
                 {
                     throw new KeyNotFoundException();
                 }
 
-                var groupIndex = _items.IndexOf(_items.First(x => x.Key.Equals(key)));
+                var groupIndex = _groups.IndexOf(_groups.First(x => x.Key.Equals(key)));
                 var val = valueSelector(item);
-                var valIndex = _items.ElementAt(groupIndex).IndexOf(val);
+                var valIndex = _groups.ElementAt(groupIndex).IndexOf(val);
 
-                if (!_items.ElementAt(groupIndex).Any(x => x.Equals(val)))
+                if (!_groups.ElementAt(groupIndex).Any(x => x.Equals(val)))
                 {
                     throw new KeyNotFoundException();
                 }
@@ -447,13 +447,13 @@ namespace Softeq.XToolkit.Common.Collections
             {
                 foreach (var item in groupInfo.Items)
                 {
-                    _items[groupInfo.GroupIndex].Remove(item.Key);
+                    _groups[groupInfo.GroupIndex].Remove(item.Key);
                 }
             }
 
             if (_emptyGroupsDisabled)
             {
-                var keysToRemove = _items.Where(x => x.Count == 0).Select(x => x.Key);
+                var keysToRemove = _groups.Where(x => x.Count == 0).Select(x => x.Key);
                 groupsToRemove = RemoveGroupsWithoutNotify(keysToRemove);
             }
 
@@ -551,12 +551,12 @@ namespace Softeq.XToolkit.Common.Collections
                 throw new ArgumentNullException(nameof(items), "One of the keys or values is null.");
             }
 
-            if (index > _items.Count + items.Count() - 1)
+            if (index > _groups.Count + items.Count() - 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            if (_items.Select(x => x.Key).Concat(items.Select(x => x.Key)).GroupBy(x => x).Any(g => g.Count() > 1))
+            if (_groups.Select(x => x.Key).Concat(items.Select(x => x.Key)).GroupBy(x => x).Any(g => g.Count() > 1))
             {
                 throw new ArgumentException("An item with the same key has already been added.");
             }
@@ -573,7 +573,7 @@ namespace Softeq.XToolkit.Common.Collections
 
             foreach (var item in toInsert)
             {
-                _items.Insert(index++, item);
+                _groups.Insert(index++, item);
             }
 
             return toInsert;
@@ -598,13 +598,13 @@ namespace Softeq.XToolkit.Common.Collections
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                if (!_items.Any(x => x.Key.Equals(key)))
+                if (!_groups.Any(x => x.Key.Equals(key)))
                 {
                     throw new KeyNotFoundException();
                 }
 
                 var val = valueSelector.Invoke(item);
-                var index = indexSelector == null ? _items.First(x => x.Key.Equals(key)).Count : indexSelector.Invoke(item);
+                var index = indexSelector == null ? _groups.First(x => x.Key.Equals(key)).Count : indexSelector.Invoke(item);
 
                 if (!itemsToAdd.Any(x => x.Key.Equals(key)))
                 {
@@ -623,7 +623,7 @@ namespace Softeq.XToolkit.Common.Collections
             {
                 foreach (var (index, values) in ranges)
                 {
-                    _items
+                    _groups
                         .First(x => x.Key.Equals(key))
                         .InsertRange(index, values.ToList());
                 }
@@ -634,24 +634,24 @@ namespace Softeq.XToolkit.Common.Collections
 
         private IReadOnlyList<(int Index, IReadOnlyList<TKey> Keys)> RemoveGroupsWithoutNotify(IEnumerable<TKey> keys)
         {
-            if (keys.Any(key => _items.All(item => !item.Key.Equals(key))))
+            if (keys.Any(key => _groups.All(item => !item.Key.Equals(key))))
             {
                 throw new KeyNotFoundException();
             }
 
             var indexes = new List<KeyValuePair<TKey, int>>();
 
-            for (int i = 0; i < _items.Count; i++)
+            for (int i = 0; i < _groups.Count; i++)
             {
-                if (keys.Any(x => x.Equals(_items[i].Key)))
+                if (keys.Any(x => x.Equals(_groups[i].Key)))
                 {
-                    indexes.Add(new KeyValuePair<TKey, int>(_items[i].Key, i));
+                    indexes.Add(new KeyValuePair<TKey, int>(_groups[i].Key, i));
                 }
             }
 
             foreach (var key in keys.ToList())
             {
-                _items.Remove(_items.First(x => x.Key.Equals(key)));
+                _groups.Remove(_groups.First(x => x.Key.Equals(key)));
             }
 
             return GroupByIndex(indexes);

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
@@ -91,7 +91,7 @@ namespace Softeq.XToolkit.Common.Collections
 
             if (items.Any(x => x.Key == null))
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(items), "One of the keys is null.");
             }
 
             if (_withoutEmptyGroups && items.Any(x => x.Value?.Count == 0))
@@ -547,12 +547,12 @@ namespace Softeq.XToolkit.Common.Collections
 
             if (items.Any(x => x.Key == null || x.Value == null))
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(items), "One of the keys or values is null.");
             }
 
             if (index > _items.Count + items.Count() - 1)
             {
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             if (_items.Select(x => x.Key).Concat(items.Select(x => x.Key)).GroupBy(x => x).Any(g => g.Count() > 1))

--- a/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableKeyGroupsCollection.cs
@@ -226,7 +226,7 @@ namespace Softeq.XToolkit.Common.Collections
         {
             if (_withoutEmptyGroups)
             {
-                throw new InvalidOperationException(nameof(key));
+                throw new InvalidOperationException($"{UnsupportEmptyGroupExceptionMessage}. Group with key '{key}' can't be clear.");
             }
 
             if (key == null)


### PR DESCRIPTION
### Description

- Some internal refactor
- Empty groups are **enabled by default**, changed default constructor

### API Changes

- `ObservableKeyGroupsCollection(bool withoutEmptyGroups = true)` -> `ObservableKeyGroupsCollection(bool allowEmptyGroups = true)`

### Platforms Affected

- Core (all platforms)

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
