### PR TITLE
Fixed handling of silent push notifications on Android

### DIFF
--- a/Softeq.XToolkit.PushNotifications.Droid/Abstract/IDroidFirebaseMessagingHandler.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/Abstract/IDroidFirebaseMessagingHandler.cs
@@ -1,0 +1,25 @@
+﻿// Developed for PAWS-HALO by Softeq Development Corporation
+// http://www.softeq.com
+
+using Firebase.Messaging;
+
+namespace Softeq.XToolkit.PushNotifications.Abstract
+{
+    /// <summary>
+    /// Basic interface for the event handler from the <see cref="FirebaseMessagingService"/>
+    /// </summary>
+    internal interface IDroidFirebaseMessagingHandler
+    {
+        /// <summary>
+        ///    Callback called when push notification is received.
+        /// </summary>
+        /// <param name="message">Received remote message.</param>
+        void OnNotificationReceived(RemoteMessage message);
+
+        /// <summary>
+        ///     Callback called when push notification token has changed.
+        /// </summary>
+        /// <param name="token">New push notification token.</param>
+        void OnPushTokenRefreshed(string token);
+    }
+}

--- a/Softeq.XToolkit.PushNotifications.Droid/Abstract/IDroidFirebaseMessagingHandler.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/Abstract/IDroidFirebaseMessagingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Developed for PAWS-HALO by Softeq Development Corporation
+﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
 using Firebase.Messaging;

--- a/Softeq.XToolkit.PushNotifications.Droid/Services/DroidPushNotificationsConsumer.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/Services/DroidPushNotificationsConsumer.cs
@@ -6,6 +6,7 @@ using Android.Content;
 using AndroidX.Lifecycle;
 using Firebase.Messaging;
 using Softeq.XToolkit.Common.Logger;
+using Softeq.XToolkit.Common.Threading;
 using Softeq.XToolkit.PushNotifications.Abstract;
 using Softeq.XToolkit.PushNotifications.Droid.Abstract;
 
@@ -46,7 +47,10 @@ namespace Softeq.XToolkit.PushNotifications.Droid.Services
             _logger = logManager.GetLogger<DroidPushNotificationsConsumer>();
 
             _lifecycleObserver = new AppLifecycleObserver();
-            ProcessLifecycleOwner.Get().Lifecycle.AddObserver(_lifecycleObserver);
+            Execute.BeginOnUIThread(() =>
+            {
+                ProcessLifecycleOwner.Get().Lifecycle.AddObserver(_lifecycleObserver);
+            });
         }
 
         /// <inheritdoc />

--- a/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
+++ b/Softeq.XToolkit.PushNotifications.Droid/Softeq.XToolkit.PushNotifications.Droid.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Abstract\IActivityLauncherDelegate.cs" />
     <Compile Include="Abstract\IDroidPushNotificationPresenter.cs" />
+    <Compile Include="Abstract\IDroidFirebaseMessagingHandler.cs" />
     <Compile Include="Abstract\INotificationsSettingsProvider.cs" />
     <Compile Include="Abstract\IDroidPushNotificationsParser.cs" />
     <Compile Include="Abstract\IDroidPushNotificationsConsumer.cs" />
@@ -80,6 +81,10 @@
     <ProjectReference Include="..\Softeq.XToolkit.Common\Softeq.XToolkit.Common.csproj">
       <Project>{24588814-B93D-4528-8917-9C2A3C4E85CA}</Project>
       <Name>Softeq.XToolkit.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Softeq.XToolkit.WhiteLabel\Softeq.XToolkit.WhiteLabel.csproj">
+      <Project>{98c3b9f4-4e4f-4c0b-baa6-c61685e0ac49}</Project>
+      <Name>Softeq.XToolkit.WhiteLabel</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Softeq.XToolkit.PushNotifications.Droid/XFirebaseMessagingService.cs
+++ b/Softeq.XToolkit.PushNotifications.Droid/XFirebaseMessagingService.cs
@@ -4,28 +4,35 @@
 using System;
 using Android.App;
 using Firebase.Messaging;
+using Softeq.XToolkit.PushNotifications.Abstract;
+using Softeq.XToolkit.PushNotifications.Droid.Services;
+using Softeq.XToolkit.WhiteLabel;
 
 namespace Softeq.XToolkit.PushNotifications.Droid
 {
     [Service(Exported = true)]
     [IntentFilter(new[] { "com.google.firebase.MESSAGING_EVENT" })]
-    public class XFirebaseMessagingService : FirebaseMessagingService
+    internal class XFirebaseMessagingService : FirebaseMessagingService
     {
-        public static Action<string>? OnTokenRefreshed;
-        public static Action<RemoteMessage>? OnNotificationReceived;
+        private readonly IDroidFirebaseMessagingHandler _messagingHandler;
+
+        public XFirebaseMessagingService()
+        {
+            _messagingHandler = Dependencies.Container.Resolve<DroidPushNotificationsService>();
+        }
 
 #pragma warning disable RECS0133 // Parameter name differs in base declaration
         public override void OnNewToken(string token)
 #pragma warning restore RECS0133 // Parameter name differs in base declaration
         {
-            OnTokenRefreshed?.Invoke(token);
+            _messagingHandler.OnPushTokenRefreshed(token);
         }
 
 #pragma warning disable RECS0133 // Parameter name differs in base declaration
         public override void OnMessageReceived(RemoteMessage message)
 #pragma warning restore RECS0133 // Parameter name differs in base declaration
         {
-            OnNotificationReceived?.Invoke(message);
+            _messagingHandler.OnNotificationReceived(message);
         }
     }
 }


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

Now, when we close the Android app and send a silent notification (where `notification = null`) it will not be handled because the `OnNotificationReceived` delegate will be `null`, since no one will create/resolve the `DroidPushNotificationsService`. Since the `FirebaseMessagingService` is recreated if the app is closed, I simply added getting the `DroidPushNotificationsService` from the container since the container is also created since the `Android.App.Application` object is created when the `FirebaseMessagingService` is recreated

### API Changes

 None

### Platforms Affected

- Android

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
