### PR TITLE
Add public method for ViewModelStore setup

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Internal/ViewModelStore.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Internal/ViewModelStore.cs
@@ -6,9 +6,14 @@ using AndroidX.Fragment.App;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Internal
 {
-    internal static class ViewModelStore
+    public static class ViewModelStore
     {
         private const string ViewModelStoreTag = "WL_ViewModelStore";
+
+        public static void SetupFor(FragmentManager fragmentManager)
+        {
+            Get(fragmentManager);
+        }
 
         internal static IInstanceStorage Of(FragmentManager fragmentManager)
         {


### PR DESCRIPTION
### Description

Add ability to setup ViewModelStore for a FragmentManager

### API Changes

Added:
 - void ViewModelStore.SetupFor(FragmentManager)

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
