### PR TITLE
Update ViewModelStore only when actual navigation is happening

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -62,7 +62,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             if (ViewModel == null && savedInstanceState != null)
             {
                 var viewModelStore = Internal.ViewModelStore.Of(ParentFragmentManager);
-                var key = GetType().Name;
+                var key = Internal.ViewModelStore.GenerateKeyForType(typeof(TViewModel));
                 DataContext = viewModelStore.Get<TViewModel>(key);
             }
         }

--- a/Softeq.XToolkit.WhiteLabel.Droid/Internal/BackStack.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Internal/BackStack.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid.Internal
 {
@@ -22,25 +21,18 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Internal
 
         internal void Add(T entry) => _backStack.Push(entry);
 
-        internal T CurrentWithRemove() => _backStack.Pop();
+        internal void GoBack() => _backStack.Pop();
 
         internal T Current() => _backStack.Peek();
 
         internal void Clear() => _backStack.Clear();
 
-        internal IReadOnlyList<TResult> Dump<TResult>(Func<T, TResult> selector)
-        {
-            return _backStack.Select(selector).ToArray();
-        }
-
-        internal T ResetToFirst()
+        internal void ResetToFirst()
         {
             while (_backStack.Count > 1)
             {
                 _backStack.Pop();
             }
-
-            return _backStack.Pop();
         }
 
         internal void GoBackWhile(Func<T, bool> canGoBack)

--- a/Softeq.XToolkit.WhiteLabel.Droid/Internal/ViewModelStore.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Internal/ViewModelStore.cs
@@ -20,6 +20,11 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Internal
             return Get(fragmentManager);
         }
 
+        internal static string GenerateKeyForType(Type type)
+        {
+            return type.Name;
+        }
+
         private static IInstanceStorage Get(FragmentManager fragmentManager)
         {
             if (fragmentManager.IsDestroyed)

--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using AndroidX.Fragment.App;
+using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Common.Threading;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
 using Softeq.XToolkit.WhiteLabel.Droid.Internal;
@@ -116,6 +117,11 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
 
         private static void UpdateViewModelStorage(FragmentManager fragmentManager, IViewModelBase? viewModelToRemove, IViewModelBase viewModelToAdd)
         {
+            if (ReferenceEquals(viewModelToRemove, viewModelToAdd))
+            {
+                return;
+            }
+
             var viewModelStore = ViewModelStore.Of(fragmentManager);
 
             if (viewModelToRemove != null)
@@ -138,6 +144,13 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
             viewModelStore.Remove(viewModelKey);
         }
 
+        private static object? ExtractCurrentFragmentViewModel(FrameNavigationConfig config)
+        {
+            var currentBindableFragment = config.Manager.FindFragmentById(config.ContainerId) as IBindable;
+
+            return currentBindableFragment?.DataContext;
+        }
+
         private void ApplyBackStack(BackStack<IViewModelBase> backStack)
         {
             Execute.BeginOnUIThread(() =>
@@ -158,6 +171,12 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
 
         private void SetCurrentFragment(FrameNavigationConfig config, IViewModelBase topViewModel)
         {
+            var currentFragmentViewModel = ExtractCurrentFragmentViewModel(config);
+            if (ReferenceEquals(topViewModel, currentFragmentViewModel))
+            {
+                return;
+            }
+
             var fragment = (Fragment) _viewLocator.GetView(topViewModel, ViewType.Fragment);
 
             var transaction = config.Manager

--- a/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Navigation/StoryboardFrameNavigationService.cs
@@ -1,7 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Softeq.XToolkit.Common.Threading;
@@ -71,23 +70,14 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Navigation
         {
         }
 
-        void IFrameNavigationService.RestoreUnfinishedNavigation()
-        {
-        }
-
         void IFrameNavigationService.NavigateToFirstPage()
         {
         }
 
         protected virtual IViewModelBase CreateViewModel<TViewModel>()
-            where TViewModel : notnull
+            where TViewModel : IViewModelBase
         {
-            if (!typeof(IViewModelBase).IsAssignableFrom(typeof(TViewModel)))
-            {
-                throw new ArgumentException($"Class must implement {nameof(IViewModelBase)}");
-            }
-
-            return (IViewModelBase) _iocContainer.Resolve<TViewModel>(this);
+            return _iocContainer.Resolve<TViewModel>(this);
         }
     }
 }

--- a/Softeq.XToolkit.WhiteLabel/Navigation/IFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel/Navigation/IFrameNavigationService.cs
@@ -62,10 +62,5 @@ namespace Softeq.XToolkit.WhiteLabel.Navigation
         ///     Restores the last fragment after a switch between tabs or back navigation.
         /// </summary>
         void RestoreNavigation();
-
-        /// <summary>
-        ///     Restores the last fragment only if there was an unfinished navigation transaction.
-        /// </summary>
-        void RestoreUnfinishedNavigation();
     }
 }


### PR DESCRIPTION
### Description

This update separates back-stack handling and `FragmentManager` manipulations within `DroidFrameNavigationSerivice`. This makes it possible to update ViewModelStore only when actual navigation is happening.

### Issues Resolved

- fixes "InvalidOperationException: View Model store has been destroyed", which happened when app tries to perform navigation actions in background

### API Changes
 
 Removed:
 - `void IFrameNavigationService.RestoreUnfinishedNavigation()` - now it's automatically handled by `RestoreNavigation()`
 

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
