### PR TITLE
Android foreground notifications intent

### DIFF
--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationIntentActivityInfo.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationIntentActivityInfo.cs
@@ -2,6 +2,7 @@
 // http://www.softeq.com
 
 using System;
+using Android.Content;
 
 namespace Softeq.XToolkit.PushNotifications.Droid
 {
@@ -15,16 +16,23 @@ namespace Softeq.XToolkit.PushNotifications.Droid
         /// </summary>
         /// <param name="activityType">The type of the Activity that shall be opened.</param>
         /// <param name="doCreateParentStack">Value indicating whether parent stack should be created for this Activity.</param>
-        public NotificationIntentActivityInfo(Type activityType, bool doCreateParentStack)
+        /// <param name="flags">Optional parameter with flags that will be used when starting this Activity (if supplied).</param>
+        public NotificationIntentActivityInfo(Type activityType, bool doCreateParentStack, ActivityFlags? flags = null)
         {
             ActivityType = activityType;
             DoCreateParentStack = doCreateParentStack;
+            Flags = flags;
         }
 
         /// <summary>
         ///     Gets or sets the type of the Activity that shall be opened.
         /// </summary>
         public Type ActivityType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the flags to use when opening this Activity.
+        /// </summary>
+        public ActivityFlags? Flags { get; set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether parent stack should be created for this Activity.

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -114,7 +114,6 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             }
             else
             {
-                intent.SetFlags(ActivityFlags.NewTask | ActivityFlags.ClearTask);
                 return PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
             }
         }

--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -96,7 +96,7 @@ namespace Softeq.XToolkit.PushNotifications.Droid
                 }
             }
 
-            var pendingIntent = CreatePendingIntent(context, intent, intentActivityInfo.DoCreateParentStack);
+            var pendingIntent = CreatePendingIntent(context, intent, intentActivityInfo.DoCreateParentStack, intentActivityInfo.Flags);
             notificationBuilder.SetContentIntent(pendingIntent);
 
             _notificationsSettings.CustomizeNotificationBuilder(notificationBuilder, pushNotification, styles.Id);
@@ -104,8 +104,13 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             NotificationManagerCompat.From(context).Notify(styles.Id, notificationBuilder.Build());
         }
 
-        private static PendingIntent CreatePendingIntent(Context context, Intent intent, bool withParentStack)
+        private static PendingIntent CreatePendingIntent(Context context, Intent intent, bool withParentStack, ActivityFlags? flags)
         {
+            if (flags.HasValue)
+            {
+                intent.SetFlags(flags.Value);
+            }
+
             if (withParentStack)
             {
                 var stackBuilder = TaskStackBuilder.Create(context);


### PR DESCRIPTION
### Description

Add ability to provide flags to Push Notification intent on Android (including No flags). By default no flags will be supplied now (previously the following flags were used: `ActivityFlags.NewTask | ActivityFlags.ClearTask`)

### API Changes

Added:
 - ActivityFlags? Flags { get; set; } to `NotificationIntentActivityInfo`

Changed:
 - NotificationIntentActivityInfo(Type activityType, bool doCreateParentStack)
 => NotificationIntentActivityInfo(Type activityType, bool doCreateParentStack, ActivityFlags? flags = null)

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [ ] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
