### PR TITLE
BaseFragment OnCreate fix

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -27,8 +27,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         public override void OnCreate(Bundle savedInstanceState)
         {
-            base.OnCreate(savedInstanceState);
-
             RestoreViewModelIfNeeded(savedInstanceState);
 
             OnViewModelRestored();
@@ -37,6 +35,10 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             {
                 ViewModel.OnInitialize();
             }
+
+            // Calling base.OnCreate initiates restoring nested Fragments
+            // so we should restore and initialize ViewModel before calling it
+            base.OnCreate(savedInstanceState);
         }
 
         public override void OnResume()


### PR DESCRIPTION
### Description

Calling base.OnCreate moved to be the last call in OnCreate (after restoring and initializing ViewModel)

### API Changes

 None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
