### PR TITLE
Enable nullability for Bindings primitives

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/DroidBinding.cs
+++ b/Softeq.XToolkit.Bindings.Droid/DroidBinding.cs
@@ -8,8 +8,6 @@ using Android.Text;
 using Android.Views;
 using Android.Widget;
 
-#nullable disable
-
 namespace Softeq.XToolkit.Bindings.Droid
 {
     /// <inheritdoc />
@@ -19,11 +17,11 @@ namespace Softeq.XToolkit.Bindings.Droid
         public DroidBinding(
             object source,
             string sourcePropertyName,
-            object target = null,
-            string targetPropertyName = null,
+            object? target = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
             : base(source, sourcePropertyName, target, targetPropertyName, mode, fallbackValue, targetNullValue)
         {
         }
@@ -32,11 +30,11 @@ namespace Softeq.XToolkit.Bindings.Droid
         public DroidBinding(
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
             : base(source, sourcePropertyExpression, target, targetPropertyExpression, mode, fallbackValue, targetNullValue)
         {
         }
@@ -46,11 +44,11 @@ namespace Softeq.XToolkit.Bindings.Droid
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             bool? resolveTopField,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
             : base(
                 source,
                 sourcePropertyExpression,
@@ -64,20 +62,23 @@ namespace Softeq.XToolkit.Bindings.Droid
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound source object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound source object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
         /// <param name="mode">
-        ///     Defines the binding's update mode. Use
-        ///     <see cref="UpdateTriggerMode.LostFocus" /> to update the binding when
-        ///     the source control loses the focus. You can also use
-        ///     <see cref="UpdateTriggerMode.PropertyChanged" /> to update the binding
+        ///     Defines the binding's update mode.
+        ///
+        ///     Use <see cref="UpdateTriggerMode.LostFocus" /> to update the binding when the source control loses the focus.
+        ///     You can also use <see cref="UpdateTriggerMode.PropertyChanged" /> to update the binding
         ///     when the source control's property changes.
+        ///
         ///     The PropertyChanged mode should only be used with the following items:
-        ///     <para>- an EditText control and its Text property (TextChanged event).</para>
-        ///     <para>- a CompoundButton control and its Checked property (CheckedChange event).</para>
+        ///     <para>- <see cref="T:Android.Widget.EditText"/> control and its <c>Text</c> property (<c>TextChanged</c> event).</para>
+        ///     <para>- <see cref="T:Android.Widget.CompoundButton"/> control and its <c>Checked</c> property (<c>CheckedChange</c> event).</para>
         /// </param>
         /// <returns>The Binding instance.</returns>
         /// <exception cref="T:System.InvalidOperationException">
@@ -87,60 +88,55 @@ namespace Softeq.XToolkit.Bindings.Droid
         /// </exception>
         public Binding<TSource, TTarget> ObserveSourceEvent(UpdateTriggerMode mode = UpdateTriggerMode.PropertyChanged)
         {
-            switch (mode)
+            return mode switch
             {
-                case UpdateTriggerMode.LostFocus:
-                    return ObserveSourceEvent<View.FocusChangeEventArgs>("FocusChange");
-
-                case UpdateTriggerMode.PropertyChanged:
-                    return CheckControlSource();
-            }
-
-            return this;
+                UpdateTriggerMode.LostFocus => ObserveSourceEvent<View.FocusChangeEventArgs>("FocusChange"),
+                UpdateTriggerMode.PropertyChanged => CheckControlSource(),
+                _ => this
+            };
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound target object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound target object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
         /// <param name="mode">
-        ///     Defines the binding's update mode. Use
-        ///     <see cref="UpdateTriggerMode.LostFocus" /> to update the binding when
-        ///     the source control loses the focus. You can also use
-        ///     <see cref="UpdateTriggerMode.PropertyChanged" /> to update the binding
-        ///     when the source control's property changes.
+        ///     Defines the binding's update mode.
+        ///
+        ///     Use <see cref="UpdateTriggerMode.LostFocus" /> to update the binding when the target control loses the focus.
+        ///     You can also use <see cref="UpdateTriggerMode.PropertyChanged" /> to update the binding
+        ///     when the target control's property changes.
+        ///
         ///     The PropertyChanged mode should only be used with the following items:
-        ///     <para>- an EditText control and its Text property (TextChanged event).</para>
-        ///     <para>- a CompoundButton control and its Checked property (CheckedChange event).</para>
+        ///     <para>- <see cref="T:Android.Widget.EditText"/> control and its <c>Text</c> property (<c>TextChanged</c> event).</para>
+        ///     <para>- <see cref="T:Android.Widget.CompoundButton"/> control and its <c>Checked</c> property (<c>CheckedChange</c> event).</para>
         /// </param>
         /// <returns>The Binding instance.</returns>
         /// <exception cref="T:System.InvalidOperationException">
-        ///     When this method is called
-        ///     on a OneTime or a OneWay binding. This exception can
-        ///     also be thrown when the source object is null or has already been
-        ///     garbage collected before this method is called.
+        ///     When this method is called on a OneTime or a OneWay binding.
+        ///     This exception can also be thrown when the source object is null or
+        ///     has already been garbage collected before this method is called.
         /// </exception>
         public Binding<TSource, TTarget> ObserveTargetEvent(UpdateTriggerMode mode = UpdateTriggerMode.PropertyChanged)
         {
-            switch (mode)
+            return mode switch
             {
-                case UpdateTriggerMode.LostFocus:
-                    return ObserveTargetEvent<View.FocusChangeEventArgs>("FocusChange");
-
-                case UpdateTriggerMode.PropertyChanged:
-                    return CheckControlTarget();
-            }
-
-            return this;
+                UpdateTriggerMode.LostFocus => ObserveTargetEvent<View.FocusChangeEventArgs>("FocusChange"),
+                UpdateTriggerMode.PropertyChanged => CheckControlTarget(),
+                _ => this
+            };
         }
 
+        /// <inheritdoc />
         [SuppressMessage("ReSharper", "RedundantAssignment", Justification = "Reviewed.")]
         [SuppressMessage("ReSharper", "EntityNameCapturedOnly.Local", Justification = "Reviewed.")]
         protected override Binding<TSource, TTarget> CheckControlSource()
         {
-            switch (PropertySource.Target)
+            switch (_propertySource!.Target)
             {
                 case EditText textBox:
                 {
@@ -161,6 +157,7 @@ namespace Softeq.XToolkit.Bindings.Droid
             }
         }
 
+        /// <inheritdoc />
         [SuppressMessage("ReSharper", "RedundantAssignment", Justification = "Reviewed.")]
         [SuppressMessage("ReSharper", "EntityNameCapturedOnly.Local", Justification = "Reviewed.")]
         protected override Binding<TSource, TTarget> CheckControlTarget()
@@ -170,7 +167,7 @@ namespace Softeq.XToolkit.Bindings.Droid
                 return this;
             }
 
-            switch (PropertyTarget.Target)
+            switch (_propertyTarget!.Target)
             {
                 case EditText textBox:
                 {

--- a/Softeq.XToolkit.Bindings.Droid/DroidBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings.Droid/DroidBindingFactory.cs
@@ -2,6 +2,7 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
@@ -9,10 +10,11 @@ using Android.Views;
 using Android.Widget;
 using Softeq.XToolkit.Common.Threading;
 
-#nullable disable
-
 namespace Softeq.XToolkit.Bindings.Droid
 {
+    /// <summary>
+    ///     The Android-specific factory to create bindings.
+    /// </summary>
     public class DroidBindingFactory : BindingFactoryBase
     {
         /// <inheritdoc />
@@ -20,11 +22,11 @@ namespace Softeq.XToolkit.Bindings.Droid
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             bool? resolveTopField,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new DroidBinding<TSource, TTarget>(
                 source,
@@ -41,11 +43,11 @@ namespace Softeq.XToolkit.Bindings.Droid
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new DroidBinding<TSource, TTarget>(
                 source,
@@ -61,11 +63,11 @@ namespace Softeq.XToolkit.Bindings.Droid
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
             object source,
             string sourcePropertyName,
-            object target = null,
-            string targetPropertyName = null,
+            object? target = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new DroidBinding<TSource, TTarget>(
                 source,
@@ -77,12 +79,13 @@ namespace Softeq.XToolkit.Bindings.Droid
                 targetNullValue);
         }
 
+        /// <inheritdoc />
         public override Delegate GetCommandHandler(
             EventInfo info,
             string eventName,
             Type elementType,
             ICommand command,
-            object commandParameter = null)
+            object? commandParameter = null)
         {
             if (string.IsNullOrEmpty(eventName) && elementType == typeof(CheckBox))
             {
@@ -98,18 +101,19 @@ namespace Softeq.XToolkit.Bindings.Droid
             return base.GetCommandHandler(info, eventName, elementType, command, commandParameter);
         }
 
+        /// <inheritdoc />
         public override Delegate GetCommandHandler<T>(
             EventInfo info,
             string eventName,
             Type elementType,
             ICommand command,
-            Binding<T, T> castedBinding)
+            Binding<T, T>? castedBinding)
         {
             if (string.IsNullOrEmpty(eventName) && elementType == typeof(CheckBox))
             {
                 return new EventHandler<CompoundButton.CheckedChangeEventArgs>((s, args) =>
                 {
-                    object param = castedBinding == null ? default : castedBinding.Value;
+                    var param = castedBinding == null ? default : castedBinding.Value;
 
                     if (command.CanExecute(param))
                     {
@@ -121,7 +125,8 @@ namespace Softeq.XToolkit.Bindings.Droid
             return base.GetCommandHandler(info, eventName, elementType, command, castedBinding);
         }
 
-        public override string GetDefaultEventNameForControl(Type type)
+        /// <inheritdoc />
+        public override string? GetDefaultEventNameForControl(Type type)
         {
             if (type == typeof(CheckBox) || typeof(CheckBox).IsAssignableFrom(type))
             {
@@ -141,10 +146,11 @@ namespace Softeq.XToolkit.Bindings.Droid
             return null;
         }
 
+        /// <inheritdoc />
         public override void HandleCommandCanExecute<T>(
             object element,
             ICommand command,
-            Binding<T, T> commandParameterBinding)
+            Binding<T, T>? commandParameterBinding)
         {
             if (element is View view)
             {
@@ -155,7 +161,7 @@ namespace Softeq.XToolkit.Bindings.Droid
         private static void HandleViewEnabled<T>(
             View view,
             ICommand command,
-            Binding<T, T> commandParameterBinding)
+            Binding<T, T>? commandParameterBinding)
         {
             var commandParameter = commandParameterBinding == null
                 ? default

--- a/Softeq.XToolkit.Bindings.iOS/AppleBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings.iOS/AppleBindingFactory.cs
@@ -2,14 +2,16 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Windows.Input;
 using UIKit;
 
-#nullable disable
-
 namespace Softeq.XToolkit.Bindings.iOS
 {
+    /// <summary>
+    ///     The iOS-specific factory to create bindings.
+    /// </summary>
     public class AppleBindingFactory : BindingFactoryBase
     {
         /// <inheritdoc />
@@ -17,11 +19,11 @@ namespace Softeq.XToolkit.Bindings.iOS
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             bool? resolveTopField,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new AppleBinding<TSource, TTarget>(
                 source,
@@ -38,11 +40,11 @@ namespace Softeq.XToolkit.Bindings.iOS
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new AppleBinding<TSource, TTarget>(
                 source,
@@ -58,11 +60,11 @@ namespace Softeq.XToolkit.Bindings.iOS
         public override Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
             object source,
             string sourcePropertyName,
-            object target = null,
-            string targetPropertyName = null,
+            object? target = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             return new AppleBinding<TSource, TTarget>(
                 source,
@@ -74,7 +76,8 @@ namespace Softeq.XToolkit.Bindings.iOS
                 targetNullValue);
         }
 
-        public override string GetDefaultEventNameForControl(Type type)
+        /// <inheritdoc />
+        public override string? GetDefaultEventNameForControl(Type type)
         {
             if (type == typeof(UIButton) || typeof(UIButton).IsAssignableFrom(type))
             {
@@ -94,10 +97,11 @@ namespace Softeq.XToolkit.Bindings.iOS
             return null;
         }
 
+        /// <inheritdoc />
         public override void HandleCommandCanExecute<T>(
             object element,
             ICommand command,
-            Binding<T, T> commandParameterBinding)
+            Binding<T, T>? commandParameterBinding)
         {
             if (element is UIControl control)
             {
@@ -108,7 +112,7 @@ namespace Softeq.XToolkit.Bindings.iOS
         private static void HandleControlEnabled<T>(
             UIControl control,
             ICommand command,
-            Binding<T, T> commandParameterBinding)
+            Binding<T, T>? commandParameterBinding)
         {
             var commandParameter = commandParameterBinding == null
                 ? default

--- a/Softeq.XToolkit.Bindings/Binding.cs
+++ b/Softeq.XToolkit.Bindings/Binding.cs
@@ -21,7 +21,7 @@ namespace Softeq.XToolkit.Bindings
         protected WeakReference? TopTarget;
 
         /// <summary>
-        ///     Occurs when the value of the databound property changes.
+        ///     Occurs when the value of the data-bound property changes.
         /// </summary>
         public abstract event EventHandler ValueChanged;
 
@@ -50,20 +50,17 @@ namespace Softeq.XToolkit.Bindings
             : TopTarget.Target;
 
         /// <summary>
-        ///     Instructs the Binding instance to stop listening to value changes and to
-        ///     remove all listeneners.
+        ///     Instructs the Binding instance to stop listening to value changes and to remove all listeners.
         /// </summary>
         public abstract void Detach();
 
         /// <summary>
-        ///     Forces the Binding's value to be reevaluated. The target value will
-        ///     be set to the source value.
+        ///     Forces the Binding's value to be reevaluated. The target value will be set to the source value.
         /// </summary>
         public abstract void ForceUpdateValueFromSourceToTarget();
 
         /// <summary>
-        ///     Forces the Binding's value to be reevaluated. The source value will
-        ///     be set to the target value.
+        ///     Forces the Binding's value to be reevaluated. The source value will be set to the target value.
         /// </summary>
         public abstract void ForceUpdateValueFromTargetToSource();
     }

--- a/Softeq.XToolkit.Bindings/BindingExtensions.cs
+++ b/Softeq.XToolkit.Bindings/BindingExtensions.cs
@@ -2,13 +2,12 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
 using Softeq.XToolkit.Common.Commands;
 using Softeq.XToolkit.Common.Disposables;
-
-#nullable disable
 
 namespace Softeq.XToolkit.Bindings
 {
@@ -17,8 +16,19 @@ namespace Softeq.XToolkit.Bindings
     /// </summary>
     public static class BindingExtensions
     {
-        private static IBindingFactory _bindingFactory;
+        private static IBindingFactory? _bindingFactory;
 
+        private static IBindingFactory BindingFactory
+        {
+            get => _bindingFactory
+                   ?? throw new InvalidOperationException(
+                       $"Please initialize extensions via {nameof(BindingExtensions)}.{nameof(Initialize)} before using.");
+        }
+
+        /// <summary>
+        ///     Initializes extensions methods. Should be called at least once before using extension methods.
+        /// </summary>
+        /// <param name="bindingFactory">The factory instance.</param>
         public static void Initialize(IBindingFactory bindingFactory)
         {
             _bindingFactory = bindingFactory;
@@ -42,8 +52,8 @@ namespace Softeq.XToolkit.Bindings
         ///     and <see cref="Binding{TSource, TTarget}.ConvertTargetToSource" /> methods to configure the binding.
         ///     It is very possible that TSource and TTarget are the same type in which case no conversion occurs.
         /// </remarks>
-        /// <typeparam name="TSource">The type of the property that is being databound before conversion.</typeparam>
-        /// <typeparam name="TTarget">The type of the property that is being databound after conversion.</typeparam>
+        /// <typeparam name="TSource">The type of the property that is being data-bound before conversion.</typeparam>
+        /// <typeparam name="TTarget">The type of the property that is being data-bound after conversion.</typeparam>
         /// <param name="source">
         ///     The source of the binding. If this object implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>
         ///     and the <see cref="BindingMode"/> is OneWay or TwoWay, the target will be notified of changes
@@ -80,16 +90,17 @@ namespace Softeq.XToolkit.Bindings
         /// </param>
         /// <param name="targetNullValue">The value used when the source property is null (or equals to default(TSource)).</param>
         /// <returns>The new Binding instance.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static Binding<TSource, TTarget> SetBinding<TSource, TTarget>(
             this object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             object target,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
-            return _bindingFactory.CreateBinding(
+            return BindingFactory.CreateBinding(
                 source,
                 sourcePropertyExpression,
                 null,
@@ -137,14 +148,15 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="targetNullValue">The value used when the source property is null (or equals to default(TSource)).</param>
         /// <typeparam name="TSource">The type of the bound property.</typeparam>
         /// <returns>The created binding instance.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static Binding<TSource, TSource> SetBinding<TSource>(
             this object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
-            return _bindingFactory.CreateBinding<TSource, TSource>(
+            return BindingFactory.CreateBinding<TSource, TSource>(
                 source,
                 sourcePropertyExpression,
                 true,
@@ -165,9 +177,9 @@ namespace Softeq.XToolkit.Bindings
         ///     If the target implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>, has observable properties and
         ///     the <see cref="BindingMode"/> is TwoWay, the source will also be notified of changes to the target's properties.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type
+        ///     The type of the target property that is being data-bound. If the source type
         ///     is not the same as the target type, an automatic conversion will be attempted. However only
         ///     simple types can be converted. For more complex conversions, use the
         ///     <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
@@ -204,15 +216,16 @@ namespace Softeq.XToolkit.Bindings
         /// </param>
         /// <param name="targetNullValue">The value used when the source property is null (or equals to default(TSource)).</param>
         /// <returns>The new Binding instance.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static Binding<TSource, TTarget> SetBinding<TSource, TTarget>(
             this object source,
             Expression<Func<TSource>> sourcePropertyExpression,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
-            return _bindingFactory.CreateBinding(
+            return BindingFactory.CreateBinding(
                 source,
                 sourcePropertyExpression,
                 null,
@@ -233,9 +246,9 @@ namespace Softeq.XToolkit.Bindings
         ///     raises the PropertyChanged event and the <see cref="BindingMode"/> is TwoWay,
         ///     the source property will also be synchronized with the target property.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound.
+        ///     The type of the target property that is being data-bound.
         ///
         ///     If the source type is not the same as the target type, an automatic conversion will be attempted.
         ///     However only simple types can be converted. For more complex conversions,
@@ -269,16 +282,17 @@ namespace Softeq.XToolkit.Bindings
         /// </param>
         /// <param name="targetNullValue">The value used when the source property is null (or equals to default(TSource)).</param>
         /// <returns>The new Binding instance.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static Binding<TSource, TTarget> SetBinding<TSource, TTarget>(
             this object source,
             string sourcePropertyName,
             object target,
-            string targetPropertyName = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
-            return _bindingFactory.CreateBinding<TSource, TTarget>(
+            return BindingFactory.CreateBinding<TSource, TTarget>(
                 source,
                 sourcePropertyName,
                 target,
@@ -297,9 +311,9 @@ namespace Softeq.XToolkit.Bindings
         ///     If the target implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>, has observable properties and
         ///     the <see cref="BindingMode"/> is TwoWay, the source will also be notified of changes to the target's properties.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type is not the same as the target type,
+        ///     The type of the target property that is being data-bound. If the source type is not the same as the target type,
         ///     an automatic conversion will be attempted. However only simple types can be converted.
         ///     For more complex conversions, use the <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
         ///     and <see cref="Binding{TSource, TTarget}.ConvertTargetToSource" /> methods to define custom converters.
@@ -327,15 +341,16 @@ namespace Softeq.XToolkit.Bindings
         /// </param>
         /// <param name="targetNullValue">The value used when the source property is null (or equals to default(TSource)).</param>
         /// <returns>The new Binding instance.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static Binding<TSource, TTarget> SetBinding<TSource, TTarget>(
             this object source,
             string sourcePropertyName,
-            string targetPropertyName = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
-            return _bindingFactory.CreateBinding<TSource, TTarget>(
+            return BindingFactory.CreateBinding<TSource, TTarget>(
                 source,
                 sourcePropertyName,
                 null,
@@ -352,6 +367,7 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="element">The element to which the command is added.</param>
         /// <param name="eventName">The name of the event that will be subscribed to to actuate the command.</param>
         /// <param name="command">The command that must be added to the element.</param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand(
             this object element,
             string eventName,
@@ -360,7 +376,7 @@ namespace Softeq.XToolkit.Bindings
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var handler = _bindingFactory.GetCommandHandler(e, eventName, t, command);
+            var handler = BindingFactory.GetCommandHandler(e, eventName, t, command);
 
             e.AddEventHandler(element, handler);
 
@@ -380,6 +396,7 @@ namespace Softeq.XToolkit.Bindings
         ///     is executed. This is a fixed value. To pass an observable value, use one of the SetCommand
         ///     overloads that uses a Binding as CommandParameter.
         /// </param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand<T>(
             this object element,
             string eventName,
@@ -389,7 +406,7 @@ namespace Softeq.XToolkit.Bindings
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var handler = _bindingFactory.GetCommandHandler(e, eventName, t, command, commandParameter);
+            var handler = BindingFactory.GetCommandHandler(e, eventName, t, command, commandParameter);
 
             e.AddEventHandler(element, handler);
 
@@ -410,18 +427,19 @@ namespace Softeq.XToolkit.Bindings
         ///     Depending on the <see cref="Binding"/>, the CommandParameter will be observed and changes
         ///     will be passed to the command, for example to update the CanExecute.
         /// </param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand<T>(
             this object element,
             string eventName,
             ICommand command,
-            Binding commandParameterBinding)
+            Binding? commandParameterBinding)
         {
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var castedBinding = (Binding<T, T>) commandParameterBinding;
+            var castedBinding = commandParameterBinding as Binding<T, T>;
 
-            var handler = _bindingFactory.GetCommandHandler(e, eventName, t, command, castedBinding);
+            var handler = BindingFactory.GetCommandHandler(e, eventName, t, command, castedBinding);
 
             e.AddEventHandler(element, handler);
 
@@ -441,6 +459,7 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="element">The element to which the command is added.</param>
         /// <param name="eventName">The name of the event that will be subscribed to to actuate the command.</param>
         /// <param name="command">The command that must be added to the element.</param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand<TEventArgs>(
             this object element,
             string eventName,
@@ -449,7 +468,7 @@ namespace Softeq.XToolkit.Bindings
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var handler = _bindingFactory.GetCommandHandler<TEventArgs>(e, eventName, t, command);
+            var handler = BindingFactory.GetCommandHandler<TEventArgs>(e, eventName, t, command);
 
             e.AddEventHandler(element, handler);
 
@@ -470,6 +489,7 @@ namespace Softeq.XToolkit.Bindings
         ///     is executed. This is a fixed value. To pass an observable value, use one of the SetCommand
         ///     overloads that uses a Binding as CommandParameter.
         /// </param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand<T, TEventArgs>(
             this object element,
             string eventName,
@@ -479,7 +499,7 @@ namespace Softeq.XToolkit.Bindings
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var handler = _bindingFactory.GetCommandHandler<T, TEventArgs>(e, eventName, t, command, commandParameter);
+            var handler = BindingFactory.GetCommandHandler<T, TEventArgs>(e, eventName, t, command, commandParameter);
 
             e.AddEventHandler(element, handler);
 
@@ -500,18 +520,19 @@ namespace Softeq.XToolkit.Bindings
         ///     that will passed to the <see cref="T:System.Windows.Input.ICommand"/>. Depending on the Binding, the CommandParameter will be observed
         ///     and changes will be passed to the command, for example to update the CanExecute.
         /// </param>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static void SetCommand<T, TEventArgs>(
             this object element,
             string eventName,
             ICommand command,
-            Binding commandParameterBinding)
+            Binding? commandParameterBinding)
         {
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var castedBinding = (Binding<T, T>) commandParameterBinding;
+            var castedBinding = commandParameterBinding as Binding<T, T>;
 
-            var handler = _bindingFactory.GetCommandHandler<T, TEventArgs>(e, eventName, t, command, castedBinding);
+            var handler = BindingFactory.GetCommandHandler<T, TEventArgs>(e, eventName, t, command, castedBinding);
 
             e.AddEventHandler(element, handler);
 
@@ -531,6 +552,7 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="eventName">The name of the event that will be subscribed to to actuate the command.</param>
         /// <param name="command">The command that must be added to the element.</param>
         /// <returns><see cref="T:System.IDisposable"/> instance for manual unset/unsubscribe of command.</returns>
+        /// <exception cref="T:System.InvalidOperationException">When class <see cref="BindingExtensions"/> is not initialized.</exception>
         public static IDisposable SetCommandWithDisposing(
             this object element,
             string eventName,
@@ -539,7 +561,7 @@ namespace Softeq.XToolkit.Bindings
             var t = element.GetType();
             var e = t.GetEventInfoForControl(eventName);
 
-            var handler = _bindingFactory.GetCommandHandler(e, eventName, t, command);
+            var handler = BindingFactory.GetCommandHandler(e, eventName, t, command);
 
             e.AddEventHandler(element, handler);
 
@@ -615,11 +637,11 @@ namespace Softeq.XToolkit.Bindings
             SetCommand(element, eventName, new RelayCommand(action));
         }
 
-        internal static EventInfo GetEventInfoForControl(this Type type, string eventName)
+        internal static EventInfo GetEventInfoForControl(this Type type, string? eventName)
         {
             if (string.IsNullOrEmpty(eventName))
             {
-                eventName = _bindingFactory.GetDefaultEventNameForControl(type);
+                eventName = BindingFactory.GetDefaultEventNameForControl(type);
             }
 
             if (string.IsNullOrEmpty(eventName))
@@ -647,9 +669,9 @@ namespace Softeq.XToolkit.Bindings
         private static void HandleCommandCanExecute<T>(
             object element,
             ICommand command,
-            Binding<T, T> commandParameterBinding = null)
+            Binding<T, T>? commandParameterBinding = null)
         {
-            _bindingFactory.HandleCommandCanExecute(element, command, commandParameterBinding);
+            BindingFactory.HandleCommandCanExecute(element, command, commandParameterBinding);
         }
     }
 }

--- a/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
+++ b/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
@@ -2,12 +2,16 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
 
 namespace Softeq.XToolkit.Bindings
 {
+    /// <summary>
+    ///     The base factory to create bindings.
+    /// </summary>
     public abstract class BindingFactoryBase : IBindingFactory
     {
         /// <inheritdoc />
@@ -18,8 +22,8 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <inheritdoc />
         public abstract Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
@@ -28,8 +32,8 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <inheritdoc />
         public abstract Binding<TSource, TTarget> CreateBinding<TSource, TTarget>(
@@ -38,17 +42,17 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <inheritdoc />
-        public abstract string GetDefaultEventNameForControl(Type type);
+        public abstract string? GetDefaultEventNameForControl(Type type);
 
         /// <inheritdoc />
         public abstract void HandleCommandCanExecute<T>(
             object element,
             ICommand command,
-            Binding<T, T> commandParameterBinding);
+            Binding<T, T>? commandParameterBinding);
 
         /// <inheritdoc />
         public virtual Delegate GetCommandHandler(
@@ -74,11 +78,11 @@ namespace Softeq.XToolkit.Bindings
             string eventName,
             Type elementType,
             ICommand command,
-            Binding<T, T> castedBinding)
+            Binding<T, T>? castedBinding)
         {
             EventHandler handler = (_, __) =>
             {
-                object param = (castedBinding == null ? default : castedBinding.Value)!;
+                var param = castedBinding == null ? default : castedBinding.Value;
 
                 if (command.CanExecute(param))
                 {
@@ -129,11 +133,11 @@ namespace Softeq.XToolkit.Bindings
             string eventName,
             Type elementType,
             ICommand command,
-            Binding<T, T> castedBinding)
+            Binding<T, T>? castedBinding)
         {
             EventHandler<TEventArgs> handler = (_, __) =>
             {
-                object param = (castedBinding == null ? default : castedBinding.Value)!;
+                var param = castedBinding == null ? default : castedBinding.Value;
 
                 if (command.CanExecute(param))
                 {

--- a/Softeq.XToolkit.Bindings/BindingGeneric.cs
+++ b/Softeq.XToolkit.Bindings/BindingGeneric.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -11,51 +12,75 @@ using System.Threading.Tasks;
 using Softeq.XToolkit.Common.Converters;
 using Softeq.XToolkit.Common.Weak;
 
-#nullable disable
-
-#pragma warning disable SA1649, SA1201, SA1204
-
 namespace Softeq.XToolkit.Bindings
 {
     /// <summary>
     ///     Creates a binding between two properties.
     ///
-    ///     If the source implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>, the source property raises the PropertyChanged event and
-    ///     the <see cref="BindingMode"/> is OneWay or TwoWay, the target property will be synchronized with the source property.
+    ///     If the source implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>,
+    ///     the source property raises the PropertyChanged event and the <see cref="BindingMode"/> is OneWay or TwoWay,
+    ///     the target property will be synchronized with the source property.
     ///
-    ///     If the target implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>, the target property raises the PropertyChanged event
-    ///     and the <see cref="BindingMode"/> is TwoWay, the source property will also be synchronized with the target property.
+    ///     If the target implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/>,
+    ///     the target property raises the PropertyChanged event and the <see cref="BindingMode"/> is TwoWay,
+    ///     the source property will also be synchronized with the target property.
     /// </summary>
-    /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+    /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
     /// <typeparam name="TTarget">
-    ///     The type of the target property that is being databound. If the source type
+    ///     The type of the target property that is being data-bound. If the source type
     ///     is not the same as the target type, an automatic conversion will be attempted. However only
     ///     simple types can be converted. For more complex conversions, use the <see cref="ConvertSourceToTarget" />
     ///     and <see cref="ConvertTargetToSource" /> methods to define custom converters.
     /// </typeparam>
+#pragma warning disable SA1649
     public abstract class Binding<TSource, TTarget> : Binding
+#pragma warning restore SA1649
     {
-        private readonly SimpleConverter _converter = new SimpleConverter();
+        private readonly WeakConverter _converter = new WeakConverter();
         private readonly List<IWeakEventListener> _listeners = new List<IWeakEventListener>();
-        private readonly Expression<Func<TSource>> _sourcePropertyExpression;
-        private readonly Func<TSource> _sourcePropertyFunc;
-        private readonly string _sourcePropertyName;
-        private readonly Expression<Func<TTarget>> _targetPropertyExpression;
-        private readonly string _targetPropertyName;
+
+        private readonly string? _sourcePropertyName;
+        private readonly string? _targetPropertyName;
+
+        private readonly Expression<Func<TSource>>? _sourcePropertyExpression;
+        private readonly Expression<Func<TTarget>>? _targetPropertyExpression;
+
+        private readonly Func<TSource>? _sourcePropertyFunc;
+
+        /// <summary>
+        ///     The source property handlers.
+        /// </summary>
         public readonly Dictionary<string, DelegateInfo> SourceHandlers = new Dictionary<string, DelegateInfo>();
+
+        /// <summary>
+        ///     The target property handlers.
+        /// </summary>
         public readonly Dictionary<string, DelegateInfo> TargetHandlers = new Dictionary<string, DelegateInfo>();
+
         private bool _isFallbackValueActive;
-        private WeakAction _onSourceUpdate;
-        private WeakAction<TSource> _onSourceUpdateWithParameter;
         private bool _resolveTopField;
+
         private bool _settingSourceToTarget;
         private bool _settingTargetToSource;
-        private PropertyInfo _sourceProperty;
-        private WeakFunc<TSource, Task> _sourceUpdateFunctionWithParameter;
-        private PropertyInfo _targetProperty;
-        private IConverter<TTarget, TSource> _valueConverter;
-        protected WeakReference PropertySource;
-        protected WeakReference PropertyTarget;
+
+        private PropertyInfo? _sourceProperty;
+        private PropertyInfo? _targetProperty;
+
+        private WeakAction? _onSourceUpdate;
+        private WeakAction<TSource>? _onSourceUpdateWithParameter;
+        private WeakFunc<TSource, Task>? _onSourceUpdateFunctionWithParameter;
+
+        private IConverter<TTarget, TSource>? _valueConverter;
+
+        /// <summary>
+        ///     A weak reference to the source property.
+        /// </summary>
+        protected WeakReference? _propertySource;
+
+        /// <summary>
+        ///     A weak reference to the target property.
+        /// </summary>
+        protected WeakReference? _propertyTarget;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Binding{TSource, TTarget}"/> class for
@@ -73,47 +98,46 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="targetPropertyName">The name of the target property for the binding.</param>
         /// <param name="mode">
         ///     The mode of the binding. OneTime means that the target property will be set once (when the binding is
-        ///     created) but that subsequent changes will be ignored. OneWay means that the target property will be set, and
-        ///     if the PropertyChanged event is raised by the source, the target property will be updated. TwoWay means that the
-        ///     source
-        ///     property will also be updated if the target raises the PropertyChanged event. Default means OneWay if only the
-        ///     source
-        ///     implements INPC, and TwoWay if both the source and the target implement INPC.
+        ///     created) but that subsequent changes will be ignored. OneWay means that the target property will be set,
+        ///     and if the PropertyChanged event is raised by the source, the target property will be updated.
+        ///     TwoWay means that the source property will also be updated if the target raises the PropertyChanged event.
+        ///     Default means OneWay if only the source implements INPC,
+        ///     and TwoWay if both the source and the target implement INPC.
         /// </param>
         /// <param name="fallbackValue">
-        ///     Tthe value to use when the binding is unable to return a value. This can happen if one of the
+        ///     The value to use when the binding is unable to return a value. This can happen if one of the
         ///     items on the Path (except the source property itself) is null, or if the Converter throws an exception.
         /// </param>
         /// <param name="targetNullValue">
-        ///     The value to use when the binding is unable to return a value. This can happen if one of the
+        ///     The target value to use when the binding is unable to return a value. This can happen if one of the
         ///     items on the Path (except the source property itself) is null, or if the Converter throws an exception.
         /// </param>
         protected Binding(
             object source,
             string sourcePropertyName,
-            object target = null,
-            string targetPropertyName = null,
+            object? target = null,
+            string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             Mode = mode;
             FallbackValue = fallbackValue;
             TargetNullValue = targetNullValue;
 
             TopSource = new WeakReference(source);
-            PropertySource = new WeakReference(source);
+            _propertySource = new WeakReference(source);
             _sourcePropertyName = sourcePropertyName;
 
             if (target == null)
             {
                 TopTarget = TopSource;
-                PropertyTarget = PropertySource;
+                _propertyTarget = _propertySource;
             }
             else
             {
                 TopTarget = new WeakReference(target);
-                PropertyTarget = new WeakReference(target);
+                _propertyTarget = new WeakReference(target);
             }
 
             _targetPropertyName = targetPropertyName;
@@ -121,7 +145,7 @@ namespace Softeq.XToolkit.Bindings
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Binding{TSource, TTarget}"/> class for
+        ///     Initializes a new instance of the <see cref="Binding{TSource, TTarget}"/> class for
         ///     which the source and target properties are located in different objects.
         /// </summary>
         /// <param name="source">
@@ -157,17 +181,15 @@ namespace Softeq.XToolkit.Bindings
         ///     The value to use when the binding is unable to return a value. This can happen if one of the
         ///     items on the Path (except the source property itself) is null, or if the Converter throws an exception.
         /// </param>
-        /// <param name="targetNullValue">
-        ///     The value to use when the binding is unable to return a value.
-        /// </param>
+        /// <param name="targetNullValue">The value to use when the binding is unable to return a value.</param>
         protected Binding(
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
             : this(
                 source,
                 sourcePropertyExpression,
@@ -180,15 +202,16 @@ namespace Softeq.XToolkit.Bindings
         {
         }
 
+        /// <inheritdoc cref="Binding{TSource,TTarget}"/>
         protected Binding(
             object source,
             Expression<Func<TSource>> sourcePropertyExpression,
             bool? resolveTopField,
-            object target = null,
-            Expression<Func<TTarget>> targetPropertyExpression = null,
+            object? target = null,
+            Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default,
-            TSource targetNullValue = default)
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!)
         {
             Mode = mode;
             FallbackValue = fallbackValue;
@@ -211,6 +234,11 @@ namespace Softeq.XToolkit.Bindings
         }
 
         /// <summary>
+        ///     Occurs when the value of the data-bound property changes.
+        /// </summary>
+        public override event EventHandler? ValueChanged;
+
+        /// <summary>
         ///     Gets the value to use when the binding is unable to return a value. This can happen if one of the
         ///     items on the Path (except the source property itself) is null, or if the Converter throws an exception.
         /// </summary>
@@ -224,31 +252,30 @@ namespace Softeq.XToolkit.Bindings
         /// <summary>
         ///     Gets the current value of the binding.
         /// </summary>
+        [MaybeNull]
         public TTarget Value
         {
             get
             {
-                if (PropertySource == null
-                    || !PropertySource.IsAlive)
+                if (!(_propertySource is { IsAlive: true }))
                 {
                     return default;
                 }
 
-                var type = PropertySource.Target.GetType();
+                var type = _propertySource.Target.GetType();
                 var property = type.GetRuntimeProperty(_sourcePropertyName);
-                return (TTarget) property.GetValue(PropertySource.Target, null);
+                return (TTarget) property.GetValue(_propertySource.Target, null);
             }
         }
 
         /// <summary>
-        ///     Defines a custom conversion method for a binding. To be used when the
-        ///     binding's source property is of a different type than the binding's
-        ///     target property, and the conversion cannot be done automatically (simple
-        ///     values).
+        ///     Defines a custom conversion method for a binding.
+        ///
+        ///     To be used when the binding's source property is of a different type than the binding's
+        ///     target property, and the conversion cannot be done automatically (simple values).
         /// </summary>
         /// <param name="convert">
-        ///     A func that will be called with the source
-        ///     property's value, and will return the target property's value.
+        ///     A func that will be called with the source property's value, and will return the target property's value.
         ///     IMPORTANT: Note that closures are not supported at the moment
         ///     due to the use of WeakActions (see http://stackoverflow.com/questions/25730530/).
         /// </param>
@@ -261,14 +288,13 @@ namespace Softeq.XToolkit.Bindings
         }
 
         /// <summary>
-        ///     Defines a custom conversion method for a two-way binding. To be used when the
-        ///     binding's target property is of a different type than the binding's
-        ///     source property, and the conversion cannot be done automatically (simple
-        ///     values).
+        ///     Defines a custom conversion method for a two-way binding.
+        ///
+        ///     To be used when the binding's target property is of a different type than the binding's
+        ///     source property, and the conversion cannot be done automatically (simple values).
         /// </summary>
         /// <param name="convertBack">
-        ///     A func that will be called with the source
-        ///     property's value, and will return the target property's value.
+        ///     A func that will be called with the source property's value, and will return the target property's value.
         ///     IMPORTANT: Note that closures are not supported at the moment
         ///     due to the use of WeakActions (see http://stackoverflow.com/questions/25730530/).
         /// </param>
@@ -280,7 +306,23 @@ namespace Softeq.XToolkit.Bindings
             return this;
         }
 
-        public Binding SetConverter(IConverter<TTarget, TSource> converter)
+        /// <summary>
+        ///     Defines a custom conversion methods for a binding.
+        ///
+        ///     To be used when the binding's source/target property is of a different type than the binding's
+        ///     target/source property, and the conversion cannot be done automatically (simple values).
+        /// </summary>
+        /// <param name="converter">
+        ///     The <see cref="IConverter{TTarget, TSource}"/> instance of the converter, where:
+        ///     <para>
+        ///     - <see cref="IConverter{TTarget, TSource}.ConvertValue"/> will have behavior like <see cref="ConvertSourceToTarget"/> method.
+        ///     </para>
+        ///     <para>
+        ///     - <see cref="IConverter{TTarget, TSource}.ConvertValueBack"/> will have behavior like <see cref="ConvertTargetToSource"/> method.
+        ///     </para>
+        /// </param>
+        /// <returns>The Binding instance.</returns>
+        public Binding SetConverter(IConverter<TTarget, TSource>? converter)
         {
             if (converter == null)
             {
@@ -307,8 +349,8 @@ namespace Softeq.XToolkit.Bindings
 
             _listeners.Clear();
 
-            DetachSourceHandlers();
-            DetachTargetHandlers();
+            DetachAllSourceHandlers();
+            DetachAllTargetHandlers();
         }
 
         /// <summary>
@@ -318,9 +360,9 @@ namespace Softeq.XToolkit.Bindings
         {
             if (_onSourceUpdate == null
                 && _onSourceUpdateWithParameter == null
-                && (PropertySource == null
-                    || !PropertySource.IsAlive
-                    || PropertySource.Target == null))
+                && (_propertySource == null
+                    || !_propertySource.IsAlive
+                    || _propertySource.Target == null))
             {
                 return;
             }
@@ -330,12 +372,12 @@ namespace Softeq.XToolkit.Bindings
                 try
                 {
                     var value = GetSourceValue();
-                    var targetValue = _targetProperty.GetValue(PropertyTarget.Target);
+                    var targetValue = _targetProperty.GetValue(_propertyTarget!.Target);
 
                     if (!Equals(value, targetValue))
                     {
                         _settingSourceToTarget = true;
-                        SetTargetValue(value);
+                        SetTargetValue(value!);
                         _settingSourceToTarget = false;
                     }
                 }
@@ -344,22 +386,20 @@ namespace Softeq.XToolkit.Bindings
                     if (!Equals(FallbackValue, default(TSource)))
                     {
                         _settingSourceToTarget = true;
-                        _targetProperty.SetValue(PropertyTarget.Target, FallbackValue, null);
+                        _targetProperty.SetValue(_propertyTarget!.Target, FallbackValue, null);
                         _settingSourceToTarget = false;
                     }
                 }
             }
 
-            if (_onSourceUpdate != null
-                && _onSourceUpdate.IsAlive)
+            if (_onSourceUpdate is { IsAlive: true })
             {
                 _onSourceUpdate.Execute();
             }
 
-            if (_onSourceUpdateWithParameter != null
-                && _onSourceUpdateWithParameter.IsAlive)
+            if (_onSourceUpdateWithParameter is { IsAlive: true })
             {
-                _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc.Invoke());
+                _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc!.Invoke());
             }
 
             RaiseValueChanged();
@@ -370,12 +410,12 @@ namespace Softeq.XToolkit.Bindings
         /// </summary>
         public override void ForceUpdateValueFromTargetToSource()
         {
-            if (PropertyTarget == null
-                || !PropertyTarget.IsAlive
-                || PropertyTarget.Target == null
-                || PropertySource == null
-                || !PropertySource.IsAlive
-                || PropertySource.Target == null)
+            if (_propertyTarget == null
+                || !_propertyTarget.IsAlive
+                || _propertyTarget.Target == null
+                || _propertySource == null
+                || !_propertySource.IsAlive
+                || _propertySource.Target == null)
             {
                 return;
             }
@@ -383,12 +423,12 @@ namespace Softeq.XToolkit.Bindings
             if (_targetProperty != null)
             {
                 var value = GetTargetValue();
-                var sourceValue = _sourceProperty.GetValue(PropertySource.Target);
+                var sourceValue = _sourceProperty!.GetValue(_propertySource.Target);
 
                 if (!Equals(value, sourceValue))
                 {
                     _settingTargetToSource = true;
-                    SetSourceValue(value);
+                    SetSourceValue(value!);
                     _settingTargetToSource = false;
                 }
             }
@@ -397,10 +437,12 @@ namespace Softeq.XToolkit.Bindings
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound source object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound source object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
         /// <param name="eventName">
         ///     The name of the event that should be observed to update the binding's value.
@@ -431,9 +473,9 @@ namespace Softeq.XToolkit.Bindings
 
             if (_onSourceUpdate == null
                 && _onSourceUpdateWithParameter == null
-                && (PropertySource == null
-                    || !PropertySource.IsAlive
-                    || PropertySource.Target == null))
+                && (_propertySource == null
+                    || !_propertySource.IsAlive
+                    || _propertySource.Target == null))
             {
                 throw new InvalidOperationException("Source is not ready");
             }
@@ -443,20 +485,19 @@ namespace Softeq.XToolkit.Bindings
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            var type = PropertySource.Target.GetType();
-            var ev = type.GetRuntimeEvent(eventName);
-            if (ev == null)
+            var type = _propertySource!.Target.GetType();
+            var @event = type.GetRuntimeEvent(eventName);
+            if (@event == null)
             {
-                throw new ArgumentException("Event not found: " + eventName, nameof(eventName));
+                throw new ArgumentException($"Event not found: {eventName}", nameof(eventName));
             }
 
             EventHandler handler = HandleSourceEvent;
 
-            var defaultHandlerInfo = SourceHandlers.Values.FirstOrDefault(i => i.IsDefault);
-
+            var defaultHandlerInfo = SourceHandlers.Values.FirstOrDefault(x => x.IsDefault);
             if (defaultHandlerInfo != null)
             {
-                DetachSourceHandlers();
+                DetachAllSourceHandlers();
             }
 
             var info = new DelegateInfo
@@ -473,34 +514,28 @@ namespace Softeq.XToolkit.Bindings
                 SourceHandlers.Add(eventName, info);
             }
 
-            ev.AddEventHandler(
-                PropertySource.Target,
-                handler);
+            @event.AddEventHandler(_propertySource.Target, handler);
 
             return this;
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound source object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound source object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
         /// <remarks>
-        ///     Use this method when the event requires a specific EventArgs type
-        ///     instead of the standard EventHandler.
+        ///     Use this method when the event requires a specific EventArgs type instead of the standard EventHandler.
         /// </remarks>
         /// <typeparam name="TEventArgs">The type of the EventArgs used by this control's event.</typeparam>
-        /// <param name="eventName">
-        ///     The name of the event that should be observed
-        ///     to update the binding's value.
-        /// </param>
+        /// <param name="eventName">The name of the event that should be observed to update the binding's value.</param>
         /// <returns>The Binding instance.</returns>
         /// <exception cref="T:System.InvalidOperationException">
-        ///     When this method is called
-        ///     on a OneTime binding. Such bindings cannot be updated. This exception can
-        ///     also be thrown when the source object is null or has already been
-        ///     garbage collected before this method is called.
+        ///     When this method is called on a OneTime binding. Such bindings cannot be updated. This exception can
+        ///     also be thrown when the source object is null or has already been garbage collected before this method is called.
         /// </exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///     When the eventName parameter is null or is an empty string.
@@ -524,9 +559,9 @@ namespace Softeq.XToolkit.Bindings
 
             if (_onSourceUpdate == null
                 && _onSourceUpdateWithParameter == null
-                && (PropertySource == null
-                    || !PropertySource.IsAlive
-                    || PropertySource.Target == null))
+                && (_propertySource == null
+                    || !_propertySource.IsAlive
+                    || _propertySource.Target == null))
             {
                 throw new InvalidOperationException("Source is not ready");
             }
@@ -536,20 +571,19 @@ namespace Softeq.XToolkit.Bindings
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            var type = PropertySource.Target.GetType();
-            var ev = type.GetRuntimeEvent(eventName);
-            if (ev == null)
+            var type = _propertySource!.Target.GetType();
+            var @event = type.GetRuntimeEvent(eventName);
+            if (@event == null)
             {
-                throw new ArgumentException("Event not found: " + eventName, nameof(eventName));
+                throw new ArgumentException($"Event not found: {eventName}", nameof(eventName));
             }
 
             EventHandler<TEventArgs> handler = HandleSourceEvent;
 
-            var defaultHandlerInfo = SourceHandlers.Values.FirstOrDefault(i => i.IsDefault);
-
+            var defaultHandlerInfo = SourceHandlers.Values.FirstOrDefault(x => x.IsDefault);
             if (defaultHandlerInfo != null)
             {
-                DetachSourceHandlers();
+                DetachAllSourceHandlers();
             }
 
             var info = new DelegateInfo
@@ -566,29 +600,24 @@ namespace Softeq.XToolkit.Bindings
                 SourceHandlers.Add(eventName, info);
             }
 
-            ev.AddEventHandler(
-                PropertySource.Target,
-                handler);
+            @event.AddEventHandler(_propertySource.Target, handler);
 
             return this;
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound target object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound target object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
-        /// <param name="eventName">
-        ///     The name of the event that should be observed
-        ///     to update the binding's value.
-        /// </param>
+        /// <param name="eventName">The name of the event that should be observed to update the binding's value.</param>
         /// <returns>The Binding instance.</returns>
         /// <exception cref="T:System.InvalidOperationException">
-        ///     When this method is called
-        ///     on a OneTime or a OneWay binding. This exception can
-        ///     also be thrown when the source object is null or has already been
-        ///     garbage collected before this method is called.
+        ///     When this method is called on a OneTime or a OneWay binding. This exception can
+        ///     also be thrown when the source object is null or has already been garbage collected before this method is called.
         /// </exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///     When the eventName parameter is null or is an empty string.
@@ -619,9 +648,9 @@ namespace Softeq.XToolkit.Bindings
                 throw new InvalidOperationException("Cannot use SetTargetEvent with onSourceUpdate");
             }
 
-            if (PropertyTarget == null
-                || !PropertyTarget.IsAlive
-                || PropertyTarget.Target == null)
+            if (_propertyTarget == null
+                || !_propertyTarget.IsAlive
+                || _propertyTarget.Target == null)
             {
                 throw new InvalidOperationException("Target is not ready");
             }
@@ -631,21 +660,20 @@ namespace Softeq.XToolkit.Bindings
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            var type = PropertyTarget.Target.GetType();
+            var type = _propertyTarget.Target.GetType();
 
-            var ev = type.GetRuntimeEvent(eventName);
-            if (ev == null)
+            var @event = type.GetRuntimeEvent(eventName);
+            if (@event == null)
             {
-                throw new ArgumentException("Event not found: " + eventName, nameof(eventName));
+                throw new ArgumentException($"Event not found: {eventName}", nameof(eventName));
             }
 
             EventHandler handler = HandleTargetEvent;
 
-            var defaultHandlerInfo = TargetHandlers.Values.FirstOrDefault(i => i.IsDefault);
-
+            var defaultHandlerInfo = TargetHandlers.Values.FirstOrDefault(x => x.IsDefault);
             if (defaultHandlerInfo != null)
             {
-                DetachTargetHandlers();
+                DetachAllTargetHandlers();
             }
 
             var info = new DelegateInfo
@@ -662,34 +690,28 @@ namespace Softeq.XToolkit.Bindings
                 TargetHandlers.Add(eventName, info);
             }
 
-            ev.AddEventHandler(
-                PropertyTarget.Target,
-                handler);
+            @event.AddEventHandler(_propertyTarget.Target, handler);
 
             return this;
         }
 
         /// <summary>
-        ///     Define when the binding should be evaluated when the bound target object
-        ///     is a control. Because Xamarin controls are not DependencyObjects, the
-        ///     bound property will not automatically update the binding attached to it. Instead,
-        ///     use this method to define which of the control's events should be observed.
+        ///     Define when the binding should be evaluated when the bound target object is a control.
+        ///
+        ///     Because Xamarin controls are not DependencyObjects,
+        ///     the bound property will not automatically update the binding attached to it.
+        ///
+        ///     Instead, use this method to define which of the control's events should be observed.
         /// </summary>
         /// <remarks>
-        ///     Use this method when the event requires a specific EventArgs type
-        ///     instead of the standard EventHandler.
+        ///     Use this method when the event requires a specific EventArgs type instead of the standard EventHandler.
         /// </remarks>
         /// <typeparam name="TEventArgs">The type of the EventArgs used by this control's event.</typeparam>
-        /// <param name="eventName">
-        ///     The name of the event that should be observed
-        ///     to update the binding's value.
-        /// </param>
+        /// <param name="eventName">The name of the event that should be observed to update the binding's value.</param>
         /// <returns>The Binding instance.</returns>
         /// <exception cref="T:System.InvalidOperationException">
-        ///     When this method is called
-        ///     on a OneTime or OneWay binding. This exception can
-        ///     also be thrown when the target object is null or has already been
-        ///     garbage collected before this method is called.
+        ///     When this method is called on a OneTime or OneWay binding. This exception can
+        ///     also be thrown when the target object is null or has already been garbage collected before this method is called.
         /// </exception>
         /// <exception cref="T:System.ArgumentNullException">
         ///     When the eventName parameter is null or is an empty string.
@@ -721,9 +743,9 @@ namespace Softeq.XToolkit.Bindings
                 throw new InvalidOperationException("Cannot use SetTargetEvent with onSourceUpdate");
             }
 
-            if (PropertyTarget == null
-                || !PropertyTarget.IsAlive
-                || PropertyTarget.Target == null)
+            if (_propertyTarget == null
+                || !_propertyTarget.IsAlive
+                || _propertyTarget.Target == null)
             {
                 throw new InvalidOperationException("Target is not ready");
             }
@@ -733,21 +755,20 @@ namespace Softeq.XToolkit.Bindings
                 throw new ArgumentNullException(nameof(eventName));
             }
 
-            var type = PropertyTarget.Target.GetType();
+            var type = _propertyTarget.Target.GetType();
 
-            var ev = type.GetRuntimeEvent(eventName);
-            if (ev == null)
+            var @event = type.GetRuntimeEvent(eventName);
+            if (@event == null)
             {
-                throw new ArgumentException("Event not found: " + eventName, nameof(eventName));
+                throw new ArgumentException($"Event not found: {eventName}", nameof(eventName));
             }
 
             EventHandler<TEventArgs> handler = HandleTargetEvent;
 
-            var defaultHandlerInfo = TargetHandlers.Values.FirstOrDefault(i => i.IsDefault);
-
+            var defaultHandlerInfo = TargetHandlers.Values.FirstOrDefault(x => x.IsDefault);
             if (defaultHandlerInfo != null)
             {
-                DetachTargetHandlers();
+                DetachAllTargetHandlers();
             }
 
             var info = new DelegateInfo
@@ -764,9 +785,7 @@ namespace Softeq.XToolkit.Bindings
                 TargetHandlers.Add(eventName, info);
             }
 
-            ev.AddEventHandler(
-                PropertyTarget.Target,
-                handler);
+            @event.AddEventHandler(_propertyTarget.Target, handler);
 
             return this;
         }
@@ -801,6 +820,18 @@ namespace Softeq.XToolkit.Bindings
             return this;
         }
 
+        /// <summary>
+        ///     Defines an generic action that will be executed every time that the binding value changes.
+        /// </summary>
+        /// <param name="callback">
+        ///     The generic action that will be executed when the binding changes.
+        ///     IMPORTANT: Note that closures are not supported at the moment
+        ///     due to the use of WeakActions (see http://stackoverflow.com/questions/25730530/).
+        /// </param>
+        /// <returns>The Binding instance.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///     When the method is called on a binding that already has a target property set.
+        /// </exception>
         public Binding<TSource, TTarget> WhenSourceChanges(Action<TSource> callback)
         {
             if (_targetPropertyExpression != null)
@@ -813,53 +844,66 @@ namespace Softeq.XToolkit.Bindings
 
             if (_onSourceUpdateWithParameter.IsAlive)
             {
-                _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc.Invoke());
+                _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc!.Invoke());
             }
 
             return this;
         }
 
-        public Binding<TSource, TTarget> WhenSourceChanges(Func<TSource, Task> func)
+        /// <summary>
+        ///     Defines an generic function that will be executed every time that the binding value changes.
+        /// </summary>
+        /// <param name="callback">
+        ///     The function that will be executed when the binding changes.
+        ///     IMPORTANT: Note that closures are not supported at the moment
+        ///     due to the use of WeakActions (see http://stackoverflow.com/questions/25730530/).
+        /// </param>
+        /// <returns>The Binding instance.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///     When the method is called on a binding that already has a target property set.
+        /// </exception>
+        public Binding<TSource, TTarget> WhenSourceChanges(Func<TSource, Task> callback)
         {
-            _sourceUpdateFunctionWithParameter = new WeakFunc<TSource, Task>(func);
+            _onSourceUpdateFunctionWithParameter = new WeakFunc<TSource, Task>(callback);
 
             return WhenSourceChanges(source =>
             {
-                _sourceUpdateFunctionWithParameter.Execute(_sourcePropertyFunc.Invoke());
+                _onSourceUpdateFunctionWithParameter.Execute(_sourcePropertyFunc!.Invoke());
             });
         }
 
+        /// <summary>
+        ///     Defines the behavior to update the binding when the source control's property changes.
+        /// </summary>
+        /// <returns>The Binding instance.</returns>
         protected abstract Binding<TSource, TTarget> CheckControlSource();
 
+        /// <summary>
+        ///     Defines the behavior to update the binding when the source control's property changes.
+        /// </summary>
+        /// <returns>The Binding instance.</returns>
         protected abstract Binding<TSource, TTarget> CheckControlTarget();
 
-        private void Attach(
-            object source,
-            object target,
-            BindingMode mode)
+        private void Attach(object? source, object? target, BindingMode mode)
         {
             Attach(source, target, mode, _resolveTopField);
         }
 
-        private void Attach(
-            object source,
-            object target,
-            BindingMode mode,
-            bool resolveTopField)
+        private void Attach(object? source, object? target, BindingMode mode, bool resolveTopField)
         {
             _resolveTopField = resolveTopField;
 
             var sourceChain = GetPropertyChain(
                 source,
                 null,
-                _sourcePropertyExpression.Body as MemberExpression,
-                _sourcePropertyName,
+                _sourcePropertyExpression!.Body as MemberExpression,
+                _sourcePropertyName!,
                 resolveTopField);
 
             var lastSourceInChain = sourceChain.Last();
             sourceChain.Remove(lastSourceInChain);
 
-            PropertySource = new WeakReference(lastSourceInChain.Instance);
+            _propertySource = new WeakReference(lastSourceInChain.Instance);
 
             if (mode != BindingMode.OneTime)
             {
@@ -888,7 +932,7 @@ namespace Softeq.XToolkit.Bindings
                 var lastTargetInChain = targetChain.Last();
                 targetChain.Remove(lastTargetInChain);
 
-                PropertyTarget = new WeakReference(lastTargetInChain.Instance);
+                _propertyTarget = new WeakReference(lastTargetInChain.Instance);
 
                 if (mode != BindingMode.OneTime)
                 {
@@ -923,34 +967,35 @@ namespace Softeq.XToolkit.Bindings
 
         private void Attach()
         {
-            if (PropertyTarget != null
-                && PropertyTarget.IsAlive
-                && PropertyTarget.Target != null
+            if (_propertyTarget != null
+                && _propertyTarget.IsAlive
+                && _propertyTarget.Target != null
                 && !string.IsNullOrEmpty(_targetPropertyName))
             {
-                var targetType = PropertyTarget.Target.GetType();
-                _targetProperty = targetType.GetRuntimeProperty(_targetPropertyName);
+                var targetType = _propertyTarget.Target.GetType();
 
+                _targetProperty = targetType.GetRuntimeProperty(_targetPropertyName);
                 if (_targetProperty == null)
                 {
-                    throw new InvalidOperationException("Property not found: " + _targetPropertyName);
+                    throw new InvalidOperationException($"Property not found: {_targetPropertyName}");
                 }
             }
 
-            if (PropertySource == null
-                || !PropertySource.IsAlive
-                || PropertySource.Target == null)
+            if (_propertySource == null
+                || !_propertySource.IsAlive
+                || _propertySource.Target == null)
             {
                 SetSpecialValues();
                 return;
             }
 
-            var sourceType = PropertySource.Target.GetType();
+            var sourceType = _propertySource.Target.GetType();
+
             _sourceProperty = sourceType.GetRuntimeProperty(_sourcePropertyName);
 
             if (_sourceProperty == null)
             {
-                throw new InvalidOperationException("Property not found: " + _sourcePropertyName);
+                throw new InvalidOperationException($"Property not found: {_sourcePropertyName}");
             }
 
             // OneTime binding
@@ -959,12 +1004,12 @@ namespace Softeq.XToolkit.Bindings
                 var value = GetSourceValue();
 
                 if (_targetProperty != null
-                    && PropertyTarget != null
-                    && PropertyTarget.IsAlive
-                    && PropertyTarget.Target != null)
+                    && _propertyTarget != null
+                    && _propertyTarget.IsAlive
+                    && _propertyTarget.Target != null)
                 {
                     _settingSourceToTarget = true;
-                    SetTargetValue(value);
+                    SetTargetValue(value!);
                     _settingSourceToTarget = false;
                 }
 
@@ -977,7 +1022,7 @@ namespace Softeq.XToolkit.Bindings
                 if (_onSourceUpdateWithParameter != null
                     && _onSourceUpdateWithParameter.IsAlive)
                 {
-                    _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc.Invoke());
+                    _onSourceUpdateWithParameter.Execute(_sourcePropertyFunc!.Invoke());
                 }
             }
 
@@ -987,7 +1032,7 @@ namespace Softeq.XToolkit.Bindings
             }
 
             // Check OneWay binding
-            if (PropertySource.Target is INotifyPropertyChanged inpc)
+            if (_propertySource.Target is INotifyPropertyChanged inpc)
             {
                 var listener = new PropertyChangedEventListener(this, inpc, true);
                 _listeners.Add(listener);
@@ -1007,11 +1052,11 @@ namespace Softeq.XToolkit.Bindings
             // Check TwoWay binding
             if (_onSourceUpdate == null
                 && _onSourceUpdateWithParameter == null
-                && PropertyTarget != null
-                && PropertyTarget.IsAlive
-                && PropertyTarget.Target != null)
+                && _propertyTarget != null
+                && _propertyTarget.IsAlive
+                && _propertyTarget.Target != null)
             {
-                if (PropertyTarget.Target is INotifyPropertyChanged inpc2)
+                if (_propertyTarget.Target is INotifyPropertyChanged inpc2)
                 {
                     var listener = new PropertyChangedEventListener(this, inpc2, false);
                     _listeners.Add(listener);
@@ -1024,9 +1069,9 @@ namespace Softeq.XToolkit.Bindings
             }
         }
 
-        private bool CanBeConverted(PropertyInfo sourceProperty, PropertyInfo targetProperty)
+        private bool CanBeConverted(PropertyInfo? sourceProperty, PropertyInfo? targetProperty)
         {
-            if (targetProperty == null)
+            if (sourceProperty == null || targetProperty == null)
             {
                 return true;
             }
@@ -1038,58 +1083,58 @@ namespace Softeq.XToolkit.Bindings
                    || (IsValueType(sourceType) && IsValueType(targetType));
         }
 
-        private void DetachSourceHandlers()
+        private void DetachAllSourceHandlers()
         {
-            if (PropertySource == null
-                || !PropertySource.IsAlive
-                || PropertySource.Target == null)
+            if (_propertySource == null
+                || !_propertySource.IsAlive
+                || _propertySource.Target == null)
             {
                 return;
             }
 
             foreach (var eventName in SourceHandlers.Keys)
             {
-                var type = PropertySource.Target.GetType();
-                var ev = type.GetRuntimeEvent(eventName);
-                if (ev == null)
+                var type = _propertySource.Target.GetType();
+                var @event = type.GetRuntimeEvent(eventName);
+                if (@event == null)
                 {
                     return;
                 }
 
-                ev.RemoveEventHandler(PropertySource.Target, SourceHandlers[eventName].Delegate);
+                @event.RemoveEventHandler(_propertySource.Target, SourceHandlers[eventName].Delegate);
             }
 
             SourceHandlers.Clear();
         }
 
-        private void DetachTargetHandlers()
+        private void DetachAllTargetHandlers()
         {
-            if (PropertySource == null
-                || !PropertySource.IsAlive
-                || PropertySource.Target == null)
+            if (_propertySource == null
+                || !_propertySource.IsAlive
+                || _propertySource.Target == null)
             {
                 return;
             }
 
             foreach (var eventName in TargetHandlers.Keys)
             {
-                var type = PropertyTarget.Target.GetType();
-                var ev = type.GetRuntimeEvent(eventName);
-                if (ev == null)
+                var type = _propertyTarget!.Target.GetType();
+                var @event = type.GetRuntimeEvent(eventName);
+                if (@event == null)
                 {
                     return;
                 }
 
-                ev.RemoveEventHandler(PropertyTarget.Target, TargetHandlers[eventName].Delegate);
+                @event.RemoveEventHandler(_propertyTarget.Target, TargetHandlers[eventName].Delegate);
             }
 
             TargetHandlers.Clear();
         }
 
-        private static IList<PropertyAndName> GetPropertyChain(
-            object topInstance,
-            IList<PropertyAndName> instances,
-            MemberExpression expression,
+        private IList<PropertyAndName> GetPropertyChain(
+            object? topInstance,
+            IList<PropertyAndName>? instances,
+            MemberExpression? expression,
             string propertyName,
             bool resolveTopField,
             bool top = true)
@@ -1099,9 +1144,8 @@ namespace Softeq.XToolkit.Bindings
                 instances = new List<PropertyAndName>();
             }
 
-            var ex = expression.Expression as MemberExpression;
-
-            if (ex == null)
+            var expr = expression!.Expression as MemberExpression;
+            if (expr == null)
             {
                 if (top)
                 {
@@ -1116,7 +1160,7 @@ namespace Softeq.XToolkit.Bindings
                 return instances;
             }
 
-            var list = GetPropertyChain(topInstance, instances, ex, propertyName, resolveTopField, false);
+            var list = GetPropertyChain(topInstance, instances, expr, propertyName, resolveTopField, false);
 
             if (list.Count == 0)
             {
@@ -1143,9 +1187,7 @@ namespace Softeq.XToolkit.Bindings
 
             if (lastInstance.Instance != null)
             {
-                var prop = ex.Member as PropertyInfo;
-
-                if (prop != null)
+                if (expr.Member is PropertyInfo prop)
                 {
                     try
                     {
@@ -1161,14 +1203,14 @@ namespace Softeq.XToolkit.Bindings
                     }
                     catch (TargetInvocationException)
                     {
+                        // ignored
                     }
                 }
                 else
                 {
-                    if (lastInstance.Instance == topInstance
-                        && resolveTopField)
+                    if (lastInstance.Instance == topInstance && resolveTopField)
                     {
-                        var field = ex.Member as FieldInfo;
+                        var field = expr.Member as FieldInfo;
                         if (field != null)
                         {
                             try
@@ -1186,8 +1228,7 @@ namespace Softeq.XToolkit.Bindings
                             catch (ArgumentException)
                             {
                                 throw new InvalidOperationException(
-                                    "Are you trying to use SetBinding with a local variable? "
-                                    + "Try to use new Binding instead");
+                                    "Are you trying to use SetBinding with a local variable? Try to use new Binding instead");
                             }
                         }
                     }
@@ -1202,7 +1243,11 @@ namespace Softeq.XToolkit.Bindings
             return list;
         }
 
-        private static string GetPropertyName<T>(Expression<Func<T>> propertyExpression)
+        [SuppressMessage(
+            "StyleCop.CSharp.OrderingRules",
+            "SA1204:Static elements should appear before instance elements",
+            Justification = "Revieved.")]
+        private static string? GetPropertyName<T>(Expression<Func<T>>? propertyExpression)
         {
             if (propertyExpression == null)
             {
@@ -1210,14 +1255,12 @@ namespace Softeq.XToolkit.Bindings
             }
 
             var body = propertyExpression.Body as MemberExpression;
-
             if (body == null)
             {
                 throw new ArgumentException("Invalid argument", nameof(propertyExpression));
             }
 
             var property = body.Member as PropertyInfo;
-
             if (property == null)
             {
                 throw new ArgumentException("Argument is not a property", nameof(propertyExpression));
@@ -1226,6 +1269,7 @@ namespace Softeq.XToolkit.Bindings
             return property.Name;
         }
 
+        [return: MaybeNull]
         private TTarget GetSourceValue()
         {
             if (_sourceProperty == null)
@@ -1233,7 +1277,7 @@ namespace Softeq.XToolkit.Bindings
                 return default;
             }
 
-            var sourceValue = (TSource) _sourceProperty.GetValue(PropertySource.Target, null);
+            var sourceValue = (TSource) _sourceProperty.GetValue(_propertySource!.Target, null);
 
             try
             {
@@ -1246,14 +1290,15 @@ namespace Softeq.XToolkit.Bindings
                     return _converter.Convert(FallbackValue);
                 }
 
-                var targetValue = (TTarget) _targetProperty.GetValue(PropertyTarget.Target, null);
+                var targetValue = (TTarget) _targetProperty!.GetValue(_propertyTarget!.Target, null);
                 return targetValue;
             }
         }
 
+        [return: MaybeNull]
         private TSource GetTargetValue()
         {
-            var targetValue = (TTarget) _targetProperty.GetValue(PropertyTarget.Target, null);
+            var targetValue = (TTarget) _targetProperty!.GetValue(_propertyTarget!.Target, null);
 
             try
             {
@@ -1261,23 +1306,23 @@ namespace Softeq.XToolkit.Bindings
             }
             catch (Exception)
             {
-                var sourceValue = (TSource) _sourceProperty.GetValue(PropertySource.Target, null);
+                var sourceValue = (TSource) _sourceProperty!.GetValue(_propertySource!.Target, null);
                 return sourceValue;
             }
         }
 
         private void HandleSourceEvent<TEventArgs>(object sender, TEventArgs args)
         {
-            if (PropertyTarget != null
-                && PropertyTarget.IsAlive
-                && PropertyTarget.Target != null
-                && PropertySource != null
-                && PropertySource.IsAlive
-                && PropertySource.Target != null
+            if (_propertyTarget != null
+                && _propertyTarget.IsAlive
+                && _propertyTarget.Target != null
+                && _propertySource != null
+                && _propertySource.IsAlive
+                && _propertySource.Target != null
                 && !_settingTargetToSource)
             {
                 var valueLocal = GetSourceValue();
-                var targetValue = _targetProperty.GetValue(PropertyTarget.Target, null);
+                var targetValue = _targetProperty!.GetValue(_propertyTarget.Target, null);
 
                 if (Equals(valueLocal, targetValue))
                 {
@@ -1287,29 +1332,29 @@ namespace Softeq.XToolkit.Bindings
                 if (_targetProperty != null)
                 {
                     _settingSourceToTarget = true;
-                    SetTargetValue(valueLocal);
+                    SetTargetValue(valueLocal!);
                     _settingSourceToTarget = false;
                 }
             }
 
             _onSourceUpdate?.Execute();
-            _onSourceUpdateWithParameter?.Execute(_sourcePropertyFunc.Invoke());
+            _onSourceUpdateWithParameter?.Execute(_sourcePropertyFunc!.Invoke());
 
             RaiseValueChanged();
         }
 
         private void HandleTargetEvent<TEventArgs>(object source, TEventArgs args)
         {
-            if (PropertyTarget != null
-                && PropertyTarget.IsAlive
-                && PropertyTarget.Target != null
-                && PropertySource != null
-                && PropertySource.IsAlive
-                && PropertySource.Target != null
+            if (_propertyTarget != null
+                && _propertyTarget.IsAlive
+                && _propertyTarget.Target != null
+                && _propertySource != null
+                && _propertySource.IsAlive
+                && _propertySource.Target != null
                 && !_settingSourceToTarget)
             {
                 var valueLocal = GetTargetValue();
-                var sourceValue = _sourceProperty.GetValue(PropertySource.Target, null);
+                var sourceValue = _sourceProperty!.GetValue(_propertySource.Target, null);
 
                 if (Equals(valueLocal, sourceValue))
                 {
@@ -1317,7 +1362,7 @@ namespace Softeq.XToolkit.Bindings
                 }
 
                 _settingTargetToSource = true;
-                SetSourceValue(valueLocal);
+                SetSourceValue(valueLocal!);
                 _settingTargetToSource = false;
             }
 
@@ -1331,7 +1376,7 @@ namespace Softeq.XToolkit.Bindings
                 return true;
             }
 
-            var sourceValue = (TSource) _sourceProperty.GetValue(PropertySource.Target, null);
+            var sourceValue = (TSource) _sourceProperty.GetValue(_propertySource!.Target, null);
             return Equals(default(TSource), sourceValue);
         }
 
@@ -1346,16 +1391,16 @@ namespace Softeq.XToolkit.Bindings
             handler?.Invoke(this, EventArgs.Empty);
         }
 
-        private void SetSourceValue(TSource value)
+        private void SetSourceValue([MaybeNull] TSource value)
         {
-            _sourceProperty.SetValue(PropertySource.Target, value, null);
+            _sourceProperty!.SetValue(_propertySource!.Target, value, null);
         }
 
         private bool SetSpecialValues()
         {
             if (_isFallbackValueActive)
             {
-                _targetProperty.SetValue(PropertyTarget.Target, _converter.Convert(FallbackValue), null);
+                _targetProperty!.SetValue(_propertyTarget!.Target, _converter.Convert(FallbackValue), null);
                 return true;
             }
 
@@ -1363,7 +1408,7 @@ namespace Softeq.XToolkit.Bindings
             {
                 if (IsSourceDefaultValue())
                 {
-                    _targetProperty.SetValue(PropertyTarget.Target, _converter.Convert(TargetNullValue), null);
+                    _targetProperty!.SetValue(_propertyTarget!.Target, _converter.Convert(TargetNullValue), null);
                     return true;
                 }
             }
@@ -1371,18 +1416,13 @@ namespace Softeq.XToolkit.Bindings
             return false;
         }
 
-        private void SetTargetValue(TTarget value)
+        private void SetTargetValue([MaybeNull] TTarget value)
         {
             if (!SetSpecialValues())
             {
-                _targetProperty.SetValue(PropertyTarget.Target, value, null);
+                _targetProperty!.SetValue(_propertyTarget!.Target, value, null);
             }
         }
-
-        /// <summary>
-        ///     Occurs when the value of the databound property changes.
-        /// </summary>
-        public override event EventHandler ValueChanged;
 
         internal class ObjectSwappedEventListener : IWeakEventListener
         {
@@ -1400,11 +1440,8 @@ namespace Softeq.XToolkit.Bindings
 
             public bool ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
             {
-                var propArgs = e as PropertyChangedEventArgs;
-
                 if (InstanceReference.Target == sender
-                    && propArgs != null
-                    && _bindingReference != null
+                    && e is PropertyChangedEventArgs
                     && _bindingReference.IsAlive
                     && _bindingReference.Target != null)
                 {
@@ -1412,10 +1449,7 @@ namespace Softeq.XToolkit.Bindings
 
                     binding.Detach();
 
-                    binding.Attach(
-                        binding.Source,
-                        binding.Target,
-                        binding.Mode);
+                    binding.Attach(binding.Source, binding.Target, binding.Mode);
 
                     return true;
                 }
@@ -1426,8 +1460,8 @@ namespace Softeq.XToolkit.Bindings
 
         internal class PropertyAndName
         {
-            public object Instance;
-            public string Name;
+            public object? Instance;
+            public string? Name;
         }
 
         internal class PropertyChangedEventListener : IWeakEventListener
@@ -1452,17 +1486,16 @@ namespace Softeq.XToolkit.Bindings
 
             public bool ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
             {
-                if (_bindingReference != null
-                    && _bindingReference.IsAlive
+                if (_bindingReference.IsAlive
                     && _bindingReference.Target != null)
                 {
                     var binding = (Binding<TSource, TTarget>) _bindingReference.Target;
 
                     if (_updateFromSourceToTarget)
                     {
-                        if (binding.PropertySource != null
-                            && binding.PropertySource.IsAlive
-                            && sender == binding.PropertySource.Target)
+                        if (binding._propertySource != null
+                            && binding._propertySource.IsAlive
+                            && sender == binding._propertySource.Target)
                         {
                             if (!binding._settingTargetToSource)
                             {
@@ -1474,9 +1507,9 @@ namespace Softeq.XToolkit.Bindings
                     }
                     else
                     {
-                        if (binding.PropertyTarget != null
-                            && binding.PropertyTarget.IsAlive
-                            && sender == binding.PropertyTarget.Target)
+                        if (binding._propertyTarget != null
+                            && binding._propertyTarget.IsAlive
+                            && sender == binding._propertyTarget.Target)
                         {
                             if (!binding._settingSourceToTarget)
                             {
@@ -1494,21 +1527,32 @@ namespace Softeq.XToolkit.Bindings
             }
         }
 
+        /// <summary>
+        ///     Extends delegate with additional properties.
+        /// </summary>
+        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Reviewed.")]
         public class DelegateInfo
         {
-            public Delegate Delegate;
+            /// <summary>
+            ///     The delegate instance.
+            /// </summary>
+            public Delegate? Delegate;
+
+            /// <summary>
+            ///     Indicates that this delegate should be used as default.
+            /// </summary>
             public bool IsDefault;
         }
 
-        private class SimpleConverter
+        private class WeakConverter
         {
-            private WeakFunc<TSource, TTarget> _convert;
-            private WeakFunc<TTarget, TSource> _convertBack;
+            private WeakFunc<TSource, TTarget>? _convert;
+            private WeakFunc<TTarget, TSource>? _convertBack;
 
+            [return: MaybeNull]
             public TTarget Convert(TSource value)
             {
-                if (_convert != null
-                    && _convert.IsAlive)
+                if (_convert is { IsAlive: true })
                 {
                     return _convert.Execute(value);
                 }
@@ -1523,10 +1567,10 @@ namespace Softeq.XToolkit.Bindings
                 }
             }
 
+            [return: MaybeNull]
             public TSource ConvertBack(TTarget value)
             {
-                if (_convertBack != null
-                    && _convertBack.IsAlive)
+                if (_convertBack is { IsAlive: true })
                 {
                     return _convertBack.Execute(value);
                 }
@@ -1551,12 +1595,13 @@ namespace Softeq.XToolkit.Bindings
                 _convertBack = new WeakFunc<TTarget, TSource>(convertBack);
             }
 
-            private TTo ConvertSafely<TFrom, TTo>(TFrom value)
+            [return: MaybeNull]
+            private static TTo ConvertSafely<TFrom, TTo>(TFrom value)
             {
                 try
                 {
                     var notNullableFromType = Nullable.GetUnderlyingType(typeof(TFrom));
-                    object notNullableValue = value;
+                    object? notNullableValue = value;
                     if (notNullableFromType != null)
                     {
                         if (value == null)

--- a/Softeq.XToolkit.Bindings/Extensions/BindableExtensions.cs
+++ b/Softeq.XToolkit.Bindings/Extensions/BindableExtensions.cs
@@ -8,6 +8,9 @@ using Softeq.XToolkit.Common.Converters;
 
 namespace Softeq.XToolkit.Bindings.Extensions
 {
+    /// <summary>
+    ///     Extensions for the Bindable components.
+    /// </summary>
     public static class BindableExtensions
     {
         /// <summary>
@@ -16,9 +19,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
         ///     to the source property. If the target implements INotifyPropertyChanged, has observable properties and
         ///     the BindingMode is TwoWay, the source will also be notified of changes to the target's properties.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type
+        ///     The type of the target property that is being data-bound. If the source type
         ///     is not the same as the target type, an automatic conversion will be attempted. However only
         ///     simple types can be converted. For more complex conversions, use the
         ///     <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
@@ -52,7 +55,7 @@ namespace Softeq.XToolkit.Bindings.Extensions
             Expression<Func<TTarget>> targetPropertyExpression,
             BindingMode mode = BindingMode.Default)
         {
-            var binding = source.SetBinding(sourcePropertyExpression, targetPropertyExpression, mode);
+            var binding = source.SetBinding(sourcePropertyExpression!, targetPropertyExpression, mode);
 
             SetBindingTo(source, binding);
 
@@ -68,9 +71,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
         ///     The method provides the ability for advanced configuration of internal
         ///     <see cref="Binding{TSource, TTarget}" /> object.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type
+        ///     The type of the target property that is being data-bound. If the source type
         ///     is not the same as the target type, an automatic conversion will be attempted. However only
         ///     simple types can be converted. For more complex conversions, use the
         ///     <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
@@ -110,9 +113,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
             BindingMode mode,
             Func<Binding<TSource, TTarget>, Binding> configure)
         {
-            var binding = source.SetBinding(sourcePropertyExpression, targetPropertyExpression, mode);
+            var binding = source.SetBinding(sourcePropertyExpression!, targetPropertyExpression, mode);
 
-            var resultBinding = configure(binding);
+            var resultBinding = configure(binding!);
 
             SetBindingTo(source, resultBinding);
 
@@ -125,9 +128,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
         ///     to the source property. If the target implements INotifyPropertyChanged, has observable properties and
         ///     the BindingMode is TwoWay, the source will also be notified of changes to the target's properties.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type
+        ///     The type of the target property that is being data-bound. If the source type
         ///     is not the same as the target type, an automatic conversion will be attempted. However only
         ///     simple types can be converted. For more complex conversions, use the
         ///     <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
@@ -158,8 +161,8 @@ namespace Softeq.XToolkit.Bindings.Extensions
             IConverter<TTarget, TSource> converter)
         {
             var binding = source
-                .SetBinding(sourcePropertyExpression, targetPropertyExpression)
-                .SetConverter(converter);
+                .SetBinding(sourcePropertyExpression!, targetPropertyExpression)
+                .SetConverter(converter!);
 
             SetBindingTo(source, binding);
 
@@ -172,9 +175,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
         ///     to the source property. If the target implements INotifyPropertyChanged, has observable properties and
         ///     the BindingMode is TwoWay, the source will also be notified of changes to the target's properties.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data-bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound. If the source type
+        ///     The type of the target property that is being data-bound. If the source type
         ///     is not the same as the target type, an automatic conversion will be attempted. However only
         ///     simple types can be converted. For more complex conversions, use the
         ///     <see cref="Binding{TSource, TTarget}.ConvertSourceToTarget" />
@@ -213,8 +216,8 @@ namespace Softeq.XToolkit.Bindings.Extensions
             IConverter<TTarget, TSource> converter)
         {
             var binding = source
-                .SetBinding(sourcePropertyExpression, targetPropertyExpression, mode)
-                .SetConverter(converter);
+                .SetBinding(sourcePropertyExpression!, targetPropertyExpression, mode)
+                .SetConverter(converter!);
 
             SetBindingTo(source, binding);
 
@@ -250,7 +253,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
             Expression<Func<TSource>> sourcePropertyExpression,
             Action<TSource> action)
         {
-            var binding = source.SetBinding(sourcePropertyExpression).WhenSourceChanges(action);
+            var binding = source
+                .SetBinding(sourcePropertyExpression!)
+                .WhenSourceChanges(action!);
 
             SetBindingTo(source, binding);
 
@@ -294,7 +299,9 @@ namespace Softeq.XToolkit.Bindings.Extensions
             Action<TSource> action,
             BindingMode mode)
         {
-            var binding = source.SetBinding(sourcePropertyExpression, mode).WhenSourceChanges(action);
+            var binding = source
+                .SetBinding(sourcePropertyExpression!, mode)
+                .WhenSourceChanges(action!);
 
             SetBindingTo(source, binding);
 
@@ -304,9 +311,7 @@ namespace Softeq.XToolkit.Bindings.Extensions
         /// <summary>
         ///     Detach all bindings of the source.
         /// </summary>
-        /// <param name="source">
-        ///     The source of the bindings.
-        /// </param>
+        /// <param name="source">The source of the bindings.</param>
         public static void DetachBindings(this IBindingsOwner source)
         {
             source.Bindings?.DetachAllAndClear();

--- a/Softeq.XToolkit.Bindings/IBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings/IBindingFactory.cs
@@ -2,12 +2,16 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
 
 namespace Softeq.XToolkit.Bindings
 {
+    /// <summary>
+    ///     Defines methods for creating bindings.
+    /// </summary>
     public interface IBindingFactory
     {
         /// <summary>
@@ -33,9 +37,9 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="targetNullValue">
         ///     The value to use when the binding is unable to return a value.
         /// </param>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound.
+        ///     The type of the target property that is being data bound.
         ///     If the source type is not the same as the target type, an automatic conversion will be attempted.
         ///     However only simple types can be converted. For more complex conversions,
         ///     use the <see cref="Binding{TSource,TTarget}.ConvertSourceToTarget" />
@@ -49,8 +53,8 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default!,
-            TSource targetNullValue = default!);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <summary>
         ///     Creates a new instance of the <see cref="Binding{TSource,TTarget}"/> class
@@ -74,9 +78,9 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="targetNullValue">
         ///     The value to use when the binding is unable to return a value.
         /// </param>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound.
+        ///     The type of the target property that is being data bound.
         ///     If the source type is not the same as the target type, an automatic conversion will be attempted.
         ///     However only simple types can be converted. For more complex conversions,
         ///     use the <see cref="Binding{TSource,TTarget}.ConvertSourceToTarget" />
@@ -89,8 +93,8 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             Expression<Func<TTarget>>? targetPropertyExpression = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default!,
-            TSource targetNullValue = default!);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <summary>
         ///     Creates a new instance of the <see cref="Binding{TSource,TTarget}"/> class
@@ -114,9 +118,9 @@ namespace Softeq.XToolkit.Bindings
         /// <param name="targetNullValue">
         ///     The value to use when the binding is unable to return a value.
         /// </param>
-        /// <typeparam name="TSource">The type of the source property that is being databound.</typeparam>
+        /// <typeparam name="TSource">The type of the source property that is being data bound.</typeparam>
         /// <typeparam name="TTarget">
-        ///     The type of the target property that is being databound.
+        ///     The type of the target property that is being data bound.
         ///     If the source type is not the same as the target type, an automatic conversion will be attempted.
         ///     However only simple types can be converted. For more complex conversions,
         ///     use the <see cref="Binding{TSource,TTarget}.ConvertSourceToTarget" />
@@ -129,8 +133,8 @@ namespace Softeq.XToolkit.Bindings
             object? target = null,
             string? targetPropertyName = null,
             BindingMode mode = BindingMode.Default,
-            TSource fallbackValue = default!,
-            TSource targetNullValue = default!);
+            [MaybeNull] TSource fallbackValue = default!,
+            [MaybeNull] TSource targetNullValue = default!);
 
         /// <summary>
         ///    Creates a new instance of the <see cref="T:System.EventHandler"/> that will wrap the command.
@@ -167,7 +171,7 @@ namespace Softeq.XToolkit.Bindings
             string eventName,
             Type elementType,
             ICommand command,
-            Binding<T, T> castedBinding);
+            Binding<T, T>? castedBinding);
 
         /// <summary>
         ///    Creates a new instance of the <see cref="T:System.EventHandler`1"/> that will wrap the command.
@@ -225,9 +229,14 @@ namespace Softeq.XToolkit.Bindings
             string eventName,
             Type elementType,
             ICommand command,
-            Binding<T, T> castedBinding);
+            Binding<T, T>? castedBinding);
 
-        string GetDefaultEventNameForControl(Type type);
+        /// <summary>
+        ///     Gets the name of the default event to use when binding, based on the <paramref name="type"/> of control.
+        /// </summary>
+        /// <param name="type">The type of control.</param>
+        /// <returns>The name of the control event.</returns>
+        string? GetDefaultEventNameForControl(Type type);
 
         /// <summary>
         ///     Provides the way for command to give a feedback to the element when CanExecuteChanged event is triggered.
@@ -239,6 +248,6 @@ namespace Softeq.XToolkit.Bindings
         ///     that will passed to the <see cref="T:System.Windows.Input.ICommand"/>. Used to determine new value of CanExecute.
         /// </param>
         /// <typeparam name="T">Type of command parameter.</typeparam>
-        void HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T> commandParameterBinding);
+        void HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T>? commandParameterBinding);
     }
 }

--- a/Softeq.XToolkit.Bindings/UpdateTriggerMode.cs
+++ b/Softeq.XToolkit.Bindings/UpdateTriggerMode.cs
@@ -9,14 +9,12 @@ namespace Softeq.XToolkit.Bindings
     public enum UpdateTriggerMode
     {
         /// <summary>
-        ///     Defines that the binding should be updated when the control
-        ///     loses the focus.
+        ///     Defines that the binding should be updated when the control loses the focus.
         /// </summary>
         LostFocus,
 
         /// <summary>
-        ///     Defines that the binding should be updated when the control's
-        ///     bound property changes.
+        ///     Defines that the binding should be updated when the control's bound property changes.
         /// </summary>
         PropertyChanged
     }


### PR DESCRIPTION
### Description

Enable nullability for:
- `BindingGeneric`
- `AppleBinding`
- `DroidBinding`
- `BindingExtesnions`
- `BaseBindingFactory`
- `AppleBindingFactory`
- `DroidBindingFactory`

Added more docs.

### Issues Resolved

- Reviewed. It's OK by design. Closes #268 
- Added more docs for #447 

### API Changes
 
 None

### Platforms Affected

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
