### PR TITLE
Android: handle cases when showing/dismissing dialogs after activity …

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
@@ -2,10 +2,10 @@
 // http://www.softeq.com
 
 using System.Threading.Tasks;
+using AndroidX.AppCompat.App;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.WhiteLabel.Droid.Providers;
-using AlertDialog = AndroidX.AppCompat.App.AlertDialog;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
 {

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
@@ -2,26 +2,32 @@
 // http://www.softeq.com
 
 using System.Threading.Tasks;
-using AndroidX.AppCompat.App;
-using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.Bindings;
+using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.WhiteLabel.Droid.Providers;
+using AlertDialog = AndroidX.AppCompat.App.AlertDialog;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
 {
     public abstract class AlertDialogBase
     {
+        private readonly IContextProvider _contextProvider = Dependencies.Container.Resolve<IContextProvider>();
+
         protected virtual AlertDialog.Builder GetBuilder()
         {
-            var context = Dependencies.Container.Resolve<IContextProvider>().CurrentActivity;
+            var context = _contextProvider.CurrentActivity;
             return new AlertDialog.Builder(context)
                 .SetCancelable(false);
         }
 
         protected virtual void Present(AlertDialog.Builder builder)
         {
-            var dialog = builder.Create();
-            dialog.Show();
+            var activity = _contextProvider.CurrentActivity;
+            if (activity != null && !activity.IsFinishing && !activity.IsDestroyed)
+            {
+                var dialog = builder.Create();
+                dialog.Show();
+            }
         }
 
         protected virtual void SetPositiveButton<T>(

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/AlertDialogBase.cs
@@ -11,23 +11,17 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
 {
     public abstract class AlertDialogBase
     {
-        private readonly IContextProvider _contextProvider = Dependencies.Container.Resolve<IContextProvider>();
-
         protected virtual AlertDialog.Builder GetBuilder()
         {
-            var context = _contextProvider.CurrentActivity;
+            var context = Dependencies.Container.Resolve<IContextProvider>().CurrentActivity;
             return new AlertDialog.Builder(context)
                 .SetCancelable(false);
         }
 
         protected virtual void Present(AlertDialog.Builder builder)
         {
-            var activity = _contextProvider.CurrentActivity;
-            if (activity != null && !activity.IsFinishing && !activity.IsDestroyed)
-            {
-                var dialog = builder.Create();
-                dialog.Show();
-            }
+            var dialog = builder.Create();
+            dialog.Show();
         }
 
         protected virtual void SetPositiveButton<T>(

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
@@ -22,7 +22,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         private readonly Lazy<IContextProvider> _contextProviderLazy = Dependencies.Container.Resolve<Lazy<IContextProvider>>();
 
         public event EventHandler? WillDismiss;
-        
+
         public event EventHandler? Dismissed;
 
         protected TViewModel ViewModel => (TViewModel) DataContext;
@@ -83,13 +83,16 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         {
             WillDismiss?.Invoke(this, null);
 
-            base.Dismiss();
+            if (Activity != null && !Activity.IsFinishing && !Activity.IsDestroyed)
+            {
+                base.Dismiss();
+            }
         }
 
         public override void OnDismiss(IDialogInterface dialog)
         {
             base.OnDismiss(dialog);
-            
+
             Dismissed?.Invoke(this, null);
 
             ViewModel.DialogComponent.CloseCommand.Execute(null);
@@ -154,7 +157,11 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         {
             Dismiss();
 
-            Internal.ViewModelStore.Of(GetFragmentManager()).Remove(GetKey());
+            var fragmentManager = GetFragmentManager();
+            if (!fragmentManager.IsDestroyed)
+            {
+                Internal.ViewModelStore.Of(fragmentManager).Remove(GetKey());
+            }
         }
 
         private string GetKey()

--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/IDialogFragment.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/IDialogFragment.cs
@@ -10,12 +10,12 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         /// <summary>
         ///     Event called when Dialog fragment will dismiss.
         /// </summary>
-        public event EventHandler? WillDismiss;
-        
+        event EventHandler? WillDismiss;
+
         /// <summary>
         ///     Event called when Dialog fragment is dismissed.
         /// </summary>
-        public event EventHandler? Dismissed;
+        event EventHandler? Dismissed;
 
         /// <summary>
         ///     Show Dialog fragment.

--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidViewLocator.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidViewLocator.cs
@@ -2,7 +2,6 @@
 // http://www.softeq.com
 
 using System;
-using System.Collections.Generic;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper;
 using Softeq.XToolkit.WhiteLabel.Mvvm;


### PR DESCRIPTION
Android: handle cases when showing/dismissing dialogs after activity was closed

### API Changes
 
 None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
