### PR TITLE
Implemented differents methods for creating and caching HttpMessageHandler

### DIFF
--- a/Softeq.XToolkit.Remote.Tests/Client/HttpMessageHandlerProviderTests.cs
+++ b/Softeq.XToolkit.Remote.Tests/Client/HttpMessageHandlerProviderTests.cs
@@ -12,9 +12,35 @@ namespace Softeq.XToolkit.Remote.Tests.Client
         [Fact]
         public void CreateDefaultHandler_Always_ReturnsHttpMessageHandler()
         {
+            var result = HttpMessageHandlerProvider.CreateOrGetCachedDefaultHandler();
+
+            Assert.IsAssignableFrom<HttpMessageHandler>(result);
+        }
+
+        [Fact]
+        public void CreateOrGetCachedDefaultHandler_Always_ReturnsHttpMessageHandler()
+        {
             var result = HttpMessageHandlerProvider.CreateDefaultHandler();
 
             Assert.IsAssignableFrom<HttpMessageHandler>(result);
+        }
+
+        [Fact]
+        public void CreateOrGetCachedDefaultHandler_Always_ReturnsSameHandler()
+        {
+            var firstHandler = HttpMessageHandlerProvider.CreateOrGetCachedDefaultHandler();
+            var secondHandler = HttpMessageHandlerProvider.CreateOrGetCachedDefaultHandler();
+
+            Assert.Equal(firstHandler, secondHandler);
+        }
+
+        [Fact]
+        public void CreateDefaultHandler_Always_ReturnsDifferentsHandler()
+        {
+            var firstHandler = HttpMessageHandlerProvider.CreateDefaultHandler();
+            var secondHandler = HttpMessageHandlerProvider.CreateDefaultHandler();
+
+            Assert.NotEqual(firstHandler, secondHandler);
         }
     }
 }

--- a/Softeq.XToolkit.Remote/Client/DefaultHttpMessageHandlerBuilder.cs
+++ b/Softeq.XToolkit.Remote/Client/DefaultHttpMessageHandlerBuilder.cs
@@ -13,7 +13,7 @@ namespace Softeq.XToolkit.Remote.Client
         ///     with default primary handler provided by <see cref="HttpMessageHandlerProvider"/>.
         /// </summary>
         public DefaultHttpMessageHandlerBuilder()
-            : this(HttpMessageHandlerProvider.CreateDefaultHandler()!)
+            : this(HttpMessageHandlerProvider.CreateOrGetCachedDefaultHandler()!)
         {
         }
 


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

Now, if we go in to get a new HttpMessageHandler for another HttpClient, we get the same HttpMessageHandler. And if HttpClient is disposed, then HttpMessageHandler will also be disposed, which will make other HttpClients not work

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 -->

Added:
 - bool HttpMessageHandlerProvider.CreateOrGetCachedDefaultHandler()

Changed:
 - bool HttpMessageHandlerProvider.CreateDefaultHandler()

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
