### PR TITLE
ViewControllerBase: use dialog interface instead of class

### DIFF
--- a/Softeq.XToolkit.WhiteLabel.iOS/ViewControllerBase.cs
+++ b/Softeq.XToolkit.WhiteLabel.iOS/ViewControllerBase.cs
@@ -7,6 +7,7 @@ using Softeq.XToolkit.Bindings;
 using Softeq.XToolkit.Bindings.Abstract;
 using Softeq.XToolkit.Bindings.Extensions;
 using Softeq.XToolkit.WhiteLabel.Mvvm;
+using Softeq.XToolkit.WhiteLabel.Navigation;
 using UIKit;
 
 namespace Softeq.XToolkit.WhiteLabel.iOS
@@ -120,7 +121,7 @@ namespace Softeq.XToolkit.WhiteLabel.iOS
 
         private void CloseDialogIfNeeded()
         {
-            if (ViewModel is DialogViewModelBase dialogViewModel)
+            if (ViewModel is IDialogViewModel dialogViewModel)
             {
                 if (IsBeingDismissed || IsMovingFromParentViewController)
                 {


### PR DESCRIPTION
### API Changes
`ViewControllerBase<T>.CloseDialogIfNeeded()` now casts ViewModel to `IDialogViewModel` instead of `DialogViewModelBase`.

### Platforms Affected
- iOS

### Behavioral/Visual Changes
None

### Before/After Screenshots
Not applicable

### PR Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/Softeq/XToolkit.WhiteLabel/blob/master/.github/CONTRIBUTING.md) document
- [x] My code follows the [code styles](https://github.com/Softeq/dotnet-guidelines/tree/xamarin_guidelines)
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)