### PR TITLE
Add registration and resolving by service key

### DIFF
--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainer.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainer.cs
@@ -1,4 +1,4 @@
-// Developed by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 using System;
@@ -23,6 +23,20 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
         ///     Instance of the <typeparamref name="TService"/>.
         /// </returns>
         TService Resolve<TService>(params object[] parameters) where TService : notnull;
+
+        /// <summary>
+        ///     Gets the instance of the specified service with the specified service key.
+        /// </summary>
+        /// <typeparam name="TService">
+        ///     Type of service to resolve.
+        /// </typeparam>
+        /// <param name="serviceKey">
+        ///     Service key.
+        /// </param>
+        /// <returns>
+        ///     Instance of the <typeparamref name="TService"/>.
+        /// </returns>
+        TService ResolveByKey<TService>(object serviceKey) where TService : notnull;
 
         [Obsolete("Use Resolve<Lazy<TService>> instead.")]
         Lazy<TService> ResolveLazy<TService>() where TService : notnull;

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Abstract/IContainerBuilder.cs
@@ -1,4 +1,4 @@
-// Developed by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 using System;
@@ -28,6 +28,9 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Abstract
         void Singleton<TService>(IfRegistered ifRegistered = IfRegistered.AppendNew);
 
         void Singleton<TService>(Func<IContainer, TService> func, IfRegistered ifRegistered = IfRegistered.AppendNew);
+
+        void Singleton<TImplementation, TService>(object serviceKey)
+             where TImplementation : TService;
 
         [Obsolete("Please use app lifecycle callbacks to access configured container")]
         void RegisterBuildCallback(Action<IContainer> action);

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerAdapter.cs
@@ -1,4 +1,4 @@
-// Developed by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 using System;
@@ -37,6 +37,17 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
             }
 
             return _container.Resolve<TService>(parameters);
+        }
+
+        /// <inheritdoc/>
+        public TService ResolveByKey<TService>(object serviceKey) where TService : notnull
+        {
+            if (_container == null)
+            {
+                throw new InvalidOperationException("DryIocContainerAdapter is not initialized");
+            }
+
+            return _container.Resolve<TService>(serviceKey: serviceKey);
         }
 
         /// <inheritdoc/>

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -1,4 +1,4 @@
-// Developed by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 using System;
@@ -81,6 +81,13 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         public void Singleton<TService>(Func<IContainer, TService> func, IfRegistered ifRegistered = IfRegistered.AppendNew)
         {
             RegisterInternal(func, Reuse.Singleton);
+        }
+
+        /// <inheritdoc />
+        public void Singleton<TImplementation, TService>(object serviceKey)
+           where TImplementation : TService
+        {
+            _dryContainer.Register<TService, TImplementation>(reuse: Reuse.Singleton, serviceKey: serviceKey);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Goal
1. `DryIocContainerBuilder` class did not have a method for registering service by service key.
2. `DryIocContainerAdapter` class did not have a method for resolving service by service key.

## Implemented
1. Method for registering service by service key as singleton in the `DryIocContainerBuilder`.
2. Method for resolving service by service key in the `DryIocContainerAdapter`.