### PR TITLE
Removed executePendingTransaction call from the navigation service

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
@@ -227,8 +227,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
                 .BeginTransaction()
                 .Replace(config.ContainerId, fragment);
 
-            var preparedTransaction = PrepareTransaction(transaction);
-
             PrepareTransaction(transaction).Commit();
         }
     }

--- a/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/Navigation/DroidFrameNavigationService.cs
@@ -229,15 +229,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid.Navigation
 
             var preparedTransaction = PrepareTransaction(transaction);
 
-            Execute.BeginOnUIThread(() =>
-            {
-                // Commit() method is executed asynchronously, so there's no way to know when will the transaction actually complete.
-                // At the same time, trying to execute multiple transactions at the same time will result in exception.
-                // ExecutePendingTransactions() should prevent exceptions even if two transactions are initiated at the same time
-                // IMPORTANT: ExecutePendingTransactions() is required to me called from UI thread
-                config.Manager.ExecutePendingTransactions();
-                preparedTransaction.Commit();
-            });
+            PrepareTransaction(transaction).Commit();
         }
     }
 }


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

Calling `executePendingTransaction` if we want to swap two fragments will very quickly lead to an `IllegalStateException: FragmentManager is already executing transactions`, so it should be removed. It looks like just calling `commit`, although asynchronous, won't cause problems, since each `commit` is queued and executed when the main thread is ready
[docs](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#commit())

### API Changes

 None

### Platforms Affected

- Android

### Behavioral/Visual Changes

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
