### PR TITLE
Add ImageName parameter to AlertDialogConfig and ConfirmDialogConfig

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Dialogs/DialogFragmentBase.cs
@@ -81,7 +81,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
 
         public override void Dismiss()
         {
-            WillDismiss?.Invoke(this, null);
+            WillDismiss?.Invoke(this, EventArgs.Empty);
 
             if (Activity != null && !Activity.IsFinishing && !Activity.IsDestroyed)
             {
@@ -93,7 +93,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Dialogs
         {
             base.OnDismiss(dialog);
 
-            Dismissed?.Invoke(this, null);
+            Dismissed?.Invoke(this, EventArgs.Empty);
 
             ViewModel.DialogComponent.CloseCommand.Execute(null);
         }

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/AlertDialogConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/AlertDialogConfig.cs
@@ -16,11 +16,15 @@ namespace Softeq.XToolkit.WhiteLabel.Dialogs
         /// <param name="title">Dialog title.</param>
         /// <param name="message">Dialog message.</param>
         /// <param name="closeButtonText">The text to be displayed on the 'Close' button.</param>
-        public AlertDialogConfig(string title, string message, string closeButtonText)
+        /// <param name="imageName">
+        ///     The name of the dialog image or <see langword="null"/> if no image should be used.
+        /// </param>
+        public AlertDialogConfig(string title, string message, string closeButtonText, string? imageName = null)
         {
             Title = title ?? throw new ArgumentNullException(nameof(title));
             Message = message ?? throw new ArgumentNullException(nameof(message));
             CloseButtonText = closeButtonText ?? throw new ArgumentNullException(nameof(closeButtonText));
+            ImageName = imageName;
         }
 
         /// <summary>
@@ -37,5 +41,10 @@ namespace Softeq.XToolkit.WhiteLabel.Dialogs
         ///     Gets the text to be displayed on the 'Close' button.
         /// </summary>
         public string CloseButtonText { get; }
+
+        /// <summary>
+        ///     Gets the name of the dialog image or <see langword="null"/> if no image should be used.
+        /// </summary>
+        public string? ImageName { get; }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Dialogs/ConfirmDialogConfig.cs
+++ b/Softeq.XToolkit.WhiteLabel/Dialogs/ConfirmDialogConfig.cs
@@ -21,6 +21,9 @@ namespace Softeq.XToolkit.WhiteLabel.Dialogs
         /// <param name="isDestructive">
         ///     Value indicating whether the 'Accept' button should look destructive on UI.
         /// </param>
+        /// <param name="imageName">
+        ///     The name of the dialog image or <see langword="null"/> if no image should be used.
+        /// </param>
         /// <exception cref="T:System.ArgumentNullException">
         ///     <paramref name="title"/>
         ///     and <paramref name="message"/>
@@ -32,13 +35,15 @@ namespace Softeq.XToolkit.WhiteLabel.Dialogs
             string message,
             string acceptButtonText,
             string? cancelButtonText = null,
-            bool isDestructive = false)
+            bool isDestructive = false,
+            string? imageName = null)
         {
             Title = title ?? throw new ArgumentNullException(nameof(title));
             Message = message ?? throw new ArgumentNullException(nameof(message));
             AcceptButtonText = acceptButtonText ?? throw new ArgumentNullException(nameof(acceptButtonText));
             CancelButtonText = cancelButtonText;
             IsDestructive = isDestructive;
+            ImageName = imageName;
         }
 
         /// <summary>
@@ -67,5 +72,10 @@ namespace Softeq.XToolkit.WhiteLabel.Dialogs
         ///     the 'Accept' button should look destructive on UI.
         /// </summary>
         public bool IsDestructive { get; }
+
+        /// <summary>
+        ///     Gets the name of the dialog image or <see langword="null"/> if no image should be used.
+        /// </summary>
+        public string? ImageName { get; }
     }
 }


### PR DESCRIPTION
### Description

Add ImageName parameter to AlertDialogConfig and ConfirmDialogConfig to be able to add images to custom dialogs

### API Changes
- Optional parameter `string? imageName = null` is added to constructors of `AlertDialogConfig` and `ConfirmDialogConfig`
- `public string? ImageName { get; }` property is added to `AlertDialogConfig` and `ConfirmDialogConfig`

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [ ] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
