### PR TITLE
Get rid of explicit interface implementation in StoryboardFrameNavigationService

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
@@ -26,9 +26,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
 
         public bool IsEmptyBackStack => !NavigationController!.ViewControllers.Any();
 
-        bool IFrameNavigationService.IsInitialized => NavigationController != null;
-
-        bool IFrameNavigationService.CanGoBack => CanGoBack;
+        public bool IsInitialized => NavigationController != null;
 
         public virtual void NavigateToViewModel<TViewModel>(
             bool clearBackStack = false,
@@ -40,12 +38,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
             NavigateToViewModel(viewModel, clearBackStack, parameters);
         }
 
-        void IFrameNavigationService.GoBack()
-        {
-            GoBack();
-        }
-
-        void IFrameNavigationService.GoBack<T>()
+        public void GoBack<T>() where T : IViewModelBase
         {
             Execute.BeginOnUIThread(() =>
             {
@@ -62,20 +55,15 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
             });
         }
 
-        void IFrameNavigationService.Initialize(object navigation)
-        {
-            Initialize(navigation);
-        }
-
-        void IFrameNavigationService.RestoreNavigation()
+        public void RestoreNavigation()
         {
         }
 
-        void IFrameNavigationService.RestoreUnfinishedNavigation()
+        public void RestoreUnfinishedNavigation()
         {
         }
 
-        void IFrameNavigationService.NavigateToFirstPage()
+        public virtual void NavigateToFirstPage()
         {
         }
 


### PR DESCRIPTION
### Description

For some reason we had explicit implementation of `IFrameNavigationService` in `StoryboardFrameNavigationService`. It wouldn't allow us to override those methods in a descendant but instead it would allow us to reimplement that interface like this:
`class NewStoryboardFrameNavigationService : StoryboardFrameNavigationService, IFrameNavigationService
{
        public void NavigateToFirstPage()
        {
            ...
        }
}`
This creates a separate method and feels very wrong.

This PR reworks implementation of `IFrameNavigationService` in `StoryboardFrameNavigationService` to avoid such possibilities and provide a more correct way to override required methods if needed in future. Additionally `NavigateToFirstPage` methods becomes virtual for that sake.

### API Changes
 
 None

### Platforms Affected

- iOS

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
