### PR TITLE
Sync Playground.Droid for MaterialDesign 1.4

### DIFF
--- a/samples/Playground.Forms/Playground.Forms.Droid/DroidBootstrapper.cs
+++ b/samples/Playground.Forms/Playground.Forms.Droid/DroidBootstrapper.cs
@@ -10,7 +10,10 @@ using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.Permissions;
 using Softeq.XToolkit.Permissions.Droid;
 using Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract;
+using Softeq.XToolkit.WhiteLabel.Droid.Providers;
+using Softeq.XToolkit.WhiteLabel.Droid.Services;
 using Softeq.XToolkit.WhiteLabel.Interfaces;
+using Softeq.XToolkit.WhiteLabel.Location;
 using Softeq.XToolkit.WhiteLabel.Services;
 
 namespace Playground.Forms.Droid
@@ -33,14 +36,12 @@ namespace Playground.Forms.Droid
             builder.Singleton<RequestResultHandler, IPermissionRequestHandler>();
 
             // launcher
-            // YP: conflict between Google.Android.Material from Xamarin.Forms (latest) and WL.Droid (old stable)
-            // builder.Singleton<EssentialsContextProvider, IContextProvider>();
+            builder.Singleton<EssentialsContextProvider, IContextProvider>();
             // builder.Singleton<DroidLauncherService, ILauncherService>();
             builder.Singleton<EssentialsLauncherService, ILauncherService>();
 
             // location
-            // YP: conflict between Google.Android.Material from Xamarin.Forms (latest) and WL.Droid (old stable)
-            // builder.Singleton<DroidLocationService, ILocationService>();
+            builder.Singleton<DroidLocationService, ILocationService>();
 
             // remote
             // - example of using custom primary http message handler

--- a/samples/Playground.Forms/Playground.Forms.Droid/Playground.Forms.Droid.csproj
+++ b/samples/Playground.Forms/Playground.Forms.Droid/Playground.Forms.Droid.csproj
@@ -105,6 +105,10 @@
       <Project>{c8da5ea8-703b-481f-9ed8-ab3ad29e5409}</Project>
       <Name>Softeq.XToolkit.Permissions</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Softeq.XToolkit.WhiteLabel.Droid\Softeq.XToolkit.WhiteLabel.Droid.csproj">
+      <Project>{7f44f0f6-8396-42d0-8a1b-dc40ce8c478c}</Project>
+      <Name>Softeq.XToolkit.WhiteLabel.Droid</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Softeq.XToolkit.WhiteLabel.Forms\Softeq.XToolkit.WhiteLabel.Forms.csproj">
       <Project>{ee5e06cb-17b2-4eca-bc82-dd06d60eab6d}</Project>
       <Name>Softeq.XToolkit.WhiteLabel.Forms</Name>


### PR DESCRIPTION

Sync Playground.Droid:
- Resolve conflict between Google.Android.Material from Xamarin.Forms (latest) and WL.Droid (old stable)

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
