### PR TITLE
Feature/android push token registration tracking

### DIFF
--- a/Softeq.XToolkit.PushNotifications/PushTokenSynchronizer.cs
+++ b/Softeq.XToolkit.PushNotifications/PushTokenSynchronizer.cs
@@ -21,7 +21,6 @@ namespace Softeq.XToolkit.PushNotifications
         private readonly IInternalSettings _internalSettings;
         private readonly IPushNotificationsHandler _pushNotificationsHandler;
         private readonly ILogger _logger;
-        private readonly SemaphoreSlim _semaphoreSlim;
 
         private CancellationTokenSource _doSendToServerCts;
 
@@ -46,7 +45,6 @@ namespace Softeq.XToolkit.PushNotifications
             _remotePushNotificationsService = remotePushNotificationsService;
 
             _logger = logManager.GetLogger<PushTokenSynchronizer>();
-            _semaphoreSlim = new SemaphoreSlim(1, 1);
         }
 
         protected virtual TimeSpan TokenSendRetryDelay { get; } = TimeSpan.FromSeconds(10);


### PR DESCRIPTION
### Description

 FCM has an auto-init feature enabled by default. It means that even if token has been deleted - it will be re-generated automatically, even if we are not subscribed for push-notifications. To preserve consistent behaviour for consumers that push token is provided only after subscription, we need to keep track of subscription status.

 NOTE: disabling auto-init might not be the option, as it also requires disabling Firebase Analytics
https://firebase.google.com/docs/cloud-messaging/android/client#prevent-auto-init

### API Changes

 None

### Platforms Affected

- Android

### Behavioral Changes

Consumers are no longer notified about new push tokens if the system is not subscribed from push notifications

### Before/After Screenshots

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
