### PR TITLE
Added possibility to conditionally notify ViewModel about appearing/disappearing

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/ViewControllerBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/ViewControllerBase.cs
@@ -66,7 +66,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
-            ViewModel.OnAppearing();
+            NotifyViewModelAboutAppearing();
             AttachBindings();
         }
 
@@ -74,7 +74,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
         {
             base.ViewWillDisappear(animated);
             DetachBindings();
-            ViewModel.OnDisappearing();
+            NotifyViewModelAboutDisappearing();
         }
 
         public override void ViewDidDisappear(bool animated)
@@ -82,6 +82,16 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
             base.ViewDidDisappear(animated);
 
             CloseDialogIfNeeded();
+        }
+
+        protected virtual void NotifyViewModelAboutAppearing()
+        {
+            ViewModel.OnAppearing();
+        }
+
+        protected virtual void NotifyViewModelAboutDisappearing()
+        {
+            ViewModel.OnDisappearing();
         }
 
         protected virtual void DoAttachBindings()


### PR DESCRIPTION
### Description

`ViewControllerBase` always calls `ViewModel.OnAppearing` method in `ViewWillAppear`, but sometimes it's needed to customize this logic. For example, we may need to skip calling this if the app is in background, and instead a `ViewController` would call `ViewModel.OnAppearing` only when the app is restored from background.

### API Changes

Added:
 - `protected virtual void NotifyViewModelAboutAppearing()`
 - `protected virtual void NotifyViewModelAboutDisappearing()`

### Platforms Affected

- iOS

### Behavioral/Visual Changes

None

### Before/After Screenshots

Not applicable

### PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
