### PR TITLE
Fixes for new ios workload

### DIFF
--- a/Softeq.XToolkit.Bindings.iOS/Softeq.XToolkit.Bindings.iOS.csproj
+++ b/Softeq.XToolkit.Bindings.iOS/Softeq.XToolkit.Bindings.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-ios12.0</TargetFramework>
+    <TargetFramework>net8.0-ios17.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CreatePackage>false</CreatePackage>
   </PropertyGroup>

--- a/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
+++ b/Softeq.XToolkit.Common.iOS/Softeq.XToolkit.Common.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-ios12.0</TargetFramework>
+    <TargetFramework>net8.0-ios17.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CreatePackage>false</CreatePackage>
   </PropertyGroup>

--- a/azure-pipelines/templates/vars.yml
+++ b/azure-pipelines/templates/vars.yml
@@ -3,6 +3,6 @@
 # https://github.com/actions/runner-images
 
 variables:
-  XCODE_VERSION: 15.0.1
-  DOTNET_SDK_VERSION: 8.0.100
-  MACOS_VM_IMAGE: 'macos-13'
+  XCODE_VERSION: 15.4
+  DOTNET_SDK_VERSION: 8.0.303
+  MACOS_VM_IMAGE: 'macos-14'


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

When building a project, the output shows that .net8-ios12 is considered deprecated when using the new ios workload (17.5). In this pull-request changes to support the latest ios workload

### Issues Resolved
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- Fixed building with [iOS 17.5](https://github.com/xamarin/xamarin-macios/releases/tag/dotnet-8.0.1xx-xcode15.4-8018)

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 -->

 None

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
