### PR TITLE
Added handling of items movement in a UICollectionView

### DIFF
--- a/Softeq.XToolkit.Bindings.iOS/ObservableCollectionViewSource.cs
+++ b/Softeq.XToolkit.Bindings.iOS/ObservableCollectionViewSource.cs
@@ -349,11 +349,12 @@ namespace Softeq.XToolkit.Bindings.iOS
 
                             for (var i = 0; i < count; i++)
                             {
-                                paths[i] = NSIndexPath.FromRowSection(e.NewStartingIndex + i, 0);
+                                paths[i] = NSIndexPath.FromItemSection(e.NewStartingIndex + i, 0);
                             }
 
                             _view.InsertItems(paths);
                         }
+
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
@@ -363,7 +364,7 @@ namespace Softeq.XToolkit.Bindings.iOS
 
                             for (var i = 0; i < count; i++)
                             {
-                                var index = NSIndexPath.FromRowSection(e.OldStartingIndex + i, 0);
+                                var index = NSIndexPath.FromItemSection(e.OldStartingIndex + i, 0);
                                 paths[i] = index;
 
                                 var item = e.OldItems[i];
@@ -376,6 +377,23 @@ namespace Softeq.XToolkit.Bindings.iOS
 
                             _view.DeleteItems(paths);
                         }
+
+                        break;
+
+                    case NotifyCollectionChangedAction.Move:
+                        {
+                            if (e.NewItems.Count != 1 || e.OldItems.Count != 1)
+                            {
+                                _view.ReloadData();
+                            }
+                            else if (e.NewStartingIndex != e.OldStartingIndex)
+                            {
+                                _view.MoveItem(
+                                    NSIndexPath.FromItemSection(e.OldStartingIndex, 0),
+                                    NSIndexPath.FromItemSection(e.NewStartingIndex, 0));
+                            }
+                        }
+
                         break;
 
                     default:

--- a/Softeq.XToolkit.Bindings.iOS/ObservableTableViewSource.cs
+++ b/Softeq.XToolkit.Bindings.iOS/ObservableTableViewSource.cs
@@ -466,6 +466,7 @@ namespace Softeq.XToolkit.Bindings.iOS
 
                             _view.InsertRows(paths, AddAnimation);
                         }
+
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
@@ -488,23 +489,24 @@ namespace Softeq.XToolkit.Bindings.iOS
 
                             _view.DeleteRows(paths, DeleteAnimation);
                         }
+
                         break;
+
                     case NotifyCollectionChangedAction.Move:
                         {
                             if (e.NewItems.Count != 1 || e.OldItems.Count != 1)
                             {
                                 _view.ReloadData();
-                                break;
                             }
-
-                            if (e.NewStartingIndex != e.OldStartingIndex)
+                            else if (e.NewStartingIndex != e.OldStartingIndex)
                             {
-                                _view.MoveRow(NSIndexPath.FromRowSection(e.OldStartingIndex, 0),
+                                _view.MoveRow(
+                                    NSIndexPath.FromRowSection(e.OldStartingIndex, 0),
                                     NSIndexPath.FromRowSection(e.NewStartingIndex, 0));
                             }
-
-                            break;
                         }
+
+                        break;
 
                     default:
                         _view.ReloadData();


### PR DESCRIPTION
### Description

Add handling of Move case, so that collection items could be sorted with animation when calling ObservableCollectionExtensions.Sort.
Made methods from UITableView and UICollectionView the same.

### API Changes

 
 None

### Platforms Affected

- iOS

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
