### PR TITLE
Added unsubscribing from CanExecute-related events when disposing SetCommandWithDisposing subscription

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
@@ -7,7 +7,7 @@ using Android.Views;
 using AndroidX.RecyclerView.Widget;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Bindings.Extensions;
-using Softeq.XToolkit.Common.Extensions;
+using Softeq.XToolkit.Common.Disposables;
 using Softeq.XToolkit.Common.Weak;
 
 #nullable disable
@@ -17,12 +17,13 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
     public abstract class BindableViewHolder<TViewModel>
         : RecyclerView.ViewHolder, IBindableViewHolder
     {
-        private readonly List<IDisposable> _commandsSubscriptions = new();
+        private readonly DisposableSubscriptionsComponent _subscriptionsComponent;
 
         private IDisposable _itemViewClickSubscription;
 
         protected BindableViewHolder(View itemView) : base(itemView)
         {
+            _subscriptionsComponent = new DisposableSubscriptionsComponent(SetCommandsWithDisposing);
         }
 
         public event EventHandler ItemClicked;
@@ -66,16 +67,14 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public virtual void DoAttachBindings()
         {
-            var commandsSubscriptions = SetCommandsWithDisposing();
-            _commandsSubscriptions.AddRange(commandsSubscriptions);
+            _subscriptionsComponent.CreateSubscriptions();
         }
 
         public virtual void DoDetachBindings()
         {
             this.DetachBindings();
 
-            _commandsSubscriptions.Apply(x => x.Dispose());
-            _commandsSubscriptions.Clear();
+            _subscriptionsComponent.DisposeSubscriptions();
         }
 
         protected virtual IEnumerable<IDisposable> SetCommandsWithDisposing()

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
@@ -7,6 +7,7 @@ using Android.Views;
 using AndroidX.RecyclerView.Widget;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Bindings.Extensions;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.Common.Weak;
 
 #nullable disable
@@ -16,6 +17,8 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
     public abstract class BindableViewHolder<TViewModel>
         : RecyclerView.ViewHolder, IBindableViewHolder
     {
+        private readonly List<IDisposable> _commandsSubscriptions = new();
+
         private IDisposable _itemViewClickSubscription;
 
         protected BindableViewHolder(View itemView) : base(itemView)
@@ -63,11 +66,21 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public virtual void DoAttachBindings()
         {
+            var commandsSubscriptions = SetCommandsWithDisposing();
+            _commandsSubscriptions.AddRange(commandsSubscriptions);
         }
 
         public virtual void DoDetachBindings()
         {
             this.DetachBindings();
+
+            _commandsSubscriptions.Apply(x => x.Dispose());
+            _commandsSubscriptions.Clear();
+        }
+
+        protected virtual IEnumerable<IDisposable> SetCommandsWithDisposing()
+        {
+            return [];
         }
     }
 }

--- a/Softeq.XToolkit.Bindings.Droid/DroidBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings.Droid/DroidBindingFactory.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Windows.Input;
 using Android.Views;
 using Android.Widget;
+using Softeq.XToolkit.Common.Disposables;
 using Softeq.XToolkit.Common.Threading;
 
 namespace Softeq.XToolkit.Bindings.Droid
@@ -147,18 +148,20 @@ namespace Softeq.XToolkit.Bindings.Droid
         }
 
         /// <inheritdoc />
-        public override void HandleCommandCanExecute<T>(
+        public override IDisposable HandleCommandCanExecute<T>(
             object element,
             ICommand command,
             Binding<T, T>? commandParameterBinding)
         {
             if (element is View view)
             {
-                HandleViewEnabled(view, command, commandParameterBinding);
+                return HandleViewEnabled(view, command, commandParameterBinding);
             }
+
+            return Disposable.Create(() => { });
         }
 
-        private static void HandleViewEnabled<T>(
+        private static IDisposable HandleViewEnabled<T>(
             View view,
             ICommand command,
             Binding<T, T>? commandParameterBinding)
@@ -171,20 +174,32 @@ namespace Softeq.XToolkit.Bindings.Droid
                 () => view.Enabled = command.CanExecute(commandParameter));
 
             // set by CanExecute
-            command.CanExecuteChanged += (s, args) =>
-            {
-                Execute.BeginOnUIThread(
-                    () => view.Enabled = command.CanExecute(commandParameter));
-            };
+            command.CanExecuteChanged += OnCommandCanExecuteChanged;
 
             // set by bindable command parameter
             if (commandParameterBinding != null)
             {
-                commandParameterBinding.ValueChanged += (s, args) =>
+                commandParameterBinding.ValueChanged += OnCommandParameterBindingValueChanged;
+            }
+
+            return Disposable.Create(() =>
+            {
+                if (commandParameterBinding != null)
                 {
-                    Execute.BeginOnUIThread(
-                        () => view.Enabled = command.CanExecute(commandParameterBinding.Value));
-                };
+                    commandParameterBinding.ValueChanged -= OnCommandParameterBindingValueChanged;
+                }
+
+                command.CanExecuteChanged -= OnCommandCanExecuteChanged;
+            });
+
+            void OnCommandCanExecuteChanged(object? s, EventArgs args)
+            {
+                Execute.BeginOnUIThread(() => view.Enabled = command.CanExecute(commandParameter));
+            }
+
+            void OnCommandParameterBindingValueChanged(object? s, EventArgs args)
+            {
+                Execute.BeginOnUIThread(() => view.Enabled = command.CanExecute(commandParameterBinding.Value));
             }
         }
     }

--- a/Softeq.XToolkit.Bindings.iOS/AppleBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings.iOS/AppleBindingFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Windows.Input;
+using Softeq.XToolkit.Common.Disposables;
 using UIKit;
 
 namespace Softeq.XToolkit.Bindings.iOS
@@ -98,18 +99,20 @@ namespace Softeq.XToolkit.Bindings.iOS
         }
 
         /// <inheritdoc />
-        public override void HandleCommandCanExecute<T>(
+        public override IDisposable HandleCommandCanExecute<T>(
             object element,
             ICommand command,
             Binding<T, T>? commandParameterBinding)
         {
             if (element is UIControl control)
             {
-                HandleControlEnabled(control, command, commandParameterBinding);
+                return HandleControlEnabled(control, command, commandParameterBinding);
             }
+
+            return Disposable.Create(() => { });
         }
 
-        private static void HandleControlEnabled<T>(
+        private static IDisposable HandleControlEnabled<T>(
             UIControl control,
             ICommand command,
             Binding<T, T>? commandParameterBinding)
@@ -122,20 +125,32 @@ namespace Softeq.XToolkit.Bindings.iOS
                 () => control.Enabled = command.CanExecute(commandParameter));
 
             // set by CanExecute
-            command.CanExecuteChanged += (s, args) =>
-            {
-                control.BeginInvokeOnMainThread(
-                    () => control.Enabled = command.CanExecute(commandParameter));
-            };
+            command.CanExecuteChanged += OnCommandCanExecuteChanged;
 
             // set by bindable command parameter
             if (commandParameterBinding != null)
             {
-                commandParameterBinding.ValueChanged += (s, args) =>
+                commandParameterBinding.ValueChanged += OnCommandParameterBindingValueChanged;
+            }
+
+            return Disposable.Create(() =>
+            {
+                if (commandParameterBinding != null)
                 {
-                    control.BeginInvokeOnMainThread(
-                        () => control.Enabled = command.CanExecute(commandParameterBinding.Value));
-                };
+                    commandParameterBinding.ValueChanged -= OnCommandParameterBindingValueChanged;
+                }
+
+                command.CanExecuteChanged -= OnCommandCanExecuteChanged;
+            });
+
+            void OnCommandCanExecuteChanged(object? s, EventArgs args)
+            {
+                control.BeginInvokeOnMainThread(() => control.Enabled = command.CanExecute(commandParameter));
+            }
+
+            void OnCommandParameterBindingValueChanged(object? s, EventArgs args)
+            {
+                control.BeginInvokeOnMainThread(() => control.Enabled = command.CanExecute(commandParameterBinding.Value));
             }
         }
     }

--- a/Softeq.XToolkit.Bindings/BindingExtensions.cs
+++ b/Softeq.XToolkit.Bindings/BindingExtensions.cs
@@ -565,9 +565,13 @@ namespace Softeq.XToolkit.Bindings
 
             e.AddEventHandler(element, handler);
 
-            HandleCommandCanExecute(element, command);
+            var canExecuteSubscriptions = HandleCommandCanExecute(element, command);
 
-            return Disposable.Create(() => e.RemoveEventHandler(element, handler));
+            return Disposable.Create(() =>
+            {
+                canExecuteSubscriptions.Dispose();
+                e.RemoveEventHandler(element, handler);
+            });
         }
 
         /// <inheritdoc cref="SetCommand(object,string,ICommand)" />
@@ -659,19 +663,19 @@ namespace Softeq.XToolkit.Bindings
             return info;
         }
 
-        private static void HandleCommandCanExecute(
+        private static IDisposable HandleCommandCanExecute(
             object element,
             ICommand command)
         {
-            HandleCommandCanExecute<object>(element, command);
+            return HandleCommandCanExecute<object>(element, command);
         }
 
-        private static void HandleCommandCanExecute<T>(
+        private static IDisposable HandleCommandCanExecute<T>(
             object element,
             ICommand command,
             Binding<T, T>? commandParameterBinding = null)
         {
-            BindingFactory.HandleCommandCanExecute(element, command, commandParameterBinding);
+            return BindingFactory.HandleCommandCanExecute(element, command, commandParameterBinding);
         }
     }
 }

--- a/Softeq.XToolkit.Bindings/BindingExtensions.cs
+++ b/Softeq.XToolkit.Bindings/BindingExtensions.cs
@@ -544,6 +544,14 @@ namespace Softeq.XToolkit.Bindings
             HandleCommandCanExecute(element, command, castedBinding);
         }
 
+        /// <inheritdoc cref="SetCommandWithDisposing(object,string,ICommand)" />
+        public static IDisposable SetCommandWithDisposing(
+            this object element,
+            ICommand command)
+        {
+            return SetCommandWithDisposing(element, string.Empty, command);
+        }
+
         /// <summary>
         ///     Sets a <see cref="T:System.Windows.Input.ICommand"/> to an object and actuates the command when a specific event is raised.
         ///     This method can only be used when the event uses a standard <see cref="T:System.EventHandler"/>.

--- a/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
+++ b/Softeq.XToolkit.Bindings/BindingFactoryBase.cs
@@ -49,7 +49,7 @@ namespace Softeq.XToolkit.Bindings
         public abstract string? GetDefaultEventNameForControl(Type type);
 
         /// <inheritdoc />
-        public abstract void HandleCommandCanExecute<T>(
+        public abstract IDisposable HandleCommandCanExecute<T>(
             object element,
             ICommand command,
             Binding<T, T>? commandParameterBinding);

--- a/Softeq.XToolkit.Bindings/IBindingFactory.cs
+++ b/Softeq.XToolkit.Bindings/IBindingFactory.cs
@@ -248,6 +248,7 @@ namespace Softeq.XToolkit.Bindings
         ///     that will passed to the <see cref="T:System.Windows.Input.ICommand"/>. Used to determine new value of CanExecute.
         /// </param>
         /// <typeparam name="T">Type of command parameter.</typeparam>
-        void HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T>? commandParameterBinding);
+        /// <returns>Disposable subscriptions to CanExecute related events.</returns>
+        IDisposable HandleCommandCanExecute<T>(object element, ICommand command, Binding<T, T>? commandParameterBinding);
     }
 }

--- a/Softeq.XToolkit.Common/Disposables/DisposableSubscriptionsComponent.cs
+++ b/Softeq.XToolkit.Common/Disposables/DisposableSubscriptionsComponent.cs
@@ -1,0 +1,45 @@
+﻿// Developed for PAWS-HALO by Softeq Development Corporation
+// http://www.softeq.com
+
+using System;
+using System.Collections.Generic;
+using Softeq.XToolkit.Common.Extensions;
+
+namespace Softeq.XToolkit.Common.Disposables;
+
+/// <summary>
+/// Provides a set of methods to create multiple subscriptions and dispose them when needed.
+/// Useful for base bindable views when it's needed to subscribe in OnAppearing and unsubscribe in OnDisappearing.
+/// </summary>
+public class DisposableSubscriptionsComponent
+{
+    private readonly Func<IEnumerable<IDisposable>> _funcCreateSubscriptions;
+    private readonly List<IDisposable> _subscriptions = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DisposableSubscriptionsComponent"/> class.
+    /// </summary>
+    /// <param name="funcCreateSubscriptions">Function which actually creates subscriptions.</param>
+    public DisposableSubscriptionsComponent(Func<IEnumerable<IDisposable>> funcCreateSubscriptions)
+    {
+        _funcCreateSubscriptions = funcCreateSubscriptions;
+    }
+
+    /// <summary>
+    /// Creates subscriptions and keeps them for future disposal.
+    /// </summary>
+    public void CreateSubscriptions()
+    {
+        var subscriptions = _funcCreateSubscriptions();
+        _subscriptions.AddRange(subscriptions);
+    }
+
+    /// <summary>
+    /// Disposes previously created subscriptions.
+    /// </summary>
+    public void DisposeSubscriptions()
+    {
+        _subscriptions.Apply(x => x.Dispose());
+        _subscriptions.Clear();
+    }
+}

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -16,7 +16,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
     public class FragmentBase<TViewModel> : Fragment, IBindable
         where TViewModel : ViewModelBase
     {
-        private IList<IDisposable> _commandsSubscriptions;
+        private IList<IDisposable> _commandsSubscriptions = new List<IDisposable>();
 
         public List<Binding> Bindings { get; } = new List<Binding>();
 
@@ -73,7 +73,6 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         protected virtual void DoAttachBindings()
         {
-            _commandsSubscriptions = new List<IDisposable>();
             var commands = SetCommands();
             if (commands != null)
             {

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -1,12 +1,14 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
+using System;
 using System.Collections.Generic;
 using Android.OS;
 using AndroidX.Fragment.App;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Bindings.Extensions;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.WhiteLabel.Mvvm;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid
@@ -14,6 +16,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
     public class FragmentBase<TViewModel> : Fragment, IBindable
         where TViewModel : ViewModelBase
     {
+        private IList<IDisposable> _commandsSubscriptions;
+
         public List<Binding> Bindings { get; } = new List<Binding>();
 
         public object DataContext { get; private set; } = default!;
@@ -69,11 +73,27 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         protected virtual void DoAttachBindings()
         {
+            _commandsSubscriptions = new List<IDisposable>();
+            var commands = SetCommands();
+            if (commands != null)
+            {
+                _commandsSubscriptions.AddRange(commands);
+            }
         }
 
         protected virtual void DoDetachBindings()
         {
             this.DetachBindings();
+            for (int i = 0; i < _commandsSubscriptions.Count; i++)
+            {
+                _commandsSubscriptions[i].Dispose();
+                _commandsSubscriptions.RemoveAt(i);
+            }
+        }
+
+        protected virtual IEnumerable<IDisposable>? SetCommands()
+        {
+            return default;
         }
 
         protected virtual void OnViewModelRestored()

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -88,9 +88,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             _commandsSubscriptions.Clear();
         }
 
-        protected virtual IEnumerable<IDisposable>? SetCommands()
+        protected virtual IList<IDisposable>? SetCommands()
         {
-            return default;
+            return new List<IDisposable>();
         }
 
         protected virtual void OnViewModelRestored()

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Android.OS;
 using AndroidX.Fragment.App;
 using Softeq.XToolkit.Bindings;
@@ -85,9 +86,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             _commandsSubscriptions.Clear();
         }
 
-        protected virtual IList<IDisposable> SetCommandsWithDisposing()
+        protected virtual IEnumerable<IDisposable> SetCommandsWithDisposing()
         {
-            return new List<IDisposable>();
+            return [];
         }
 
         protected virtual void OnViewModelRestored()

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Android.OS;
 using AndroidX.Fragment.App;
 using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Bindings.Extensions;
-using Softeq.XToolkit.Common.Extensions;
+using Softeq.XToolkit.Common.Disposables;
 using Softeq.XToolkit.WhiteLabel.Mvvm;
 
 namespace Softeq.XToolkit.WhiteLabel.Droid
@@ -17,7 +16,12 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
     public class FragmentBase<TViewModel> : Fragment, IBindable
         where TViewModel : ViewModelBase
     {
-        private readonly List<IDisposable> _commandsSubscriptions = new();
+        private readonly DisposableSubscriptionsComponent _subscriptionsComponent;
+
+        protected FragmentBase()
+        {
+            _subscriptionsComponent = new DisposableSubscriptionsComponent(SetCommandsWithDisposing);
+        }
 
         public List<Binding> Bindings { get; } = new List<Binding>();
 
@@ -74,16 +78,14 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         protected virtual void DoAttachBindings()
         {
-            var commandsSubscriptions = SetCommandsWithDisposing();
-            _commandsSubscriptions.AddRange(commandsSubscriptions);
+            _subscriptionsComponent.CreateSubscriptions();
         }
 
         protected virtual void DoDetachBindings()
         {
             this.DetachBindings();
 
-            _commandsSubscriptions.Apply(x => x.Dispose());
-            _commandsSubscriptions.Clear();
+            _subscriptionsComponent.DisposeSubscriptions();
         }
 
         protected virtual IEnumerable<IDisposable> SetCommandsWithDisposing()

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -83,11 +83,9 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
         protected virtual void DoDetachBindings()
         {
             this.DetachBindings();
-            for (int i = 0; i < _commandsSubscriptions.Count; i++)
-            {
-                _commandsSubscriptions[i].Dispose();
-                _commandsSubscriptions.RemoveAt(i);
-            }
+
+            _commandsSubscriptions.Apply(x => x.Dispose());
+            _commandsSubscriptions.Clear();
         }
 
         protected virtual IEnumerable<IDisposable>? SetCommands()

--- a/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.Droid/FragmentBase.cs
@@ -16,7 +16,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
     public class FragmentBase<TViewModel> : Fragment, IBindable
         where TViewModel : ViewModelBase
     {
-        private IList<IDisposable> _commandsSubscriptions = new List<IDisposable>();
+        private readonly List<IDisposable> _commandsSubscriptions = new();
 
         public List<Binding> Bindings { get; } = new List<Binding>();
 
@@ -73,11 +73,8 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
 
         protected virtual void DoAttachBindings()
         {
-            var commands = SetCommands();
-            if (commands != null)
-            {
-                _commandsSubscriptions.AddRange(commands);
-            }
+            var commandsSubscriptions = SetCommandsWithDisposing();
+            _commandsSubscriptions.AddRange(commandsSubscriptions);
         }
 
         protected virtual void DoDetachBindings()
@@ -88,7 +85,7 @@ namespace Softeq.XToolkit.WhiteLabel.Droid
             _commandsSubscriptions.Clear();
         }
 
-        protected virtual IList<IDisposable>? SetCommands()
+        protected virtual IList<IDisposable> SetCommandsWithDisposing()
         {
             return new List<IDisposable>();
         }


### PR DESCRIPTION

<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 -->

 None

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)
- iOS
- Android

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
