### PR TITLE
Replace custom delegates with EventHandler pattern

### DIFF
--- a/Softeq.XToolkit.Connectivity.iOS/IosConnectivityService.cs
+++ b/Softeq.XToolkit.Connectivity.iOS/IosConnectivityService.cs
@@ -18,8 +18,8 @@ namespace Softeq.XToolkit.Connectivity.iOS
         private readonly Dictionary<NWInterfaceType, bool> _connectionStatuses;
         private readonly IList<NWPathMonitor> _monitors;
 
-        public event ConnectivityChangedEventHandler? ConnectivityChanged;
-        public event ConnectivityTypeChangedEventHandler? ConnectivityTypeChanged;
+        public event EventHandler<ConnectivityChangedEventArgs>? ConnectivityChanged;
+        public event EventHandler<ConnectivityTypeChangedEventArgs>? ConnectivityTypeChanged;
 
         public IosConnectivityService()
         {

--- a/Softeq.XToolkit.Connectivity/ConnectivityService.cs
+++ b/Softeq.XToolkit.Connectivity/ConnectivityService.cs
@@ -10,8 +10,8 @@ namespace Softeq.XToolkit.Connectivity
 {
     public class ConnectivityService : IConnectivityService
     {
-        public virtual event ConnectivityChangedEventHandler? ConnectivityChanged;
-        public virtual event ConnectivityTypeChangedEventHandler? ConnectivityTypeChanged;
+        public virtual event EventHandler<ConnectivityChangedEventArgs>? ConnectivityChanged;
+        public virtual event EventHandler<ConnectivityTypeChangedEventArgs>? ConnectivityTypeChanged;
 
         public ConnectivityService()
         {

--- a/Softeq.XToolkit.Connectivity/IConnectivityService.cs
+++ b/Softeq.XToolkit.Connectivity/IConnectivityService.cs
@@ -9,9 +9,9 @@ namespace Softeq.XToolkit.Connectivity
 {
     public interface IConnectivityService : IDisposable
     {
-        event ConnectivityChangedEventHandler ConnectivityChanged;
+        event EventHandler<ConnectivityChangedEventArgs> ConnectivityChanged;
 
-        event ConnectivityTypeChangedEventHandler ConnectivityTypeChanged;
+        event EventHandler<ConnectivityTypeChangedEventArgs> ConnectivityTypeChanged;
 
         bool IsConnected { get; }
 


### PR DESCRIPTION
### Description

Replace custom delegates with EventHandler pattern

### API Changes

Changed:
 - `ConnectivityChangedEventHandler IConnectivityService.ConnectivityChanged` => `EventHandler<ConnectivityChangedEventArgs> IConnectivityService.ConnectivityChanged`
 - `ConnectivityTypeChangedEventHandler ConnectivityTypeChanged` => `EventHandler<ConnectivityTypeChangedEventArgs> ConnectivityTypeChanged`

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
