### PR TITLE
Add Storage Info Providers

### DIFF
--- a/Softeq.XToolkit.Common.Droid/Files/DroidStorageInfoProvider.cs
+++ b/Softeq.XToolkit.Common.Droid/Files/DroidStorageInfoProvider.cs
@@ -12,7 +12,8 @@ namespace Softeq.XToolkit.Common.Droid.Files
     {
         /// <inheritdoc />
         /// <remarks>
-        ///     More modern implementation via <see cref="T:Android.OS.Storage.StorageManager"/> should be in the WhiteLabel.
+        ///     More modern implementation via <see cref="T:Android.OS.Storage.StorageManager"/> yon can see here:
+        ///     <see cref="T:Softeq.XToolkit.WhiteLabel.Droid.Providers.ModernDroidStorageInfoProvider"/>.
         /// </remarks>
         public List<StorageInfo> Current
         {

--- a/Softeq.XToolkit.Common.Droid/Files/DroidStorageInfoProvider.cs
+++ b/Softeq.XToolkit.Common.Droid/Files/DroidStorageInfoProvider.cs
@@ -1,0 +1,37 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using Android.OS;
+using Java.IO;
+using Softeq.XToolkit.Common.Files;
+
+namespace Softeq.XToolkit.Common.Droid.Files
+{
+    public class DroidStorageInfoProvider : IStorageInfoProvider
+    {
+        /// <inheritdoc />
+        /// <remarks>
+        ///     More modern implementation via <see cref="T:Android.OS.Storage.StorageManager"/> should be in the WhiteLabel.
+        /// </remarks>
+        public List<StorageInfo> Current
+        {
+            get
+            {
+                var directory = Environment.IsExternalStorageEmulated
+                    ? Environment.ExternalStorageDirectory!
+                    : Environment.DataDirectory;
+
+                var internalStorageInfo = GetInfoByDirectory(StorageType.Internal, directory!);
+
+                return new List<StorageInfo> { internalStorageInfo };
+            }
+        }
+
+        private static StorageInfo GetInfoByDirectory(StorageType type, File directory)
+        {
+            var stats = new StatFs(directory.Path);
+            return new StorageInfo(type, (ulong)stats.TotalBytes, (ulong)stats.AvailableBytes);
+        }
+    }
+}

--- a/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
+++ b/Softeq.XToolkit.Common.Droid/Softeq.XToolkit.Common.Droid.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Converters\VisibilityConverter.cs" />
     <Compile Include="DroidMainThreadExecutor.cs" />
     <Compile Include="Extensions\ContextExtensions.cs" />
+    <Compile Include="Files\DroidStorageInfoProvider.cs" />
     <Compile Include="Permissions\IPermissionRequestHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\TextViewExtensions.cs" />

--- a/Softeq.XToolkit.Common.iOS/Files/IosStorageInfoProvider.cs
+++ b/Softeq.XToolkit.Common.iOS/Files/IosStorageInfoProvider.cs
@@ -1,0 +1,115 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Foundation;
+using ObjCRuntime;
+using Softeq.XToolkit.Common.Files;
+using UIKit;
+
+namespace Softeq.XToolkit.Common.iOS.Files
+{
+    public class IosStorageInfoProvider : IStorageInfoProvider
+    {
+        /// <inheritdoc />
+        public List<StorageInfo> Current
+        {
+            get
+            {
+                var homePath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                var fileSystemAttributes = GetFileSystemAttributesForPath(homePath);
+
+                StorageInfo info;
+
+                Debug.WriteLine($"System Total: {fileSystemAttributes.Size}");
+                if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+                {
+                    var volumeCapacities = GetVolumeAvailableCapacities(homePath);
+                    info = new StorageInfo(StorageType.Internal, fileSystemAttributes.Size, volumeCapacities.AvailableCapacityForImportantUsage);
+
+                    Debug.WriteLine($"AvailableCapacity: {volumeCapacities.AvailableCapacity}");
+                    Debug.WriteLine($"AvailableCapacityForImportantUsage: {volumeCapacities.AvailableCapacityForImportantUsage}");
+                    Debug.WriteLine($"AvailableCapacityForOpportunisticUsage: {volumeCapacities.AvailableCapacityForOpportunisticUsage}");
+                }
+                else
+                {
+                    Debug.WriteLine($"System Free: {fileSystemAttributes.FreeSize}");
+                    info = new StorageInfo(StorageType.Internal, fileSystemAttributes.Size, fileSystemAttributes.FreeSize);
+                }
+
+                return new List<StorageInfo> { info };
+            }
+        }
+
+        public NSFileSystemAttributes GetFileSystemAttributesForPath(string path)
+        {
+            var attributes = NSFileManager.DefaultManager.GetFileSystemAttributes(path, out NSError error);
+
+            if (error != null)
+            {
+                throw new NSErrorException(error);
+            }
+
+            return attributes;
+        }
+
+        /// <summary>
+        /// Total available capacity in bytes for "Important" resources,
+        /// including space expected to be cleared by purging non-essential and cached resources.
+        ///
+        /// "Important" means something that the user or application clearly expects to be present on the local system,
+        /// but is ultimately replaceable. This would include items that the user has explicitly requested via the UI,
+        /// and resources that an application requires in order to provide functionality.
+        ///
+        /// Examples:
+        ///     A video that the user has explicitly requested to watch but has not yet finished watching or
+        ///     an audio file that the user has requested to download.
+        ///     This value should not be used in determining if there is room for an irreplaceable resource.
+        ///     In the case of irreplaceable resources, always attempt to save the resource regardless of available capacity and
+        ///     handle failure as gracefully as possible.
+        /// </summary>
+        /// <remarks>
+        ///     More details:
+        ///     <see href="https://developer.apple.com/documentation/foundation/nsurlresourcekey/checking_volume_storage_capacity?language=objc" />.
+        /// </remarks>
+        /// <param name="path">Target path. Default is file system root.</param>
+        /// <returns>
+        ///     Available capacity values:
+        ///     - AvailableCapacity - available capacity in bytes, minimal.
+        ///     - AvailableCapacityForImportantUsage - capacity in bytes for storing important resources, maximum available space.
+        ///     - AvailableCapacityForOpportunisticUsage - capacity in bytes for storing nonessential resources.
+        /// </returns>
+        /// <exception cref="NSErrorException">Native error during request info from the system.</exception>
+        [Introduced(PlatformName.iOS, 11, 0)]
+        public (ulong AvailableCapacity, ulong AvailableCapacityForImportantUsage, ulong AvailableCapacityForOpportunisticUsage)
+            GetVolumeAvailableCapacities(string path = "/")
+        {
+            var keys = new[]
+            {
+                NSUrl.VolumeAvailableCapacityKey,
+                NSUrl.VolumeAvailableCapacityForImportantUsageKey,
+                NSUrl.VolumeAvailableCapacityForOpportunisticUsageKey
+            };
+
+            var dict = NSUrl.FromFilename(path).GetResourceValues(keys, out NSError error);
+            if (error != null)
+            {
+                throw new NSErrorException(error);
+            }
+
+            var availableCapacity = GetNumber(dict, NSUrl.VolumeAvailableCapacityKey);
+            var capacityForImportantUsage = GetNumber(dict, NSUrl.VolumeAvailableCapacityForImportantUsageKey);
+            var capacityForOpportunisticUsage = GetNumber(dict, NSUrl.VolumeAvailableCapacityForOpportunisticUsageKey);
+
+            return (availableCapacity, capacityForImportantUsage, capacityForOpportunisticUsage);
+        }
+
+        protected static ulong GetNumber(NSDictionary dict, NSString key)
+        {
+            var value = dict.ObjectForKey(key) as NSNumber;
+            return value?.UInt64Value ?? 0;
+        }
+    }
+}

--- a/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
+++ b/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Files\IosStorageInfoProvider.cs" />
     <Compile Include="IosMainThreadExecutor.cs" />
     <Compile Include="TextFilters\ForbiddenCharsFilter.cs" />
     <Compile Include="TextFilters\ITextFilter.cs" />

--- a/Softeq.XToolkit.Common/Files/IStorageInfoProvider.cs
+++ b/Softeq.XToolkit.Common/Files/IStorageInfoProvider.cs
@@ -1,0 +1,19 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Softeq.XToolkit.Common.Files
+{
+    /// <summary>
+    ///     Provides info about available storages.
+    /// </summary>
+    public interface IStorageInfoProvider
+    {
+        /// <summary>
+        ///     Gets info about available storages.
+        /// </summary>
+        List<StorageInfo> Current { get; }
+    }
+}

--- a/Softeq.XToolkit.Common/Files/StorageInfo.cs
+++ b/Softeq.XToolkit.Common/Files/StorageInfo.cs
@@ -1,12 +1,19 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System;
-
 namespace Softeq.XToolkit.Common.Files
 {
-    public readonly struct StorageInfo : IEquatable<StorageInfo>
+    /// <summary>
+    ///     Contains info about storage.
+    /// </summary>
+    public readonly struct StorageInfo
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="StorageInfo"/> struct.
+        /// </summary>
+        /// <param name="type">Type of storage.</param>
+        /// <param name="totalBytes">Total storage bytes.</param>
+        /// <param name="freeBytes">Free storage bytes.</param>
         public StorageInfo(StorageType type, ulong totalBytes, ulong freeBytes)
         {
             Type = type;
@@ -14,44 +21,45 @@ namespace Softeq.XToolkit.Common.Files
             FreeBytes = freeBytes;
         }
 
+        /// <summary>
+        ///     Gets storage type.
+        /// </summary>
         public StorageType Type { get; }
 
+        /// <summary>
+        ///     Gets total storage bytes.
+        /// </summary>
         public ulong TotalBytes { get; }
 
+        /// <summary>
+        ///     Gets available free storage bytes.
+        /// </summary>
         public ulong FreeBytes { get; }
 
         /// <inheritdoc />
-        public bool Equals(StorageInfo other) =>
-            Type == other.Type &&
-            FreeBytes == other.FreeBytes &&
-            TotalBytes == other.TotalBytes;
-
-        /// <inheritdoc />
-        public static bool operator ==(StorageInfo lhs, StorageInfo rhs) => lhs.Equals(rhs);
-
-        /// <inheritdoc />
-        public static bool operator !=(StorageInfo lhs, StorageInfo rhs) => !(lhs == rhs);
-
-        /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is StorageInfo info && Equals(info);
-        }
-
-        public override int GetHashCode() => (TotalBytes, FreeBytes, Type).GetHashCode();
-
         public override string ToString() => $"Type: {Type}, Total: {TotalBytes}, Free: {FreeBytes}";
     }
 
+    /// <summary>
+    ///     Storage type.
+    /// </summary>
+#pragma warning disable SA1201
     public enum StorageType
+#pragma warning restore SA1201
     {
+        /// <summary>
+        ///     Unknown storage.
+        /// </summary>
         Unknown = 0,
+
+        /// <summary>
+        ///     Internal storage.
+        /// </summary>
         Internal = 1,
+
+        /// <summary>
+        ///     External storage.
+        /// </summary>
         External = 2
     }
 }

--- a/Softeq.XToolkit.Common/Files/StorageInfo.cs
+++ b/Softeq.XToolkit.Common/Files/StorageInfo.cs
@@ -1,0 +1,57 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+
+namespace Softeq.XToolkit.Common.Files
+{
+    public readonly struct StorageInfo : IEquatable<StorageInfo>
+    {
+        public StorageInfo(StorageType type, ulong totalBytes, ulong freeBytes)
+        {
+            Type = type;
+            TotalBytes = totalBytes;
+            FreeBytes = freeBytes;
+        }
+
+        public StorageType Type { get; }
+
+        public ulong TotalBytes { get; }
+
+        public ulong FreeBytes { get; }
+
+        /// <inheritdoc />
+        public bool Equals(StorageInfo other) =>
+            Type == other.Type &&
+            FreeBytes == other.FreeBytes &&
+            TotalBytes == other.TotalBytes;
+
+        /// <inheritdoc />
+        public static bool operator ==(StorageInfo lhs, StorageInfo rhs) => lhs.Equals(rhs);
+
+        /// <inheritdoc />
+        public static bool operator !=(StorageInfo lhs, StorageInfo rhs) => !(lhs == rhs);
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            return obj is StorageInfo info && Equals(info);
+        }
+
+        public override int GetHashCode() => (TotalBytes, FreeBytes, Type).GetHashCode();
+
+        public override string ToString() => $"Type: {Type}, Total: {TotalBytes}, Free: {FreeBytes}";
+    }
+
+    public enum StorageType
+    {
+        Unknown = 0,
+        Internal = 1,
+        External = 2
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/Providers/ModernDroidStorageInfoProvider.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Providers/ModernDroidStorageInfoProvider.cs
@@ -1,0 +1,95 @@
+﻿// Developed by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Android.App.Usage;
+using Android.Content;
+using Android.OS;
+using Android.OS.Storage;
+using Java.IO;
+using Java.Util;
+using Softeq.XToolkit.Common.Extensions;
+using Softeq.XToolkit.Common.Files;
+
+namespace Softeq.XToolkit.WhiteLabel.Droid.Providers
+{
+    public class ModernDroidStorageInfoProvider : IStorageInfoProvider
+    {
+        private readonly IContextProvider _contextProvider;
+
+        public ModernDroidStorageInfoProvider(IContextProvider contextProvider)
+        {
+            _contextProvider = contextProvider;
+        }
+
+        public List<StorageInfo> Current
+        {
+            get
+            {
+                var storageManager = StorageManager.FromContext(_contextProvider.AppContext);
+                if (storageManager == null)
+                {
+                    throw new InvalidOperationException($"Can't resolve '{nameof(StorageManager)}'");
+                }
+
+                var storageStatsManager = _contextProvider.AppContext.GetSystemService(Context.StorageStatsService) as StorageStatsManager;
+                if (storageStatsManager == null)
+                {
+                    throw new InvalidOperationException($"Can't resolve '{nameof(StorageStatsManager)}'");
+                }
+
+                return _contextProvider.AppContext.GetExternalFilesDirs(null)
+                    .EmptyIfNull()
+                    .Select(directory => GetInfoByDirectory(directory, storageManager, storageStatsManager))
+                    .ToList();
+            }
+        }
+
+        // YP: Workaround over the storageManager.getStorageVolumes + getDirectory (API 30)
+        // https://stackoverflow.com/a/57126727/5925490
+        private static StorageInfo GetInfoByDirectory(
+            File directory,
+            StorageManager storageManager,
+            StorageStatsManager storageStatsManager)
+        {
+            var type = StorageType.Unknown;
+            var storageVolume = storageManager.GetStorageVolume(directory);
+
+            if (storageVolume != null)
+            {
+                type = storageVolume.IsRemovable ? StorageType.External : StorageType.Internal;
+
+                // YP: skip non-primary volumes, because should be used `storageVolume.getStorageUuid` (API 31)
+                if (storageVolume.IsPrimary)
+                {
+                    return GetInfoByVolume(type, storageVolume.Uuid, storageStatsManager);
+                }
+            }
+
+            var stats = new StatFs(directory.Path);
+            return new StorageInfo(type, (ulong)stats.TotalBytes, (ulong)stats.AvailableBytes);
+        }
+
+        private static StorageInfo GetInfoByVolume(
+            StorageType type,
+            string? storageVolumeUuid,
+            StorageStatsManager storageStatsManager)
+        {
+            var storageUuid = string.IsNullOrEmpty(storageVolumeUuid)
+                ? StorageManager.UuidDefault
+                : UUID.FromString(storageVolumeUuid!);
+
+            if (storageUuid == null)
+            {
+                throw new InvalidOperationException($"Invalid storage volume UUID: '{storageVolumeUuid}'.");
+            }
+
+            var totalBytes = storageStatsManager.GetTotalBytes(storageUuid);
+            var freeBytes = storageStatsManager.GetFreeBytes(storageUuid);
+
+            return new StorageInfo(type, (ulong)totalBytes, (ulong)freeBytes);
+        }
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/Providers/ModernDroidStorageInfoProvider.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Providers/ModernDroidStorageInfoProvider.cs
@@ -24,6 +24,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Providers
             _contextProvider = contextProvider;
         }
 
+        /// <inheritdoc />
         public List<StorageInfo> Current
         {
             get

--- a/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Softeq.XToolkit.WhiteLabel.Droid.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Navigation\ViewType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\ContextProvider.cs" />
+    <Compile Include="Providers\ModernDroidStorageInfoProvider.cs" />
     <Compile Include="Services\DroidAppInfoService.cs" />
     <Compile Include="Services\DroidToastService.cs" />
     <Compile Include="Services\KeyboardService.cs" />


### PR DESCRIPTION
### Description

Get info about available storage space.

### API Changes

Added:

**XToolkit.Common:**
 - IStorageInfoProvider
 - StorageInfo
 
**XToolkit.Common.iOS:**
 - DroidStorageInfoProvider

**XToolkit.Common.Droid:**
 - DroidStorageInfoProvider

**XToolkit.WhiteLabel.Droid:**
 - ModernDroidStorageInfoProvider
 
### Platforms Affected

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
