### PR TITLE
Parameters added to BindableRecyclerViewAdapter constructor

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -325,7 +325,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
         public BindableRecyclerViewAdapter(
             IEnumerable<IGrouping<TKey, TItem>> items,
             Type headerViewHolder = null,
-            Type footerViewHolder = null)
+            Type footerViewHolder = null,
+            Type headerSectionViewHolder = null,
+            Type footerSectionViewHolder = null)
             : base(headerViewHolder, footerViewHolder)
         {
             _dataSource = items;
@@ -334,6 +336,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             {
                 _subscription = new NotifyCollectionKeyGroupChangedEventSubscription<TKey, TItem>(dataSourceNew, NotifyCollectionChanged);
             }
+
+            HeaderSectionViewHolder = headerSectionViewHolder;
+            FooterSectionViewHolder = footerSectionViewHolder;
 
             ReloadMapping();
         }

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -35,9 +35,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             FooterViewHolder = footerViewHolder;
         }
 
-        protected Type HeaderViewHolder { get; set; }
+        protected Type HeaderViewHolder { get; }
 
-        protected Type FooterViewHolder { get; set; }
+        protected Type FooterViewHolder { get; }
 
         public ICommand<TItem> ItemClick
         {
@@ -343,9 +343,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             ReloadMapping();
         }
 
-        public Type HeaderSectionViewHolder { get; set; }
+        protected Type HeaderSectionViewHolder { get; }
 
-        public Type FooterSectionViewHolder { get; set; }
+        protected Type FooterSectionViewHolder { get; }
 
         public override int ItemCount => _flatMapping.Count;
 

--- a/samples/Playground/Playground.Droid/Views/Collections/GroupedCollectionPageActivity.cs
+++ b/samples/Playground/Playground.Droid/Views/Collections/GroupedCollectionPageActivity.cs
@@ -39,11 +39,8 @@ namespace Playground.Droid.Views.Collections
             _recyclerView.HasFixedSize = true;
 
             // init adapter
-            var adapter = new CustomAdapter(ViewModel.ProductListViewModel.Products)
+            var adapter = new CustomAdapter(ViewModel.ProductListViewModel.Products, typeof(ProductHeaderViewHolder), typeof(ProductFooterViewHolder))
             {
-                HeaderSectionViewHolder = typeof(ProductHeaderViewHolder),
-                FooterSectionViewHolder = typeof(ProductFooterViewHolder),
-
                 // ItemClick = ViewModel.AddToCartCommand
             };
             _recyclerView.SetAdapter(adapter);

--- a/samples/Playground/Playground.Droid/Views/Collections/GroupedTablePageActivity.cs
+++ b/samples/Playground/Playground.Droid/Views/Collections/GroupedTablePageActivity.cs
@@ -44,11 +44,8 @@ namespace Playground.Droid.Views.Collections
             _recyclerView.HasFixedSize = true;
 
             // init adapter
-            var adapter = new CustomAdapter(ViewModel.ProductListViewModel.Products)
+            var adapter = new CustomAdapter(ViewModel.ProductListViewModel.Products, typeof(ProductHeaderViewHolder), typeof(ProductFooterViewHolder))
             {
-                HeaderSectionViewHolder = typeof(ProductHeaderViewHolder),
-                FooterSectionViewHolder = typeof(ProductFooterViewHolder),
-
                 // ItemClick = ViewModel.AddToCartCommand
             };
             _recyclerView.SetAdapter(adapter);
@@ -107,8 +104,8 @@ namespace Playground.Droid.Views.Collections
         ProductViewModel, // item data type
         ProductViewHolder> // item ViewHolder type
     {
-        public CustomAdapter(ObservableKeyGroupsCollection<ProductHeaderViewModel, ProductViewModel> items)
-            : base(items)
+        public CustomAdapter(ObservableKeyGroupsCollection<ProductHeaderViewModel, ProductViewModel> items, Type headerSectionViewHolder, Type footerSectionViewHolder)
+            : base(items, headerSectionViewHolder: headerSectionViewHolder, footerSectionViewHolder: footerSectionViewHolder)
         {
         }
 


### PR DESCRIPTION
### Description

BindableRecyclerViewAdapter didn't have option to initialize HeaderSectionViewHolder and FooterSectionViewHolder in construction. 

### API Changes

None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
