### PR TITLE
Added customizing the font of links

### DIFF
--- a/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
@@ -79,6 +79,23 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
             return self;
         }
 
+        public static NSMutableAttributedString LinksFont(
+            this NSMutableAttributedString self, UIFont font)
+        {
+            self.EnumerateAttributes(
+                new NSRange(0, self.Length),
+                NSAttributedStringEnumeration.Reverse,
+                (NSDictionary attrs, NSRange range, ref bool stop) =>
+                {
+                    if (attrs.ContainsKey(UIStringAttributeKey.Link))
+                    {
+                        self.RemoveAttribute(UIStringAttributeKey.Font, range);
+                        self.AddAttribute(UIStringAttributeKey.Font, font, range);
+                    }
+                });
+            return self;
+        }
+
         /// <summary>
         ///    Set underline for range.
         /// </summary>

--- a/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
+++ b/Softeq.XToolkit.Common.iOS/Extensions/NSStringExtensions.cs
@@ -82,9 +82,10 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
         public static NSMutableAttributedString LinksFont(
             this NSMutableAttributedString self, UIFont font)
         {
+            self.BeginEditing();
             self.EnumerateAttributes(
                 new NSRange(0, self.Length),
-                NSAttributedStringEnumeration.Reverse,
+                NSAttributedStringEnumeration.None,
                 (NSDictionary attrs, NSRange range, ref bool stop) =>
                 {
                     if (attrs.ContainsKey(UIStringAttributeKey.Link))
@@ -93,6 +94,7 @@ namespace Softeq.XToolkit.Common.iOS.Extensions
                         self.AddAttribute(UIStringAttributeKey.Font, font, range);
                     }
                 });
+            self.EndEditing();
             return self;
         }
 


### PR DESCRIPTION
<!-- WAIT! 
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

Added ability to customize the font of links in UITextAreas

### API Changes
Added:
 - LinksFont(this NSMutableAttributedString self, UIFont font)
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [ ] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
