### PR TITLE
Fix closing ios dialogs

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
@@ -172,7 +172,8 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
                 try
                 {
                     presentedController.View?.EndEditing(true);
-                    presentedController.DismissViewController(true, () => tcs.TrySetResult(true));
+                    presentedController.PresentingViewController
+                        .DismissViewController(true, () => tcs.TrySetResult(true));
                 }
                 catch (Exception ex)
                 {

--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
@@ -154,11 +154,18 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
 
             Execute.BeginOnUIThread(() =>
             {
-                var targetViewController = _viewLocator.GetView(viewModel);
-                var topViewController = _viewLocator.GetTopViewController();
-                topViewController.View?.EndEditing(true);
-                topViewController.PresentViewController(targetViewController, true, null);
-                tcs.TrySetResult(targetViewController);
+                try
+                {
+                    var targetViewController = _viewLocator.GetView(viewModel);
+                    var topViewController = _viewLocator.GetTopViewController();
+                    topViewController.View?.EndEditing(true);
+                    topViewController.PresentViewController(targetViewController, true, () => tcs.TrySetResult(targetViewController));
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex);
+                    tcs.TrySetException(ex);
+                }
             });
 
             return tcs.Task;

--- a/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/Services/StoryboardDialogsService.cs
@@ -148,9 +148,9 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
             return new PresentationResult(presentedViewController, null);
         }
 
-        private Task<PresentedViewController> PresentModalViewControllerAsync(object viewModel)
+        private Task<UIViewController> PresentModalViewControllerAsync(object viewModel)
         {
-            var tcs = new TaskCompletionSource<PresentedViewController>();
+            var tcs = new TaskCompletionSource<UIViewController>();
 
             Execute.BeginOnUIThread(() =>
             {
@@ -158,21 +158,21 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
                 var topViewController = _viewLocator.GetTopViewController();
                 topViewController.View?.EndEditing(true);
                 topViewController.PresentViewController(targetViewController, true, null);
-                tcs.TrySetResult(new PresentedViewController(topViewController, targetViewController));
+                tcs.TrySetResult(targetViewController);
             });
 
             return tcs.Task;
         }
 
-        private Task<bool> DismissViewControllerAsync(PresentedViewController controllerRequest)
+        private Task<bool> DismissViewControllerAsync(UIViewController presentedController)
         {
             var tcs = new TaskCompletionSource<bool>();
             Execute.BeginOnUIThread(() =>
             {
                 try
                 {
-                    controllerRequest.Modal.View?.EndEditing(true);
-                    controllerRequest.Parent.DismissViewController(true, () => tcs.TrySetResult(true));
+                    presentedController.View?.EndEditing(true);
+                    presentedController.DismissViewController(true, () => tcs.TrySetResult(true));
                 }
                 catch (Exception ex)
                 {
@@ -185,26 +185,14 @@ namespace Softeq.XToolkit.WhiteLabel.iOS.Services
 
         private class PresentationResult
         {
-            public PresentationResult(PresentedViewController viewController, object? result)
+            public PresentationResult(UIViewController viewController, object? result)
             {
                 ViewController = viewController;
                 Result = result;
             }
 
-            public PresentedViewController ViewController { get; }
+            public UIViewController ViewController { get; }
             public object? Result { get; }
-        }
-
-        private class PresentedViewController
-        {
-            public PresentedViewController(UIViewController parent, UIViewController modal)
-            {
-                Parent = parent;
-                Modal = modal;
-            }
-
-            public UIViewController Parent { get; }
-            public UIViewController Modal { get; }
         }
     }
 }


### PR DESCRIPTION
<!-- WAIT! 
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

It is possible that the controller that presented the dialog has been removed from the navigation stack, so calling `DismissViewController` on it will not close the previously shown dialog. ~~We can call `DismissViewController` on the shown `ViewController` and `UIKit` will do all the work for us~~ (as it turned out, not always - in the case if the dismiss controller, that presented another one, then it will not dismiss itself, but the presented one)
https://developer.apple.com/documentation/uikit/uiviewcontroller/1621505-dismiss

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before
![Simulator Screen Recording - iPhone 8 - 2022-04-13 at 19 00 29](https://user-images.githubusercontent.com/14176511/163223140-12b4bae7-030e-41b1-92f4-cceb6aea6175.gif)

After
![Simulator Screen Recording - iPhone 8 - 2022-04-13 at 19 01 10](https://user-images.githubusercontent.com/14176511/163223149-7657f07b-e7eb-4c5b-bf68-40c7495106c0.gif)

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
