### PR TITLE
protected setter added to BindableRecyclerViewAdapterBase for ViewHol…

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -35,9 +35,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             FooterViewHolder = footerViewHolder;
         }
 
-        protected Type HeaderViewHolder { get; }
+        protected Type HeaderViewHolder { get; protected set; }
 
-        protected Type FooterViewHolder { get; }
+        protected Type FooterViewHolder { get; protected set; }
 
         public ICommand<TItem> ItemClick
         {

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -35,9 +35,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             FooterViewHolder = footerViewHolder;
         }
 
-        protected Type HeaderViewHolder { get; protected set; }
+        protected Type HeaderViewHolder { get; set; }
 
-        protected Type FooterViewHolder { get; protected set; }
+        protected Type FooterViewHolder { get; set; }
 
         public ICommand<TItem> ItemClick
         {


### PR DESCRIPTION
### Description

Appears that ViewHolders needed protected setters

### API Changes

None

### Platforms Affected

Android

### Behavioral/Visual Changes

None

### Before/After Screenshots
Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
