### PR TITLE
Fixed binding to ObservableRangeCollection.Count when calling RemoveRange

### DIFF
--- a/Softeq.XToolkit.Common/Collections/ObservableRangeCollection.cs
+++ b/Softeq.XToolkit.Common/Collections/ObservableRangeCollection.cs
@@ -303,6 +303,8 @@ namespace Softeq.XToolkit.Common.Collections
                     Items.Remove(item);
                 }
 
+                OnPropertyChanged(EventArgsCache.CountPropertyChanged);
+                OnPropertyChanged(EventArgsCache.IndexerPropertyChanged);
                 OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
 
                 return;


### PR DESCRIPTION
…ange

<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes binding to ObservableRangeCollection.Count when calling RemoveRange

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 -->

 None

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [ ] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
