### PR TITLE
Fixed nullability in IInternalSettings interface

### DIFF
--- a/Softeq.XToolkit.Common/Extensions/InternalSettingsExtensions.cs
+++ b/Softeq.XToolkit.Common/Extensions/InternalSettingsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Developed by Softeq Development Corporation
 // http://www.softeq.com
 
-using System.Diagnostics.CodeAnalysis;
 using Softeq.XToolkit.Common.Interfaces;
 
 namespace Softeq.XToolkit.Common.Extensions
@@ -12,7 +11,7 @@ namespace Softeq.XToolkit.Common.Extensions
             this IInternalSettings internalSettings,
             IJsonSerializer jsonSerializer,
             string key,
-            T value)
+            T? value)
         {
             if (value == null)
             {
@@ -24,14 +23,13 @@ namespace Softeq.XToolkit.Common.Extensions
             internalSettings.AddOrUpdateValue(key, json);
         }
 
-        [return: MaybeNull]
-        public static T GetJsonValueOrDefault<T>(
+        public static T? GetJsonValueOrDefault<T>(
             this IInternalSettings internalSettings,
             IJsonSerializer jsonSerializer,
             string key,
-            [MaybeNull] T defaultValue = default!)
+            T? defaultValue = default)
         {
-            var json = internalSettings.GetValueOrDefault(key, default(string)!);
+            var json = internalSettings.GetValueOrDefault(key, default(string));
             return string.IsNullOrEmpty(json)
                 ? defaultValue
                 : jsonSerializer.Deserialize<T>(json);

--- a/Softeq.XToolkit.Common/Interfaces/IInternalSettings.cs
+++ b/Softeq.XToolkit.Common/Interfaces/IInternalSettings.cs
@@ -36,7 +36,7 @@ namespace Softeq.XToolkit.Common.Interfaces
         /// </summary>
         /// <param name="key">key to update.</param>
         /// <param name="value">value to set.</param>
-        void AddOrUpdateValue(string key, string value);
+        void AddOrUpdateValue(string key, string? value);
 
         /// <summary>
         ///     Adds or updates a value.
@@ -103,7 +103,7 @@ namespace Softeq.XToolkit.Common.Interfaces
         /// <param name="key">Key for settings.</param>
         /// <param name="defaultValue">default value if not set.</param>
         /// <returns>Value or default.</returns>
-        string GetValueOrDefault(string key, string? defaultValue = default);
+        string? GetValueOrDefault(string key, string? defaultValue = default);
 
         /// <summary>
         ///     Gets the current value or the default that you specify.

--- a/Softeq.XToolkit.PushNotifications/Abstract/IPushTokenStorageService.cs
+++ b/Softeq.XToolkit.PushNotifications/Abstract/IPushTokenStorageService.cs
@@ -8,6 +8,6 @@ namespace Softeq.XToolkit.PushNotifications.Abstract
         /// <summary>
         ///     Gets or sets push token in custom storage.
         /// </summary>
-        string PushToken { get; set; }
+        string? PushToken { get; set; }
     }
 }

--- a/Softeq.XToolkit.PushNotifications/PushTokenStorageService.cs
+++ b/Softeq.XToolkit.PushNotifications/PushTokenStorageService.cs
@@ -18,7 +18,7 @@ namespace Softeq.XToolkit.PushNotifications
         }
 
         /// <inheritdoc />
-        public string PushToken
+        public string? PushToken
         {
             get => _internalSettings.GetValueOrDefault(_pushTokenKey, default(string));
             set => _internalSettings.AddOrUpdateValue(_pushTokenKey, value);

--- a/Softeq.XToolkit.PushNotifications/PushTokenSynchronizer.cs
+++ b/Softeq.XToolkit.PushNotifications/PushTokenSynchronizer.cs
@@ -73,7 +73,7 @@ namespace Softeq.XToolkit.PushNotifications
 
             if (IsTokenRegisteredInSystem && !IsTokenSavedOnServer)
             {
-                return DoSendTokenToServer(_pushTokenStorageService.PushToken);
+                return DoSendTokenToServer(_pushTokenStorageService.PushToken!);
             }
 
             return Task.CompletedTask;
@@ -90,7 +90,7 @@ namespace Softeq.XToolkit.PushNotifications
             }
 
             var tokenRemovedFromServer = await _remotePushNotificationsService
-                .RemovePushNotificationsToken(_pushTokenStorageService.PushToken)
+                .RemovePushNotificationsToken(_pushTokenStorageService.PushToken!)
                 .ConfigureAwait(false);
             if (tokenRemovedFromServer)
             {

--- a/Softeq.XToolkit.WhiteLabel/Services/InternalSettings.cs
+++ b/Softeq.XToolkit.WhiteLabel/Services/InternalSettings.cs
@@ -24,7 +24,7 @@ namespace Softeq.XToolkit.WhiteLabel.Services
             Preferences.Set(key, value);
         }
 
-        public void AddOrUpdateValue(string key, string value)
+        public void AddOrUpdateValue(string key, string? value)
         {
             Preferences.Set(key, value);
         }
@@ -69,7 +69,7 @@ namespace Softeq.XToolkit.WhiteLabel.Services
             return Preferences.Get(key, defaultValue);
         }
 
-        public string GetValueOrDefault(string key, string? defaultValue = default)
+        public string? GetValueOrDefault(string key, string? defaultValue = default)
         {
             return Preferences.Get(key, defaultValue);
         }


### PR DESCRIPTION
<!-- WAIT!
     Before you submit this PR, make sure you're building on and targeting the right branch!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### API Changes
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny

 -->

 - string -> string? GetValueOrDefault

### Platforms Affected
<!-- Please list all platforms affected by these changes -->

- Core (all platforms)

### Behavioral/Visual Changes
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### PR Checklist
<!-- To be completed by reviewers -->
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
