### PR TITLE
Managing bindings in bindable RecyclerView adapter and view holders

### DIFF
--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -110,7 +110,8 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
         public void DoAttachBindings()
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            _existingBindableViewHolders.Where(x => x.DataContext != null)
+            _existingBindableViewHolders
+                .Where(x => !x.AreBindingsAttached && x.DataContext != null)
                 .Apply(x => x.DoAttachBindings());
         }
 

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -19,15 +19,16 @@ using Softeq.XToolkit.Common.Weak;
 
 namespace Softeq.XToolkit.Bindings.Droid.Bindable
 {
-    public abstract class BindableRecyclerViewAdapterBase<TItem, TItemHolder> : RecyclerView.Adapter
+    public abstract class BindableRecyclerViewAdapterBase<TItem, TItemHolder> : RecyclerView.Adapter, IBindableRecyclerViewAdapter
         where TItemHolder : BindableViewHolder<TItem>
     {
         protected readonly IList<FlatItem> _flatMapping = new List<FlatItem>();
+        private readonly List<IBindableViewHolder> _existingBindableViewHolders = new();
 
         protected IDisposable _subscription;
-        private protected ICommand<TItem> _itemClick;
+        private ICommand<TItem> _itemClick;
 
-        public BindableRecyclerViewAdapterBase(
+        protected BindableRecyclerViewAdapterBase(
             Type headerViewHolder,
             Type footerViewHolder)
         {
@@ -93,24 +94,48 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             base.OnViewDetachedFromWindow(holder);
         }
 
-        public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
+        public sealed override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
+        {
+            var result = DoCreateViewHolder(parent, viewType);
+
+            if (result is IBindableViewHolder bindableViewHolder)
+            {
+                _existingBindableViewHolders.Add(bindableViewHolder);
+            }
+
+            return result;
+        }
+
+        public void DoAttachBindings()
+        {
+            _existingBindableViewHolders.ForEach(x => x.DoAttachBindings());
+        }
+
+        public void DoDetachBindings()
+        {
+            _existingBindableViewHolders.ForEach(x => x.DoDetachBindings());
+        }
+
+        public void OnDestroy()
+        {
+            _subscription?.Dispose();
+            DoDetachBindings();
+            _existingBindableViewHolders.Clear();
+        }
+
+        protected virtual RecyclerView.ViewHolder DoCreateViewHolder(ViewGroup parent, int viewType)
         {
             var itemType = (ItemType) viewType;
 
-            switch (itemType)
+            return itemType switch
             {
-                case ItemType.Header:
-                    return OnCreateHeaderViewHolder(parent);
-
-                case ItemType.Item:
-                    return OnCreateItemViewHolder(parent, itemType);
-
-                case ItemType.Footer:
-                    return OnCreateFooterViewHolder(parent);
-
-                default:
-                    throw new ArgumentException($"Unable to create a view holder for \"{viewType}\" view type.", nameof(viewType));
-            }
+                ItemType.Header => OnCreateHeaderViewHolder(parent),
+                ItemType.Item => OnCreateItemViewHolder(parent, itemType),
+                ItemType.Footer => OnCreateFooterViewHolder(parent),
+                _ => throw new ArgumentException(
+                    $"Unable to create a view holder for \"{viewType}\" view type.",
+                    nameof(viewType))
+            };
         }
 
         public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
@@ -138,8 +163,6 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
             base.OnViewRecycled(holder);
         }
-
-        public void StopListeningToSourceUpdates() => _subscription?.Dispose();
 
         protected virtual RecyclerView.ViewHolder OnCreateHeaderViewHolder(ViewGroup parent)
         {
@@ -351,7 +374,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public override int ItemCount => _flatMapping.Count;
 
-        public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
+        protected override RecyclerView.ViewHolder DoCreateViewHolder(ViewGroup parent, int viewType)
         {
             var itemType = (ItemType) viewType;
 
@@ -363,7 +386,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
                     return OnCreateSectionFooterViewHolder(parent, ItemType.SectionFooter);
 
                 default:
-                    return base.OnCreateViewHolder(parent, viewType);
+                    return base.DoCreateViewHolder(parent, viewType);
             }
         }
 
@@ -396,7 +419,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            StopListeningToSourceUpdates();
+            OnDestroy();
         }
 
         protected void ReloadMapping()

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -13,6 +13,7 @@ using Softeq.XToolkit.Bindings.Extensions;
 using Softeq.XToolkit.Common.Collections;
 using Softeq.XToolkit.Common.Collections.EventArgs;
 using Softeq.XToolkit.Common.Commands;
+using Softeq.XToolkit.Common.Extensions;
 using Softeq.XToolkit.Common.Weak;
 
 #nullable disable
@@ -108,7 +109,9 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public void DoAttachBindings()
         {
-            _existingBindableViewHolders.ForEach(x => x.DoAttachBindings());
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            _existingBindableViewHolders.Where(x => x.DataContext != null)
+                .Apply(x => x.DoAttachBindings());
         }
 
         public void DoDetachBindings()

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableRecyclerViewAdapter.cs
@@ -116,7 +116,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             _existingBindableViewHolders.ForEach(x => x.DoDetachBindings());
         }
 
-        public void OnDestroy()
+        public void CleanUp()
         {
             _subscription?.Dispose();
             DoDetachBindings();
@@ -419,7 +419,7 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            OnDestroy();
+            CleanUp();
         }
 
         protected void ReloadMapping()

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
@@ -32,6 +32,8 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public object DataContext { get; private set; }
 
+        public bool AreBindingsAttached { get; private set; }
+
         protected TViewModel ViewModel => (TViewModel) DataContext;
 
         void IBindable.SetDataContext(object dataContext)
@@ -67,6 +69,12 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public virtual void DoAttachBindings()
         {
+            if (AreBindingsAttached)
+            {
+                return;
+            }
+
+            AreBindingsAttached = true;
             _subscriptionsComponent.CreateSubscriptions();
         }
 
@@ -75,6 +83,8 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             this.DetachBindings();
 
             _subscriptionsComponent.DisposeSubscriptions();
+
+            AreBindingsAttached = false;
         }
 
         protected virtual IEnumerable<IDisposable> SetCommandsWithDisposing()

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/BindableViewHolder.cs
@@ -69,11 +69,6 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
 
         public virtual void DoAttachBindings()
         {
-            if (AreBindingsAttached)
-            {
-                return;
-            }
-
             AreBindingsAttached = true;
             _subscriptionsComponent.CreateSubscriptions();
         }
@@ -83,7 +78,6 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
             this.DetachBindings();
 
             _subscriptionsComponent.DisposeSubscriptions();
-
             AreBindingsAttached = false;
         }
 

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableRecyclerViewAdapter.cs
@@ -7,5 +7,5 @@ public interface IBindableRecyclerViewAdapter
 {
     void DoAttachBindings();
     void DoDetachBindings();
-    void OnDestroy();
+    void CleanUp();
 }

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableRecyclerViewAdapter.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableRecyclerViewAdapter.cs
@@ -1,0 +1,11 @@
+﻿// Developed for PAWS-HALO by Softeq Development Corporation
+// http://www.softeq.com
+
+namespace Softeq.XToolkit.Bindings.Droid.Bindable;
+
+public interface IBindableRecyclerViewAdapter
+{
+    void DoAttachBindings();
+    void DoDetachBindings();
+    void OnDestroy();
+}

--- a/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableViewHolder.cs
+++ b/Softeq.XToolkit.Bindings.Droid/Bindable/IBindableViewHolder.cs
@@ -10,6 +10,8 @@ namespace Softeq.XToolkit.Bindings.Droid.Bindable
     {
         event EventHandler ItemClicked;
 
+        bool AreBindingsAttached { get; }
+
         void OnAttachedToWindow();
         void OnDetachedFromWindow();
         void OnViewRecycled();


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

Added possibility to 
- manually attach and detach bindings of all existing `ViewHolder`s managed by a `BindableRecyclerViewAdapter`;
- manually dispose all subscriptions inside `BindableRecyclerViewAdapter` when they are no longer needed (typically in `Fragment.OnDestroyView`.

### API Changes
Added:
```
interface IBindableRecyclerViewAdapter:
 - void DoAttachBindings()
 - void DoDetachBindings()
 - void CleanUp()
```

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
