### PR TITLE
Expose rules to configure container outside

### DIFF
--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -23,20 +23,20 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         /// <summary>
         ///     Initializes a new instance of the <see cref="DryIocContainerBuilder"/> class.
         /// </summary>
-        /// <param name="rules">
-        ///     Custom <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
-        ///     <see cref="DefaultRules"/> will be used if the value is <c>null</c>.
-        /// </param>
-        public DryIocContainerBuilder(Rules? rules = null)
+        public DryIocContainerBuilder()
         {
-            _dryContainer = new Container(rules ?? DefaultRules);
+            _dryContainer = new Container(CreateContainerRules());
             _buildActions = new List<Action<IContainer>>();
         }
 
         /// <summary>
-        ///     Gets default <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
+        ///     Gets <see cref="DryIoc.Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
         /// </summary>
-        public static Rules DefaultRules => Rules.Default;
+        /// <returns><see cref="DryIoc.Rules"/> associated with WL Container instance.</returns>
+        protected virtual Rules CreateContainerRules()
+        {
+            return Rules.Default;
+        }
 
         /// <inheritdoc />
         public void PerDependency<TImplementation, TService>(IfRegistered ifRegistered = IfRegistered.AppendNew)

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -21,22 +21,28 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         private IDryContainer _dryContainer;
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="DryIocContainerBuilder"/> class with <see cref="DefaultRules"/>.
+        /// </summary>
+        public DryIocContainerBuilder() : this(DefaultRules)
+        {
+        }
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="DryIocContainerBuilder"/> class.
         /// </summary>
-        public DryIocContainerBuilder()
+        /// <param name="rules">
+        ///     Custom <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
+        /// </param>
+        public DryIocContainerBuilder(Rules rules)
         {
-            _dryContainer = new Container(CreateContainerRules());
+            _dryContainer = new Container(rules);
             _buildActions = new List<Action<IContainer>>();
         }
 
         /// <summary>
-        ///     Gets <see cref="DryIoc.Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
+        ///     Gets default <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
         /// </summary>
-        /// <returns><see cref="DryIoc.Rules"/> associated with WL Container instance.</returns>
-        protected virtual Rules CreateContainerRules()
-        {
-            return Rules.Default.WithUseInterpretation();
-        }
+        public static Rules DefaultRules => Rules.Default.WithUseInterpretation();
 
         /// <inheritdoc />
         public void PerDependency<TImplementation, TService>(IfRegistered ifRegistered = IfRegistered.AppendNew)

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -35,7 +35,7 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         /// <returns><see cref="DryIoc.Rules"/> associated with WL Container instance.</returns>
         protected virtual Rules CreateContainerRules()
         {
-            return Rules.Default;
+            return Rules.Default.WithUseInterpretation();
         }
 
         /// <inheritdoc />

--- a/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
+++ b/Softeq.XToolkit.WhiteLabel/Bootstrapper/Containers/DryIocContainerBuilder.cs
@@ -23,11 +23,20 @@ namespace Softeq.XToolkit.WhiteLabel.Bootstrapper.Containers
         /// <summary>
         ///     Initializes a new instance of the <see cref="DryIocContainerBuilder"/> class.
         /// </summary>
-        public DryIocContainerBuilder()
+        /// <param name="rules">
+        ///     Custom <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
+        ///     <see cref="DefaultRules"/> will be used if the value is <c>null</c>.
+        /// </param>
+        public DryIocContainerBuilder(Rules? rules = null)
         {
-            _dryContainer = new Container();
+            _dryContainer = new Container(rules ?? DefaultRules);
             _buildActions = new List<Action<IContainer>>();
         }
+
+        /// <summary>
+        ///     Gets default <see cref="Rules" /> to alter behavior of internal <see cref="DryIoc.IContainer" />.
+        /// </summary>
+        public static Rules DefaultRules => Rules.Default;
 
         /// <inheritdoc />
         public void PerDependency<TImplementation, TService>(IfRegistered ifRegistered = IfRegistered.AppendNew)


### PR DESCRIPTION
### Description

Add `WithUseInterpretation` rule for fix crash on iOS.

### API Changes

Added:
 - `protected virtual Rules DryIocContainerBuilder.CreateContainerRules()`

### Platforms Affected

- Core (all platforms)

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
