### PR TITLE
Conditional Assert to warn about compiler-generated targets

### DIFF
--- a/Softeq.XToolkit.Common/Weak/WeakDelegate.cs
+++ b/Softeq.XToolkit.Common/Weak/WeakDelegate.cs
@@ -2,7 +2,9 @@
 // http://www.softeq.com
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 
 namespace Softeq.XToolkit.Common.Weak
@@ -27,6 +29,7 @@ namespace Softeq.XToolkit.Common.Weak
                 return;
             }
 
+            AssertCompilerGeneratedTarget(@delegate);
             DelegateTargetReference = new WeakReference(@delegate.Target);
             if (!ReferenceEquals(@delegate.Target, target))
             {
@@ -136,6 +139,19 @@ namespace Softeq.XToolkit.Common.Weak
             return IsCustomTargetAlive
                 ? DelegateTargetReference?.Target
                 : null;
+        }
+
+        [Conditional("DEBUG")]
+        private static void AssertCompilerGeneratedTarget(TDelegate @delegate)
+        {
+            var isCompilerGenerated = @delegate.Target.GetType().GetCustomAttribute<CompilerGeneratedAttribute>() != null;
+            if (!isCompilerGenerated)
+            {
+                return;
+            }
+
+            Debug.WriteLine("WeakDelegate's target is compiler-generated, it might be garbage-collected");
+            Debug.WriteLine(Environment.StackTrace);
         }
     }
 }


### PR DESCRIPTION
### Description

Adds a conditional (DEBUG-only) assertion for cases, when weak delegates are used with potentially risky lambda expressions. Warning message will be propagated to the Debug Console if the target if the delegate is non-static class with `[CompilerGenerated]` attribute, specifically:
- if lambda has only static references. In this case compiler generates a singleton class, which is never garbage collected, so it is more of a false alarm;
- if lambda has some references to local variables. In this case compiler generates a class and creates an instance of this class, never keeping any hard reference to it - so it might be garbage collected at any moment.

### API Changes
 
 None

### Platforms Affected

- Core (all platforms)

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
