### PR TITLE
Permission manager changed

### DIFF
--- a/Softeq.XToolkit.Permissions.Droid/PermissionsManager.cs
+++ b/Softeq.XToolkit.Permissions.Droid/PermissionsManager.cs
@@ -23,17 +23,17 @@ namespace Softeq.XToolkit.Permissions.Droid
         }
 
         /// <inheritdoc />
+        public virtual Task<PermissionStatus> CheckAsync<T>()
+            where T : BasePermission, new()
+        {
+            return _permissionsService.CheckPermissionsAsync<T>();
+        }
+
+        /// <inheritdoc />
         public Task<PermissionStatus> CheckWithRequestAsync<T>()
             where T : BasePermission, new()
         {
             return CommonCheckWithRequestAsync<T>();
-        }
-
-        /// <inheritdoc />
-        public Task<PermissionStatus> CheckAsync<T>()
-            where T : BasePermission, new()
-        {
-            return _permissionsService.CheckPermissionsAsync<T>();
         }
 
         /// <inheritdoc />
@@ -43,7 +43,7 @@ namespace Softeq.XToolkit.Permissions.Droid
                                         ?? throw new ArgumentNullException(nameof(permissionsDialogService));
         }
 
-        private bool IsPermissionDeniedEver<T>()
+        protected bool IsPermissionDeniedEver<T>()
             where T : BasePermission
         {
             return Preferences.Get(GetPermissionDeniedEverKey<T>(), false);


### PR DESCRIPTION
<!-- WAIT! 
     It's not possible for android to get Unknown status from permission manager like iOS. To have ability to override behaviour and implement own logic for unknown status it is needed to expose interface.
     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 - PermissionManager.CheckAsync<T>

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
