### PR TITLE
pending intent fixed

### DIFF
--- a/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/NotificationsHelper.cs
@@ -115,11 +115,11 @@ namespace Softeq.XToolkit.PushNotifications.Droid
             {
                 var stackBuilder = TaskStackBuilder.Create(context);
                 stackBuilder.AddNextIntentWithParentStack(intent);
-                return stackBuilder.GetPendingIntent(0, PendingIntentFlags.UpdateCurrent);
+                return stackBuilder.GetPendingIntent(0, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
             }
             else
             {
-                return PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent);
+                return PendingIntent.GetActivity(context, 0, intent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
             }
         }
 


### PR DESCRIPTION
### Description
In android 12 Pending Intent should have Mutable or Immutable flag. Immutable choose because intent is not changed and it's recommended to use immutable if possible 

Added:
 - Immutable flag

### Platforms Affected

- Android



### PR Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
